### PR TITLE
Always display the bottom-bar KI alert for GZ Markers in range.

### DIFF
--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -1000,10 +1000,10 @@ class xKI(ptModifier):
                 self.gGZMarkerInRange = value[0]
                 self.gGZMarkerInRangeRepy = value[1]
                 self.RefreshMiniKIMarkerDisplay()
-                if not KIMini.dialog.isEnabled():
-                    NewItemAlert.dialog.show()
-                    KIAlert = ptGUIControlButton(NewItemAlert.dialog.getControlFromTag(kAlertKIAlert))
-                    KIAlert.show()
+                # Show alert
+                NewItemAlert.dialog.show()
+                KIAlert = ptGUIControlButton(NewItemAlert.dialog.getControlFromTag(kAlertKIAlert))
+                KIAlert.show()
         elif command == kGZOutRange:
             self.gGZMarkerInRange = 0
             self.gGZMarkerInRangeRepy = None


### PR DESCRIPTION
The transition on the MiniKI display from a white to red marker is easy to miss, so in order to see the easily-visible KI alert in the bottom bar the player has to constantly close the KI after each marker capture.

This minor fix *always* displays the alert even if the MiniKI is open; it reduces tedium and makes it easier to do marker missions with less useless clicking and even while chatting.