### PR TITLE
StartUp dialog tries to link to age without valid player selected

### DIFF
--- a/Python/xDialogStartUp.py
+++ b/Python/xDialogStartUp.py
@@ -539,7 +539,10 @@ class xDialogStartUp(ptResponder):
                 PtShowDialog("GUIDialog04d")
             return
         
-        elif opType == PtAccountUpdateType.kActivePlayer:
+        if playerInt == 0:
+            return
+        
+        if opType == PtAccountUpdateType.kActivePlayer:
             print "Active player set."
 
             pythonBox = PtFindSceneobject("OptionsDialog", "GUI")


### PR DESCRIPTION
Immediately after dialog startup OnAccountUpdate is called with player id = 0 and operation kActivePlayer. This causes game to try linking to AvatarCustomization. Since there is no vault available, this causes some problems later in game (like making linking manager think, it has deferred age link).
