### PR TITLE
Fix Unicode characters in chat

### DIFF
--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -5691,8 +5691,8 @@ class xKI(ptModifier):
         elif event == kAction or event == kValueChanged:
             ctrlID = control.getTagID()
             if ctrlID == kGUI.ChatEditboxID:
-                if not control.wasEscaped() and control.getString() != "":
-                    self.chatMgr.SendMessage(control.getString())
+                if not control.wasEscaped() and control.getStringW() != "":
+                    self.chatMgr.SendMessage(control.getStringW())
                 self.chatMgr.ToggleChatMode(0)
             elif ctrlID == kGUI.ChatDisplayArea:
                 self.KillFadeTimer()
@@ -5775,8 +5775,8 @@ class xKI(ptModifier):
         elif event == kAction or event == kValueChanged:
             ctrlID = control.getTagID()
             if ctrlID == kGUI.ChatEditboxID:
-                if not control.wasEscaped() and control.getString() != "":
-                    self.chatMgr.SendMessage(control.getString())
+                if not control.wasEscaped() and control.getStringW() != u"":
+                    self.chatMgr.SendMessage(control.getStringW())
                 self.chatMgr.ToggleChatMode(0)
                 self.StartFadeTimer()
             elif ctrlID == kGUI.PlayerList:

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -187,12 +187,6 @@ class xKIChat(object):
         if PtGetLocalAvatar().avatar.getCurrentMode() == PtBrainModes.kAFK:
             PtAvatarExitAFK()
 
-        try:
-            message = unicode(message, kCharSet)
-        except UnicodeError:
-            message = None
-            self.AddChatLine(None, PtGetLocalizedString("KI.Errors.TextOnly"), kChat.SystemMessage)
-
         # Check for special commands.
         message = self.commandsProcessor(message)
         if not message:

--- a/Python/ki/xKIConstants.py
+++ b/Python/ki/xKIConstants.py
@@ -48,10 +48,6 @@ from PlasmaTypes import *
 # Uru modules.
 import xEnum
 
-## Character set constant.
-# @todo Update this when the p2fs really support unicode.
-kCharSet = "cp1252"
-
 ## Number of items to scroll through in content list.
 kContentListScrollSize = 5
 


### PR DESCRIPTION
The Python side: No longer need to convert `message` to unicode, because it's now passed in that way.  Requires H-uru/Plasma#362
