### PR TITLE
Restore minimum resolution 800x600

### DIFF
--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -1627,6 +1627,8 @@ class xOptionsMenu(ptModifier):
 
         vidResList = []
         for i in PtGetSupportedDisplayModes():
+            if i[0] < 800 or i[1] < 600:
+                continue
             if windowed and (i[0] >= PtGetDesktopWidth() and i[1] >= PtGetDesktopHeight()):
                 continue
             vidResList.append("%ix%i" % (i[0], i[1]))


### PR DESCRIPTION
While the game appears to work fine in smaller resolutions such as 640x480, the clutter they add makes the slider harder to use, so restoring the limitation to 800x600 and above, previously enforced by the hardcoded resolution lists, seems justified.

Replacement for H-uru/Plasma#203, intended for http://foundry.openuru.org/fisheye/cru/MOULSCRIPT-20.
