### PR TITLE
Implement chat history browsing (Client and Python)

### DIFF
--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -1778,6 +1778,26 @@ class xKI(ptModifier):
             control.end()
             control.refresh()
 
+    #~~~~~~~~~~~~~~~~~#
+    # Message History #
+    #~~~~~~~~~~~~~~~~~#
+
+    ## Set a control's text to a log entry in the message history
+    def MessageHistory(self, control, set):
+
+        if (set == "up"):
+            if (self.chatMgr.MessageHistoryIs < len(self.chatMgr.MessageHistoryList)-1):
+                self.chatMgr.MessageHistoryIs = self.chatMgr.MessageHistoryIs +1
+                control.setStringW(self.chatMgr.MessageHistoryList[self.chatMgr.MessageHistoryIs])
+                control.end()
+                control.refresh()
+        elif (set == "down"):
+            if (self.chatMgr.MessageHistoryIs > 0):
+                self.chatMgr.MessageHistoryIs = self.chatMgr.MessageHistoryIs -1
+                control.setStringW(self.chatMgr.MessageHistoryList[self.chatMgr.MessageHistoryIs])
+                control.end()
+                control.refresh()
+
     #~~~~~~~~~~#
     # GZ Games #
     #~~~~~~~~~~#
@@ -5901,6 +5921,15 @@ class xKI(ptModifier):
             ctrlID = control.getTagID()
             if ctrlID == kGUI.ChatEditboxID:
                 self.Autocomplete(control)
+        # Up or Down key to scroll in the chat history
+        elif event == kMessageHistoryUp:
+            ctrlID = control.getTagID()
+            if ctrlID == kGUI.ChatEditboxID:
+                self.MessageHistory(control, "up")
+        elif event == kMessageHistoryDown:
+            ctrlID = control.getTagID()
+            if ctrlID == kGUI.ChatEditboxID:
+                self.MessageHistory(control, "down")
 
     ## Process notifications originating from the BigKI itself.
     # This does not process notifications specific to an expanded view - each

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -96,6 +96,10 @@ class xKIChat(object):
         # Add the commands processor.
         self.commandsProcessor = CommandsProcessor(self)
 
+        # Message History
+        self.MessageHistoryIs = -1 # Current position in message history (up/down key)
+        self.MessageHistoryList = [] # Contains our message history
+
     #######
     # GUI #
     #######
@@ -139,6 +143,8 @@ class xKIChat(object):
     ## Make the player enter or exit chat mode.
     # Chat mode means the player's keyboard input is being sent to the chat.
     def ToggleChatMode(self, entering, firstChar=None):
+        # Reset selection in message history
+        self.MessageHistoryIs = -1
 
         if self.KILevel == kMicroKI:
             mKIdialog = KIMicro.dialog
@@ -192,6 +198,11 @@ class xKIChat(object):
         if not message:
             return
         msg = message.lower()
+
+        # Message History input
+        self.MessageHistoryList.insert(0,message)
+        if (len(self.MessageHistoryList) > kMessageHistoryListMax):
+            self.MessageHistoryList.pop()
 
         # Get any selected players.
         userListBox = ptGUIControlListBox(KIMini.dialog.getControlFromTag(kGUI.PlayerList))

--- a/Python/ki/xKIConstants.py
+++ b/Python/ki/xKIConstants.py
@@ -66,6 +66,9 @@ kMaxBookAlertTime = 20.0
 kAlertKIAlert = 60
 kAlertBookAlert = 61
 
+## How many of our chat messages shall we log
+kMessageHistoryListMax = 50
+
 ## KI light responders.
 kListLightResps = ["respKILightOff","respKILightOn" ]
 

--- a/Python/plasma/PlasmaTypes.py
+++ b/Python/plasma/PlasmaTypes.py
@@ -116,7 +116,9 @@ kDialogLoaded=4         # the dialog has just been loaded
 kFocusChange=5          # the focus changed from one control to another, or none, within the dialog
 kExitMode = 6		# Modal dialog received an exit mode command
 kInterestingEvent = 7   # an interesting event happened
-kSpecialAction = 8      #special action ( kEditBox tab press)
+kSpecialAction = 8      # special action ( kEditBox tab press)
+kMessageHistoryUp = 9   # chat history up key pressed
+kMessageHistoryDown = 10    # chat history down key pressed
 
 # OnRoomLoad 'what' types
 kLoaded=1


### PR DESCRIPTION
Here are the python scripts that implement chat history browsing. You can repeat previous chat messages by pressing the up and down keys.
This requires H-uru/Plasma#416.
