### PR TITLE
Fix bookshelf for large KI numbers (> 2^24)

### DIFF
--- a/Python/psnlBookshelf.py
+++ b/Python/psnlBookshelf.py
@@ -383,17 +383,11 @@ class psnlBookshelf(ptModifier):
                     if event[1] == "IShelveBook" and type(objBookPicked) != type(None):
                         self.IShelveBook()
                         
-                        
                     if event[1].split(",")[0] == "ILink": # parse the spawn point info off the entire note (which comes through as "ILink, SpawnPointName,SpawnPointTitle")
-                        
-                        LinkerID = event[3]
-                        #~ print "LinkerID = ", LinkerID
-                        avatar = PtGetLocalAvatar()   
-                        myID = PtGetClientIDFromAvatarKey(avatar.getKey())
-                        #~ print "myID = ", myID
-                        self.IShelveBook()
-                        if LinkerID == myID:
+                        if event[3] < 0: #legacy check (if > 0 then it's from old code and, therefore, not ours)
+                            self.IShelveBook()
                             
+                            avatar = PtGetLocalAvatar()
                             #reenable First person before linking out
                             cam = ptCamera()
                             cam.enableFirstPersonOverride()

--- a/Python/xLinkingBookGUIPopup.py
+++ b/Python/xLinkingBookGUIPopup.py
@@ -363,12 +363,11 @@ class xLinkingBookGUIPopup(ptModifier):
                                             else:
                                                 entry.chronicleSetValue("no")
                                     
-                                    # this book was taken off the personal age bookshelf. Send a note telling to link, and WHO the linker is.
-                                    avatar = PtGetLocalAvatar()   
-                                    myID = PtGetClientIDFromAvatarKey(avatar.getKey())
+                                    # this book was taken off the personal age bookshelf. Send a note telling to link
                                     note = ptNotify(self.key)
                                     note.setActivate(1.0)
-                                    note.addVarNumber("ILink" + "," + SpawnPointName_Dict[event[2]] + "," + SpawnPointTitle_Dict[event[2]], myID)
+                                    note.addVarNumber("ILink" + "," + SpawnPointName_Dict[event[2]] + "," + SpawnPointTitle_Dict[event[2]], -1.0)
+                                    note.netPropagate(0)
                                     note.send()
                             # bye-bye
                     elif event[1] == PtBookEventTypes.kNotifyShow:


### PR DESCRIPTION
Notify message keeps numbers in float field. When that number is larger than ~16.7M, precision is lost and comparisons are failing. 

Fortunately, in this case that comparison is not needed, since it's only used to verify, if message is addressed to avatar. This message is never sent to other avatars, so we can just disable net propagation.
