### PR TITLE
ptDynamicMap plString-ification

### DIFF
--- a/Python/nb01Easel.py
+++ b/Python/nb01Easel.py
@@ -116,6 +116,6 @@ class nb01Easel(ptModifier):
         dyna_map.textmap.setFont(dyna_fontname.value, dyna_fontsize.value)
         dyna_map.textmap.setJustify(PtJustify.kCenter)
         dyna_map.textmap.setLineSpacing(dyna_fontspacing.value)
-        dyna_map.textmap.drawTextW(0,0,text)
+        dyna_map.textmap.drawText(0,0,text)
         dyna_map.textmap.flush()
 

--- a/Python/plasma/Plasma.py
+++ b/Python/plasma/Plasma.py
@@ -2283,10 +2283,6 @@ class ptDynamicMap:
 - 'text' is a string of the text to be drawn"""
         pass
 
-    def drawTextW(self,x,y,text):
-        """Unicode version of drawText"""
-        pass
-
     def fillRect(self,left,top,right,bottom,color):
         """Fill in the specified rectangle with a color
 - left,top,right,bottom define the rectangle

--- a/Python/xDynTextObj.py
+++ b/Python/xDynTextObj.py
@@ -100,5 +100,5 @@ class xDynTextObj(ptModifier):
         theMap.setFont(fontName, fontSize)
         theMap.setJustify(justify)
         theMap.setLineSpacing(spacing)
-        theMap.drawTextW(textX,textY,PtGetLocalizedString(locPath))
+        theMap.drawText(textX,textY,PtGetLocalizedString(locPath))
         theMap.flush()

--- a/Python/xSimpleImager.py
+++ b/Python/xSimpleImager.py
@@ -504,7 +504,7 @@ class xSimpleImager(ptModifier):
                                 PtDebugPrint("simpleImager: now showing textnote %s" % (textsubject),level=kDebugDumpLevel)
                                 message = PtGetLocalizedString("Neighborhood.Messages.Imager", [textfrom, textsubject, textbody])
                                 message = xCensor.xCensor(message,theCensorLevel)
-                                ImagerMap.textmap.drawTextW(kTextXStart,kTextYStart,message)
+                                ImagerMap.textmap.drawText(kTextXStart,kTextYStart,message)
                                 ImagerMap.textmap.flush()
                         else:
                             PtDebugPrint("xSimpleImager[%s]: Can't display element type %d" % (ImagerName.value,elemType),level=kWarningLevel)


### PR DESCRIPTION
This fixes a lot of crazy xSimpleImager tracebacks I see on Gehn involving drawTextW. I assume that xCensor was handing us a string object (vs unicode) and expecting us to draw that.

Please note that this depends on H-uru/Plasma#425
