### PR TITLE
Chat scrolling improvements

### DIFF
--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -1123,6 +1123,23 @@ class xKI(ptModifier):
         elif ID == kTimers.JalakBtnDelay:
             self.SetJalakGUIButtons(1)
 
+        # Flash the scroll down arrow.
+        elif ID == kTimers.IncomingChatFlash:
+            if self.KILevel < kNormalKI:
+                mKIdialog = KIMicro.dialog
+            else:
+                mKIdialog = KIMini.dialog
+            if self.chatMgr.incomingChatFlashState > 0:
+                btn = ptGUIControlButton(mKIdialog.getControlFromTag(kGUI.miniChatScrollDown))
+                if self.chatMgr.incomingChatFlashState & 1:
+                    btn.hide()
+                else:
+                    btn.show()
+                self.chatMgr.incomingChatFlashState -= 1
+                PtAtTimeCallback(self.key, 0.15, kTimers.IncomingChatFlash)
+            else:
+                mKIdialog.refreshAllControls()
+
     ## Called by Plasma when a screen capture is done.
     # This gets called once the screen capture is performed and ready to be
     # processed by the KI.

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -79,11 +79,12 @@ class xKIChat(object):
         self.privateChatChannel = 0
         self.toReplyToLastPrivatePlayerID = None
 
-        # Fading globals.
+        # Fading & blinking globals.
         self.currentFadeTick = 0
         self.fadeEnableFlag = True
         self.fadeMode = kChat.FadeNotActive
         self.ticksOnFull = 30
+        self.incomingChatFlashState = 0
 
         # Set the properties from the KI.
         self.key = None  # Plasma has to be initialized for this.
@@ -591,6 +592,9 @@ class xKIChat(object):
         if not wasAtEnd:
             # scroll back to where we were
             chatArea.setScrollPosition(savedPosition)
+            # flash the down arrow to indicate that new chat has come in
+            self.incomingChatFlashState = 3
+            PtAtTimeCallback(self.key, 0.0, kTimers.IncomingChatFlash)
         chatArea.endUpdate()
 
         # Copy all the data to the miniKI if the user upgrades it.

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -576,10 +576,6 @@ class xKIChat(object):
         chatArea.insertStringW(chatMessageFormatted)
         chatArea.moveCursor(PtGUIMultiLineDirection.kBufferEnd)
 
-        # Scroll the chat by the number of new lines.
-        if not wasAtEnd:
-            chatArea.setScrollPosition(savedPosition)
-
         # Write to the log file.
         if self.chatLogFile is not None and self.chatLogFile.isOpen():
             self.chatLogFile.write(chatHeaderFormatted[0:] + chatMessageFormatted)
@@ -589,6 +585,12 @@ class xKIChat(object):
             while chatArea.getBufferSize() > kChat.MaxChatSize and chatArea.getBufferSize() > 0:
                 PtDebugPrint(u"xKIChat.AddChatLine(): Max chat buffer size reached. Removing top line.", level=kDebugDumpLevel)
                 chatArea.deleteLinesFromTop(1)
+                if savedPosition > 0:
+                    # this is only accurate if the deleted line only occupied one line in the control (wasn't soft-wrapped), but that tends to be the usual case
+                    savedPosition -= 1
+        if not wasAtEnd:
+            # scroll back to where we were
+            chatArea.setScrollPosition(savedPosition)
         chatArea.endUpdate()
 
         # Copy all the data to the miniKI if the user upgrades it.

--- a/Python/ki/xKIConstants.py
+++ b/Python/ki/xKIConstants.py
@@ -634,3 +634,4 @@ class kTimers:
     DumpLogs = 6
     LightStop = 7
     JalakBtnDelay = 8
+    IncomingChatFlash = 9


### PR DESCRIPTION
These two changes ([41765b9](https://foundry.openuru.org/gitblit/commit/?r=MOULSCRIPT-ou.git&h=41765b9f8c9feff5c1e2d135580f7a2c394a3c76) and [28f668f](https://foundry.openuru.org/gitblit/commit/?r=MOULSCRIPT-ou.git&h=28f668f6c16045a0863158989ffd0d0383202847)) have been in MOULa for a long time, but apparently I forgot to submit them back here after I packed them onto Lyrositor’s [OU equivalent](https://bitbucket.org/OpenUru_org/moulscript-ou/pull-requests/19) of #40, as I noticed last weekend on Gehn.

Presently, when KI chat text field is full, i.e. incoming lines push out old ones at the top, and you are scrolled up to somewhere in the middle of the field, an incoming line still shifts the text by one line, instead of keeping the scroll position locked to the text as intended (and as it works when the field is not full). The first commit fixes that.

This however makes incoming chat unnoticeable when scrolled up. To compensate for that, the second commit makes the down scroll arrow blink when chat comes in.

To illustrate the usability issue caused by the current behavior: At the Veelay Tsahvahn party on Gehn it happened to me once that I answered a question that had actually been posted several minutes before (and had long been answered by others), because it was just then pushed into my visible chat range, and I hadn’t noticed that I was scrolled up.