### PR TITLE
Bump a public neighborhood to the top of the Nexus list when someone links to it.

### DIFF
--- a/Python/nb01UpdateHoodInfoImager.py
+++ b/Python/nb01UpdateHoodInfoImager.py
@@ -132,6 +132,13 @@ class nb01UpdateHoodInfoImager(ptResponder):
             self.ISendNotify(HoodInfoImagerScript.value, sname, 1.0)
 
     def IUpdatePublicHoodDate(self):
+        # The MOULa server sorts the public hood list by date last set public.
+        # We want to have it sorted by date last linked to, so that hoods that
+        # are in active use don't drop off the list. Since we can't modify the
+        # server we fake this by updating the 'set public' timestamp every time
+        # someone links in.
+        # On all known servers, setting from true to true is sufficient to
+        # update the timestamp even though it's not an actual change.
         infoNode = ptAgeVault().getAgeInfo()
         if infoNode.isPublic():
             ptVault().setAgePublic(infoNode, True)


### PR DESCRIPTION
This is a proof-of-concept implementation of the scheme I proposed in [_4 pinned hoods in nexus_ on the MOUL forum](http://mystonline.com/forums/viewtopic.php?t=27639&p=414181#p414181). It achieves that public neighborhoods that are in active use stay (near the top) on the list in the Nexus, even after their owners disappear (as is the case for the numerous dedicated Delin & Tsogal hoods that have been made over time), with no manual toggling needed, and no need for pinned hoods.

Tested on MOSS and MOULa. Not tested on Dirtsand.

Requires H-uru/Plasma#461.
