### PR TITLE
Update scripts to match H-uru/Plasma#549

### DIFF
--- a/Python/Ahnonay.py
+++ b/Python/Ahnonay.py
@@ -203,15 +203,15 @@ class Ahnonay(ptResponder):
     ###########################
     def OnPageLoad(self,what,who):
         global spherePages
-        print "Ahnonay.OnPageLoad(): what=%s who=%s" % (what, who)
+        PtDebugPrint(u"Ahnonay.OnPageLoad(): what={} who={}".format(what, who), level=kDebugDumpLevel)
 
         if what == kLoaded:
             if who in spherePages: 
                 ageSDL = PtGetAgeSDL()
                 sphere = str(ageSDL["ahnyCurrentSphere"][0])
                 offset = str(ageSDL["ahnyCurrentOffset"][0])
-                print "Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset)
-                
+                PtDebugPrint("Ahnonay.OnPageLoad(): Sphere0{} loaded with offset:{}".format(sphere, offset), level=kWarningLevel)
+
                 linkmgr = ptNetLinkingMgr()
                 link = linkmgr.getCurrAgeLink()
                 spawnPoint = link.getSpawnPoint()

--- a/Python/minkDayNight.py
+++ b/Python/minkDayNight.py
@@ -129,16 +129,16 @@ class minkDayNight(ptResponder):
     ###########################
     def OnPageLoad(self,what,who):
         global HackIt
-        print "minkDayNight.OnPageLoad(): what=%s who=%s" % (what, who)
+        PtDebugPrint(u"minkDayNight.OnPageLoad(): what={} who={}".format(what, who), level=kDebugDumpLevel)
 
         if what == kLoaded:
-            if who == "Minkata_District_minkExteriorDay" or who == "Minkata_minkExteriorDay":
+            if who in {u"Minkata_District_minkExteriorDay", u"Minkata_minkExteriorDay"}:
                 if HackIt:
                     HackIt = 0
                     return
                 print "minkDayNight.OnPageLoad(): Day Page loaded, unloading Night"
                 PtPageOutNode("minkExteriorNight")
-            elif who == "Minkata_District_minkExteriorNight" or who == "Minkata_minkExteriorNight":
+            elif who in {u"Minkata_District_minkExteriorNight", u"Minkata_minkExteriorNight"}:
                 if HackIt:
                     HackIt = 0
                     return
@@ -146,7 +146,8 @@ class minkDayNight(ptResponder):
                 PtPageOutNode("minkExteriorDay")
                 
         elif what == kUnloaded:
-            if who == "Minkata_District_minkExteriorDay" or who == "Minkata_District_minkExteriorNight" or who == "Minkata_minkExteriorDay" or who == "Minkata_minkExteriorNight":
+            if who in {u"Minkata_District_minkExteriorDay", u"Minkata_District_minkExteriorNight",
+                       u"Minkata_minkExteriorDay", u"Minkata_minkExteriorNight"}:
                 print "minkDayNight.OnPageLoad(): Page unloaded, Fading screen back in"
                 PtFadeIn(1.5, 1)
                 respExcludeRegion.run(self.key, state="Release")

--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -486,7 +486,7 @@ class xOptionsMenu(ptModifier):
     def OnPageLoad(self,what,room):
         global gFirstReltoVisit
 
-        if (room == "Personal_psnlMYSTII" or room == "Personal_District_psnlMYSTII") and gFirstReltoVisit:
+        if room in {u"Personal_psnlMYSTII", u"Personal_District_psnlMYSTII"} and gFirstReltoVisit:
             gFirstReltoVisit = false
 
             vault = ptVault()


### PR DESCRIPTION
Updates scripts to handle a side effect of H-uru/Plasma#529, namely, the conversion of the second argument of the `OnPageLoad` callback from an `str` to an `unicode` object.