### PR TITLE
Fix random seeding issues

### DIFF
--- a/Python/PhilRelto.py
+++ b/Python/PhilRelto.py
@@ -50,7 +50,6 @@ event manager hooks for phil's personal age
 from Plasma import *
 from PlasmaTypes import *
 from PlasmaKITypes import *
-import random
 
 class PhilRelto(ptResponder):
 

--- a/Python/clftImager.py
+++ b/Python/clftImager.py
@@ -147,10 +147,10 @@ class clftImager(ptResponder):
         ptResponder.__init__(self)
         self.id = 50248473
         self.version = 29
+        random.seed()
 
 
     def OnFirstUpdate(self):
-        random.seed()
         #self.ageSDL = PtGetAgeSDL()
         #self.ageSDL.setFlags(stringSDLVarPanelE.value,1,1)
         #self.ageSDL.sendToClients(stringSDLVarPanelE.value)

--- a/Python/clftNpcZandi.py
+++ b/Python/clftNpcZandi.py
@@ -101,7 +101,7 @@ class clftNpcZandi(ptModifier):
         print "__init__clftNpcZandi v.", self.version
         self.NpcName = None
         self.ZandiFace = None
-        
+        random.seed()
 
     def OnFirstUpdate(self):
         self.AlreadyPlayed = 0
@@ -112,8 +112,6 @@ class clftNpcZandi(ptModifier):
         self.PlayWelcome2 = 0
         self.LastSpeech = -1
         self.PlayOnFinish = 0
-
-        random.seed()
 
         vault = ptVault()
         #~ entry = vault.findChronicleEntry("JourneyClothProgress")

--- a/Python/clftYeeshaPageImager.py
+++ b/Python/clftYeeshaPageImager.py
@@ -80,7 +80,7 @@ class clftYeeshaPageImager(ptModifier):
         self.version = version
         print "__init__clftYeeshaPageImager v.", version
         self.ImagerUsable = 1
-        
+        random.seed()
 
     def OnFirstUpdate(self):
         global PlayFull
@@ -88,7 +88,6 @@ class clftYeeshaPageImager(ptModifier):
         AgeStartedIn = PtGetAgeName()
 
         PtUnloadDialog("YeeshaPageGUI")
-        random.seed()
         self.CloseImager(1)
 
 

--- a/Python/grsnPrisonRandomSDLItems.py
+++ b/Python/grsnPrisonRandomSDLItems.py
@@ -84,6 +84,7 @@ class grsnPrisonRandomSDLItems(ptResponder):
         version = 2
         self.version = version
         print "__init__grsnPrisonRandomItems v.", version
+        random.seed()
 
     def OnServerInitComplete(self):
         global AllItems
@@ -93,8 +94,6 @@ class grsnPrisonRandomSDLItems(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         # pick items to display
-        random.seed()
-
         ItemsToPick = random.randint(kMinNumItems, kMaxNumItems)
         AlreadyPicked = [ ]
 

--- a/Python/nglnTreeMonkey.py
+++ b/Python/nglnTreeMonkey.py
@@ -82,9 +82,6 @@ class nglnTreeMonkey(ptResponder):
         version = 3
         self.version = version
         print "__init__nglnTreeMonkey v.", version,".0"
-
-    ###########################
-    def OnFirstUpdate(self):
         random.seed()
 
     ###########################

--- a/Python/nglnUrwinBrain.py
+++ b/Python/nglnUrwinBrain.py
@@ -91,9 +91,6 @@ class nglnUrwinBrain(ptResponder):
         version = 4
         self.version = version
         print "__init__nglnUrwinBrain v.", version,".0"
-
-    ############################
-    def OnFirstUpdate(self):
         random.seed()
 
     ############################

--- a/Python/nxusBookMachine.py
+++ b/Python/nxusBookMachine.py
@@ -333,6 +333,7 @@ class nxusBookMachine(ptModifier):
         version = 5
         self.version = version
         print "__init__nxusBookMachine v.", version
+        random.seed()
 
         self.guiState = kGUIDeactivated
         self.getBookBtnUp = False

--- a/Python/tldnShroomieBrain.py
+++ b/Python/tldnShroomieBrain.py
@@ -113,8 +113,6 @@ class tldnShroomieBrain(ptResponder):
         version = 3
         self.version = version
         print "__init__tldnShroomieBrain v.", version,".2"
-
-    def OnFirstUpdate(self):
         random.seed()
 
     def OnServerInitComplete(self):

--- a/Python/xBlueSpiral.py
+++ b/Python/xBlueSpiral.py
@@ -119,6 +119,7 @@ class xBlueSpiral(ptResponder):
         self.tableId = 0 # for this one it's zero, cause there is only one table, other script will have a max attribute
         self.gameId = 0 # DIFFERENT from table id. This is the actual ID number of the game, table ID is simply a way to get a game without knowing its gameID
         print "xBlueSpiral: init  version = %d" % self.version
+        random.seed()
 
     ###########################
     def OnFirstUpdate(self):

--- a/Python/xJourneyCloths.py
+++ b/Python/xJourneyCloths.py
@@ -100,8 +100,6 @@ class xJourneyCloths(ptModifier):
         version = 7
         self.version = version
         print "__init__xJourneyCloths v.", version
-
-    def OnServerInitComplete(self):
         random.seed()
 
     def OnNotify(self,state,id,events):

--- a/Python/xPodBahroSymbol.py
+++ b/Python/xPodBahroSymbol.py
@@ -84,6 +84,7 @@ class xPodBahroSymbol(ptResponder):
         version = 1
         self.version = version
         print "__init__xPodBahroSymbol v.", version,".0"
+        random.seed()
 
     ###########################
     def OnServerInitComplete(self):


### PR DESCRIPTION
As reported @ http://forum.guildofwriters.org/viewtopic.php?p=58166#p58166 random seeding sometimes fails in OnFirstUpdate, so we have moved it to **init** and removed the D'ni Time spec. Python does a good enough job seeding it without our input.

I expect that the issue was that OnFirstUpdate was never actually called. The Minkata sparklie issue is a testament to that.
