### PR TITLE
Add "uft8" param in chatHeaderFormatted

### DIFF
--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -553,7 +553,7 @@ class xKIChat(object):
                 mKIdialog.show()
         if player is not None:
             separator = "" if pretext.endswith(" ") else " "
-            chatHeaderFormatted = U"{}{}{}:".format(pretext, separator, unicode(player.getPlayerName()))
+            chatHeaderFormatted = U"{}{}{}:".format(pretext, separator, (player.getPlayerName(), "utf8"))
             chatMessageFormatted = U" {}".format(message)
         else:
             # It must be a status or error message.

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -553,7 +553,7 @@ class xKIChat(object):
                 mKIdialog.show()
         if player is not None:
             separator = "" if pretext.endswith(" ") else " "
-            chatHeaderFormatted = U"{}{}{}:".format(pretext, separator, (player.getPlayerName(), "utf8"))
+            chatHeaderFormatted = U"{}{}{}:".format(pretext, separator, player.getPlayerNameW())
             chatMessageFormatted = U" {}".format(message)
         else:
             # It must be a status or error message.

--- a/Python/plasma/Plasma.py
+++ b/Python/plasma/Plasma.py
@@ -5934,6 +5934,10 @@ class ptPlayer:
         """Returns the name of the player"""
         pass
 
+    def getPlayerNameW(self):
+        """Returns the name of the player as Unicode"""
+        pass
+
     def isCCR(self):
         """Is this player a CCR?"""
         pass


### PR DESCRIPTION
To prevent an error when a player plays in a language with accented
characters.