### PR TITLE
Fix Sphere Spinning

### DIFF
--- a/Python/ahnyQuabs.py
+++ b/Python/ahnyQuabs.py
@@ -141,7 +141,8 @@ class ahnyQuabs(ptModifier, object):
             # Make sure this isn't the player jumping into the water for a quick swim
             # Musing: Ideally, we would despawn the clone here since it's now useless,
             #         but removing the brain without causing rampant issues might be problematic...
-            if PtFindAvatar(events) != PtGetLocalAvatar():
+            colso = PtFindAvatar(events)
+            if colso.isAvatar() and not colso.isHuman():
                 self.quabs -= 1
                 PtDebugPrint("ahnyQuabs.OnNotify():\tQuabs remaining: %i" % self.quabs, level=kWarningLevel)
                 return


### PR DESCRIPTION
This fixes the sphere turning bug as described at http://forum.guildofwriters.org/viewtopic.php?p=63604#p63604

When multiple players are in the age, the remote player is thought to be a quab and causes the quab count to be decremented. This can lead to the python thinking there are 255/-1 quabs left, instead of zero.

This changeset depends on H-uru/Plasma#342
