### PR TITLE
Fix KI chat scrolling issue when scrolled up.

### DIFF
--- a/Python/plasma/Plasma.py
+++ b/Python/plasma/Plasma.py
@@ -4247,6 +4247,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """Returns a ptGUIDialog of the dialog that owns this GUI control"""
         pass
 
+    def getScrollPosition(self):
+        """Returns what line is the top line."""
+        pass
+
     def getSelectColor(self):
         """Returns the selection color"""
         pass
@@ -4290,6 +4294,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def insertStyle(self,style):
         """Inserts an encoded font style at the current cursor position."""
+        pass
+
+    def isAtEnd(self):
+        """Returns whether the cursor is at the end."""
         pass
 
     def isEnabled(self):

--- a/Python/xKI.py
+++ b/Python/xKI.py
@@ -7077,6 +7077,8 @@ class xKI(ptModifier):
                 chatMessageFormatted = " " + message
 
         chatarea = ptGUIControlMultiLineEdit(mKIdialog.getControlFromTag(kChatDisplayArea))
+        savedPosition = chatarea.getScrollPosition()
+        wasAtEnd = chatarea.isAtEnd()
         chatarea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
         chatarea.insertStringW(U"\n")
         chatarea.insertColor(headerColor)
@@ -7088,6 +7090,11 @@ class xKI(ptModifier):
         #Added unicode support here!
         chatarea.insertStringW(chatMessageFormatted)
         chatarea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
+
+        # Scroll the chat by the number of new lines.
+        if not wasAtEnd:
+            chatarea.setScrollPosition(savedPosition)
+
         # see if we're logging
         if type(ChatLogFile) != type(None) and ChatLogFile.isOpen():
             ChatLogFile.write(chatHeaderFormatted[0:]+chatMessageFormatted)


### PR DESCRIPTION
This fixes a common gripe with KI chat, which has a tendency to scroll down when someone else sends a chat message, even if you have scrolled up. This fix makes it scroll down only when the user is already looking at the bottom. I haven't had much time to test, but it seemed to work without problems for me.

It requires pulling https://github.com/H-uru/Plasma/pull/222 and https://github.com/H-uru/moul-scripts/pull/38 first.
