### PR TITLE
Remove unneeded kFontShadowed flags in the Big KI dialogs

### DIFF
--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -49,6 +49,7 @@ from Plasma import *
 from PlasmaGame import *
 from PlasmaTypes import *
 from PlasmaKITypes import *
+from PlasmaConstants import *
 from PlasmaVaultConstants import *
 from PlasmaNetConstants import *
 
@@ -1507,6 +1508,15 @@ class xKI(ptModifier):
         KIBlackbar.dialog.hide()
         BigKI.dialog.hide()
         self.chatMgr.ToggleChatMode(0)
+
+        # Remove unneeded kFontShadowed flags (as long as we can't do that directly in the PRPs)
+        for dialogAttr in (BigKI, KIListModeDialog, KIJournalExpanded, KIPictureExpanded, KIPlayerExpanded, KIAgeOwnerExpanded, KISettings, KIMarkerFolderExpanded, KICreateMarkerGameGUI):
+            for i in xrange(dialogAttr.dialog.getNumControls()):
+                f = ptGUIControl(dialogAttr.dialog.getControlFromIndex(i))
+                # call this on all controls, even those that use the color scheme of the
+                # dialog and would already report the flag cleared after the first one,
+                # as they still need the setFontFlags call to refresh themselves
+                f.setFontFlags(f.getFontFlags() & ~int(PtFontFlags.kFontShadowed))
 
         if self.KILevel == kMicroKI:
             # Show the microBlackbar.

--- a/Python/plasma/PlasmaConstants.py
+++ b/Python/plasma/PlasmaConstants.py
@@ -168,6 +168,12 @@ class PtJustify:
     kCenter = 1
     kRightJustify = 2
 
+class PtFontFlags:
+    """(none)"""
+    kFontBold = 1
+    kFontItalic = 2
+    kFontShadowed = 4
+
 class PtLOSObjectType:
     """(none)"""
     kClickables = 0


### PR DESCRIPTION
This is the Python companion to H-uru/Plasma#392.

Example of the problem it works around:
![xray](https://cloud.githubusercontent.com/assets/234094/2684940/be296780-c1c0-11e3-8240-38d7c4a554c6.png)
