### PR TITLE
Remove hardcoded resolution list

### DIFF
--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -1546,7 +1546,7 @@ class xOptionsMenu(ptModifier):
                     videoField.setValue( float(res) / (numRes - 1))
                 else:
                     videoField.setValue( 0 )
-        self.SetVidResField(res)
+        self.SetVidResField(vidRes)
 
     def InitVideoControlsGUI(self):
         xIniDisplay.ReadIni()


### PR DESCRIPTION
Thanks to a snippet devised by @CWalther in #12, we no longer require a hardcoded map of aspect ratios to resolutions. This will better facilitate using all resolutions supported by the user's hardware.
