### PR TITLE
Fix RT Chat Lag

### DIFF
--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -2734,17 +2734,22 @@ class xKI(ptModifier):
             mKIdialog = KIMicro.dialog
         else:
             mKIdialog = KIMini.dialog
-        if self.chatMgr.fadeMode != kChat.FadeNotActive:
+
+        # Optimization: only do this if we are fading or have faded
+        if self.chatMgr.fadeMode in (kChat.FadeDoingFade, kChat.FadeDone):
+            mKIdialog.setForeColor(-1, -1, -1, self.originalForeAlpha)
+            mKIdialog.setSelectColor(-1, -1, -1, self.originalSelectAlpha)
+            if self.KILevel == kNormalKI:
+                playerlist = ptGUIControlListBox(mKIdialog.getControlFromTag(kGUI.PlayerList))
+                playerlist.show()
+            chatArea = ptGUIControlMultiLineEdit(mKIdialog.getControlFromTag(kGUI.ChatDisplayArea))
+            chatArea.enableScrollControl()
+            mKIdialog.refreshAllControls()
+
+        # Toggle state
+        if self.chatMgr.fadeMode not in (kChat.FadeNotActive, kChat.FadeDone):
             self.chatMgr.fadeMode = kChat.FadeStopping
         self.currentFadeTick = self.chatMgr.ticksOnFull
-        mKIdialog.setForeColor(-1, -1, -1, self.originalForeAlpha)
-        mKIdialog.setSelectColor(-1, -1, -1, self.originalSelectAlpha)
-        if self.KILevel == kNormalKI:
-            playerlist = ptGUIControlListBox(mKIdialog.getControlFromTag(kGUI.PlayerList))
-            playerlist.show()
-        chatArea = ptGUIControlMultiLineEdit(mKIdialog.getControlFromTag(kGUI.ChatDisplayArea))
-        chatArea.enableScrollControl()
-        mKIdialog.refreshAllControls()
 
     def ResetFadeState(self, force=False):
         """This turns the chat fade OFF and resets it if the user is not chatting.
@@ -2777,7 +2782,7 @@ class xKI(ptModifier):
             if self.KILevel == kNormalKI:
                 playerlist = ptGUIControlListBox(mKIdialog.getControlFromTag(kGUI.PlayerList))
                 playerlist.hide()
-            self.chatMgr.fadeMode = kChat.FadeNotActive
+            self.chatMgr.fadeMode = kChat.FadeDone
 
     #~~~~~~#
     # Ages #

--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -2722,7 +2722,7 @@ class xKI(ptModifier):
         if not self.chatMgr.fadeEnableFlag:
             return
         if not BigKI.dialog.isEnabled():
-            if self.chatMgr.fadeMode == kChat.FadeNotActive:
+            if self.chatMgr.fadeMode in (kChat.FadeNotActive, kChat.FadeDone):
                 PtAtTimeCallback(self.key, kChat.FullTickTime, kTimers.Fade)
             self.chatMgr.fadeMode = kChat.FadeFullDisp
             self.currentFadeTick = self.chatMgr.ticksOnFull

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -517,7 +517,7 @@ class xKIChat(object):
                     self.AddPlayerToRecents(player.getPlayerID())
 
                     # Are we mentioned in the message?
-                    if message.lower().find(PtGetLocalPlayer().getPlayerName().lower()) >= 0:
+                    if message.lower().find(PtGetClientName().lower()) >= 0:
                         bodyColor = kColors.ChatMessageMention
                         forceKI = True
                         PtFlashWindow()
@@ -559,19 +559,19 @@ class xKIChat(object):
             # It must be a status or error message.
             chatHeaderFormatted = pretext
             if not pretext:
-                chatMessageFormatted = message
+                chatMessageFormatted = U"{}".format(message)
             else:
-                chatMessageFormatted = " " + message
+                chatMessageFormatted = U" {}".format(message)
 
         chatArea = ptGUIControlMultiLineEdit(mKIdialog.getControlFromTag(kGUI.ChatDisplayArea))
+        chatArea.beginUpdate()
         savedPosition = chatArea.getScrollPosition()
         wasAtEnd = chatArea.isAtEnd()
         chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
-        chatArea.insertStringW(U"\n")
         chatArea.insertColor(headerColor)
 
         # Added unicode support here.
-        chatArea.insertStringW(chatHeaderFormatted)
+        chatArea.insertStringW(U"\n{}".format(chatHeaderFormatted))
         chatArea.insertColor(bodyColor)
         chatArea.insertStringW(chatMessageFormatted)
         chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
@@ -589,16 +589,17 @@ class xKIChat(object):
             while chatArea.getBufferSize() > kChat.MaxChatSize and chatArea.getBufferSize() > 0:
                 PtDebugPrint(u"xKIChat.AddChatLine(): Max chat buffer size reached. Removing top line.", level=kDebugDumpLevel)
                 chatArea.deleteLinesFromTop(1)
+        chatArea.endUpdate()
 
         # Copy all the data to the miniKI if the user upgrades it.
         if self.KILevel == kMicroKI:
             chatArea2 = ptGUIControlMultiLineEdit(KIMini.dialog.getControlFromTag(kGUI.ChatDisplayArea))
+            chatArea2.beginUpdate()
             chatArea2.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
-            chatArea2.insertStringW(U"\n")
             chatArea2.insertColor(headerColor)
 
             # Added unicode support here.
-            chatArea2.insertStringW(chatHeaderFormatted)
+            chatArea2.insertStringW(U"\n{}".format(chatHeaderFormatted))
             chatArea2.insertColor(bodyColor)
             chatArea2.insertStringW(chatMessageFormatted)
             chatArea2.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
@@ -606,9 +607,9 @@ class xKIChat(object):
             if chatArea2.getBufferSize() > kChat.MaxChatSize:
                 while chatArea2.getBufferSize() > kChat.MaxChatSize and chatArea2.getBufferSize() > 0:
                     chatArea2.deleteLinesFromTop(1)
+            chatArea2.endUpdate()
 
         # Update the fading controls.
-        mKIdialog.refreshAllControls()
         self.ResetFadeState()
 
     ## Display a status message to the player (or players if net-propagated).

--- a/Python/ki/xKIConstants.py
+++ b/Python/ki/xKIConstants.py
@@ -170,6 +170,7 @@ class kChat:
     FadeFullDisp = 1
     FadeDoingFade = 2
     FadeStopping = 3
+    FadeDone = 4
     FadeTimeMax = 120
     FullTickTime = 1.0
     FadeTickTime = 0.05

--- a/Python/plasma/Plasma.py
+++ b/Python/plasma/Plasma.py
@@ -4205,6 +4205,9 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
         """None"""
         pass
 
+    def beginUpdate(self):
+        """Signifies that the control will be updated heavily starting now, so suppress all redraws"""
+
     def clearBuffer(self):
         """Clears all text from the multi-line edit control."""
         pass
@@ -4235,6 +4238,10 @@ class ptGUIControlMultiLineEdit(ptGUIControl):
 
     def enableScrollControl(self):
         """Enables the scroll control if there is one"""
+        pass
+
+    def endUpdate(self, redraw=True):
+        """Signifies that the massive updates are over. We can now redraw."""
         pass
 
     def focus(self):


### PR DESCRIPTION
This pull request fixes several stutters noticed when receiving KIChat messages in large ages, such as Ae'gura. The problem is that refreshing GUI dialogs is an expensive operation (up to 10 ms). I initially converted some of this over to refreshing the control only. However, what isn't advertised to the scripter is that many common operations have implicit updates inside them (you would tend to expect this to not be the case since there is a dedicated `refresh()` method). This is especially problematic with the MultiLineEdit control where we do at least 4 operations that cause an implicit refresh.

We now batch our changes and cause a refresh when they're done. The result is a buttery smooth Ae'gura--even when I have a bot in the age sending random chat messages every half second. :trollface: 