### PR TITLE
Handle mentions in chat messages

### DIFF
--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -469,7 +469,10 @@ class xKIChat(object):
                     # PM Processing: Save playerID and flash client window
                     if cFlags.private:
                         self.lastPrivatePlayerID = (player.getPlayerName(), player.getPlayerID(), 1)
-                        self.AddPlayerToRecents(player.getPlayerID())
+                        PtFlashWindow()
+                    # Are we mentioned in the message?
+                    elif message.lower().find(PtGetLocalPlayer().getPlayerName().lower()) >= 0:
+                        bodyColor = kColors.ChatMessageMention
                         PtFlashWindow()
 
             # Is it a ccr broadcast?
@@ -506,6 +509,12 @@ class xKIChat(object):
                     headerColor = kColors.ChatHeaderBroadcast
                     pretext = PtGetLocalizedString("KI.Chat.BroadcastMsgRecvd")
                     self.AddPlayerToRecents(player.getPlayerID())
+
+                    # Are we mentioned in the message?
+                    if message.lower().find(PtGetLocalPlayer().getPlayerName().lower()) >= 0:
+                        bodyColor = kColors.ChatMessageMention
+                        forceKI = True
+                        PtFlashWindow()
 
             # Is it a private message?
             elif cFlags.private:

--- a/Python/ki/xKIConstants.py
+++ b/Python/ki/xKIConstants.py
@@ -196,6 +196,7 @@ class kColors:
     AgenGreenDk = ptColor(0.65, 0.745, 0.6353, 1.0)
                 
     DniYellow   = ptColor(0.851, 0.812, 0.576, 1.0)
+    DniYellowLt = ptColor(1.0, 1.0, 0.6, 1.0)
     DniCyan     = ptColor(0.576, 0.867, 0.851, 1.0)
     DniBlue     = ptColor(0.780, 0.706, 0.870, 1.0)
     DniRed      = ptColor(1.0, 0.216, 0.380, 1.0)
@@ -212,6 +213,7 @@ class kColors:
     
     # Chat colors (messages and headers).
     ChatMessage             = DniWhite
+    ChatMessageMention      = DniYellowLt
     ChatHeaderBroadcast     = DniBlue
     ChatHeaderPrivate       = DniYellow
     ChatHeaderAdmin         = DniCyan


### PR DESCRIPTION
This adds text highlighting and window flashing to age, buddy and neighbor messages that contain the player's name.

![urumention](https://f.cloud.github.com/assets/161936/1797594/34b9b678-6af7-11e3-9c84-c91cbcf1dc27.jpg)
