### PR TITLE
Run 'safe' 2to3 fixers and convert print to PtDebugPrint

### DIFF
--- a/Python/Ahnonay.py
+++ b/Python/Ahnonay.py
@@ -100,46 +100,46 @@ class Ahnonay(ptResponder):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "AhnonayLink":
                             linkid = chron
-                            print "Ahnonay.OnServerInitComplete(): Link Chron already exists: %s" % (linkid.getValue())
+                            print("Ahnonay.OnServerInitComplete(): Link Chron already exists: %s" % (linkid.getValue()))
                         elif chron and chron.getName() == "AhnonayLocked":
                             locked = chron
-                            print "Ahnonay.OnServerInitComplete(): Locked Chron already exists: %s" % (locked.getValue())
+                            print("Ahnonay.OnServerInitComplete(): Locked Chron already exists: %s" % (locked.getValue()))
                         elif chron and chron.getName() == "AhnonayVolatile":
                             volatile = chron
-                            print "Ahnonay.OnServerInitComplete(): Volatile Chron already exists: %s" % (volatile.getValue())
+                            print("Ahnonay.OnServerInitComplete(): Volatile Chron already exists: %s" % (volatile.getValue()))
                         elif chron and chron.getName() == "AhnonaySpawnPoints":
                             spawn = chron
-                            print "Ahnonay.OnServerInitComplete(): Spawn Chron already exists: %s" % (spawn.getValue())
+                            print("Ahnonay.OnServerInitComplete(): Spawn Chron already exists: %s" % (spawn.getValue()))
                         elif chron and chron.getName() == "AhnonayOwner":
                             owner = chron
                     break
 
         if owner == None:
-            print "I am not the age owner, and I don't have my own Ahnonay"
+            print("I am not the age owner, and I don't have my own Ahnonay")
         elif owner.getValue() == myID:
             if linkid == None:
-                print "Ahnonay.OnServerInitComplete(): Link Chron not found, creating"
+                print("Ahnonay.OnServerInitComplete(): Link Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonayLink")
                 newNode.chronicleSetValue(guid)
                 ageDataFolder.addNode(newNode)
 
             if locked == None:
-                print "Ahnonay.OnServerInitComplete(): Locked Chron not found, creating"
+                print("Ahnonay.OnServerInitComplete(): Locked Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonayLocked")
                 newNode.chronicleSetValue("1")
                 ageDataFolder.addNode(newNode)
 
             if volatile == None:
-                print "Ahnonay.OnServerInitComplete(): Volatile Chron not found, creating"
+                print("Ahnonay.OnServerInitComplete(): Volatile Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonayVolatile")
                 newNode.chronicleSetValue("0")
                 ageDataFolder.addNode(newNode)
 
             if spawn == None:
-                print "Ahnonay.OnServerInitComplete(): Spawn Chron not found, creating"
+                print("Ahnonay.OnServerInitComplete(): Spawn Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonaySpawnPoints")
                 newNode.chronicleSetValue("Default,LinkInPointDefault")
@@ -147,13 +147,13 @@ class Ahnonay(ptResponder):
 
             if volatile and linkid:
                 if volatile.getValue() == "1" and guid != linkid.getValue():
-                    print "Ahnonay.OnServerInitComplete(): In a new instance of Ahnonay so setting new vars"
+                    print("Ahnonay.OnServerInitComplete(): In a new instance of Ahnonay so setting new vars")
                     linkid.setValue(guid)
                     locked.setValue("1")
                     volatile.setValue("0")
                     spawn.setValue("Default,LinkInPointDefault")
         else:
-            print "I am not the age owner, but I do have my own Ahnonay"
+            print("I am not the age owner, but I do have my own Ahnonay")
 
 
         ageSDL = PtGetAgeSDL()
@@ -172,11 +172,11 @@ class Ahnonay(ptResponder):
 
         if spTitle == "SCSavePoint":
             if spName == "SaveClothPoint7" or spName == "SaveClothPoint8":
-                print "linking to hub or hut"
+                print("linking to hub or hut")
                 newSphere = 4
             else:
                 offset = str(ageSDL["ahnyCurrentOffset"][0])
-                print "Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset)
+                print("Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset))
                 newSphere = (int(sphere) - int(offset)) % 4
                 if newSphere == 0:
                     newSphere = 4
@@ -221,7 +221,7 @@ class Ahnonay(ptResponder):
 
                 if spTitle == "SCSavePoint":
                     if spName == "SaveClothPoint7" or spName == "SaveClothPoint8":
-                        print "linking to hub or hut"
+                        print("linking to hub or hut")
                         newSphere = 4
                     else:
                         newSphere = (int(sphere) - int(offset)) % 4

--- a/Python/Ahnonay.py
+++ b/Python/Ahnonay.py
@@ -100,46 +100,46 @@ class Ahnonay(ptResponder):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "AhnonayLink":
                             linkid = chron
-                            print("Ahnonay.OnServerInitComplete(): Link Chron already exists: %s" % (linkid.getValue()))
+                            PtDebugPrint("Ahnonay.OnServerInitComplete(): Link Chron already exists: %s" % (linkid.getValue()))
                         elif chron and chron.getName() == "AhnonayLocked":
                             locked = chron
-                            print("Ahnonay.OnServerInitComplete(): Locked Chron already exists: %s" % (locked.getValue()))
+                            PtDebugPrint("Ahnonay.OnServerInitComplete(): Locked Chron already exists: %s" % (locked.getValue()))
                         elif chron and chron.getName() == "AhnonayVolatile":
                             volatile = chron
-                            print("Ahnonay.OnServerInitComplete(): Volatile Chron already exists: %s" % (volatile.getValue()))
+                            PtDebugPrint("Ahnonay.OnServerInitComplete(): Volatile Chron already exists: %s" % (volatile.getValue()))
                         elif chron and chron.getName() == "AhnonaySpawnPoints":
                             spawn = chron
-                            print("Ahnonay.OnServerInitComplete(): Spawn Chron already exists: %s" % (spawn.getValue()))
+                            PtDebugPrint("Ahnonay.OnServerInitComplete(): Spawn Chron already exists: %s" % (spawn.getValue()))
                         elif chron and chron.getName() == "AhnonayOwner":
                             owner = chron
                     break
 
         if owner == None:
-            print("I am not the age owner, and I don't have my own Ahnonay")
+            PtDebugPrint("I am not the age owner, and I don't have my own Ahnonay")
         elif owner.getValue() == myID:
             if linkid == None:
-                print("Ahnonay.OnServerInitComplete(): Link Chron not found, creating")
+                PtDebugPrint("Ahnonay.OnServerInitComplete(): Link Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonayLink")
                 newNode.chronicleSetValue(guid)
                 ageDataFolder.addNode(newNode)
 
             if locked == None:
-                print("Ahnonay.OnServerInitComplete(): Locked Chron not found, creating")
+                PtDebugPrint("Ahnonay.OnServerInitComplete(): Locked Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonayLocked")
                 newNode.chronicleSetValue("1")
                 ageDataFolder.addNode(newNode)
 
             if volatile == None:
-                print("Ahnonay.OnServerInitComplete(): Volatile Chron not found, creating")
+                PtDebugPrint("Ahnonay.OnServerInitComplete(): Volatile Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonayVolatile")
                 newNode.chronicleSetValue("0")
                 ageDataFolder.addNode(newNode)
 
             if spawn == None:
-                print("Ahnonay.OnServerInitComplete(): Spawn Chron not found, creating")
+                PtDebugPrint("Ahnonay.OnServerInitComplete(): Spawn Chron not found, creating")
                 newNode = ptVaultChronicleNode(0)
                 newNode.chronicleSetName("AhnonaySpawnPoints")
                 newNode.chronicleSetValue("Default,LinkInPointDefault")
@@ -147,13 +147,13 @@ class Ahnonay(ptResponder):
 
             if volatile and linkid:
                 if volatile.getValue() == "1" and guid != linkid.getValue():
-                    print("Ahnonay.OnServerInitComplete(): In a new instance of Ahnonay so setting new vars")
+                    PtDebugPrint("Ahnonay.OnServerInitComplete(): In a new instance of Ahnonay so setting new vars")
                     linkid.setValue(guid)
                     locked.setValue("1")
                     volatile.setValue("0")
                     spawn.setValue("Default,LinkInPointDefault")
         else:
-            print("I am not the age owner, but I do have my own Ahnonay")
+            PtDebugPrint("I am not the age owner, but I do have my own Ahnonay")
 
 
         ageSDL = PtGetAgeSDL()
@@ -172,11 +172,11 @@ class Ahnonay(ptResponder):
 
         if spTitle == "SCSavePoint":
             if spName == "SaveClothPoint7" or spName == "SaveClothPoint8":
-                print("linking to hub or hut")
+                PtDebugPrint("linking to hub or hut")
                 newSphere = 4
             else:
                 offset = str(ageSDL["ahnyCurrentOffset"][0])
-                print("Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset))
+                PtDebugPrint("Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset))
                 newSphere = (int(sphere) - int(offset)) % 4
                 if newSphere == 0:
                     newSphere = 4
@@ -221,7 +221,7 @@ class Ahnonay(ptResponder):
 
                 if spTitle == "SCSavePoint":
                     if spName == "SaveClothPoint7" or spName == "SaveClothPoint8":
-                        print("linking to hub or hut")
+                        PtDebugPrint("linking to hub or hut")
                         newSphere = 4
                     else:
                         newSphere = (int(sphere) - int(offset)) % 4

--- a/Python/AhnonayCathedral.py
+++ b/Python/AhnonayCathedral.py
@@ -81,7 +81,7 @@ class AhnonayCathedral(ptResponder):
                             owner = chron
                     break
         if owner == None and vault.amOwnerOfCurrentAge():
-            print "I own this Cathedral, but I haven't set myself as Ahnonay owner yet."
+            print("I own this Cathedral, but I haven't set myself as Ahnonay owner yet.")
             newNode = ptVaultChronicleNode(0)
             newNode.chronicleSetName("AhnonayOwner")
             newNode.chronicleSetValue(str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey())))

--- a/Python/AhnonayCathedral.py
+++ b/Python/AhnonayCathedral.py
@@ -81,7 +81,7 @@ class AhnonayCathedral(ptResponder):
                             owner = chron
                     break
         if owner == None and vault.amOwnerOfCurrentAge():
-            print("I own this Cathedral, but I haven't set myself as Ahnonay owner yet.")
+            PtDebugPrint("I own this Cathedral, but I haven't set myself as Ahnonay owner yet.")
             newNode = ptVaultChronicleNode(0)
             newNode.chronicleSetName("AhnonayOwner")
             newNode.chronicleSetValue(str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey())))

--- a/Python/AhnyVogondolaRide.py
+++ b/Python/AhnyVogondolaRide.py
@@ -82,7 +82,7 @@ class AhnyVogondolaRide(ptResponder):
         if (id == click.id and state):
             avatar = PtFindAvatar(events)
             climb.run(avatar)
-            print"clicked on chair"
+            print("clicked on chair")
             return
         
         if (id == hutChairClickable.id and state):
@@ -90,20 +90,20 @@ class AhnyVogondolaRide(ptResponder):
             theAvatar.physics.warpObj(dummy.value.getKey())
             PtAttachObject(theAvatar.getKey(),dummy.value.getKey())
             theAvatar.avatar.enterSubWorld(subworld.value)
-            print"pinned avatar"
+            print("pinned avatar")
             beginHutRide.run(self.key,avatar=theAvatar)
         
         if (id == climb.id):
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage:
                     lower.run(self.key,avatar=PtGetLocalAvatar())
-                    print"finished smart-seek"
+                    print("finished smart-seek")
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
                     theAvatar=PtGetLocalAvatar()
                     theAvatar.physics.warpObj(dummy.value.getKey())
                     PtAttachObject(theAvatar.getKey(),dummy.value.getKey())
                     theAvatar.avatar.enterSubWorld(subworld.value)
-                    print"pinned avatar"
+                    print("pinned avatar")
                     ride.run(self.key,avatar=theAvatar)
         
         if (id == eject1.id and state):
@@ -117,14 +117,14 @@ class AhnyVogondolaRide(ptResponder):
             PtDetachObject(theAvatar.getKey(),dummy.value.getKey())
             theAvatar.avatar.exitSubWorld()
             theAvatar.physics.warpObj(ejectPt1.value.getKey())
-            print"ejecting at the hub"
+            print("ejecting at the hub")
             
         if (id == ejectResp2.id and state):
             theAvatar=PtGetLocalAvatar()
             PtDetachObject(theAvatar.getKey(),dummy.value.getKey())
             theAvatar.avatar.exitSubWorld()
             theAvatar.physics.warpObj(ejectPt2.value.getKey())
-            print"ejecting at the hut"        
+            print("ejecting at the hut")        
         
         
              

--- a/Python/AhnyVogondolaRide.py
+++ b/Python/AhnyVogondolaRide.py
@@ -82,7 +82,7 @@ class AhnyVogondolaRide(ptResponder):
         if (id == click.id and state):
             avatar = PtFindAvatar(events)
             climb.run(avatar)
-            print("clicked on chair")
+            PtDebugPrint("clicked on chair")
             return
         
         if (id == hutChairClickable.id and state):
@@ -90,20 +90,20 @@ class AhnyVogondolaRide(ptResponder):
             theAvatar.physics.warpObj(dummy.value.getKey())
             PtAttachObject(theAvatar.getKey(),dummy.value.getKey())
             theAvatar.avatar.enterSubWorld(subworld.value)
-            print("pinned avatar")
+            PtDebugPrint("pinned avatar")
             beginHutRide.run(self.key,avatar=theAvatar)
         
         if (id == climb.id):
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage:
                     lower.run(self.key,avatar=PtGetLocalAvatar())
-                    print("finished smart-seek")
+                    PtDebugPrint("finished smart-seek")
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
                     theAvatar=PtGetLocalAvatar()
                     theAvatar.physics.warpObj(dummy.value.getKey())
                     PtAttachObject(theAvatar.getKey(),dummy.value.getKey())
                     theAvatar.avatar.enterSubWorld(subworld.value)
-                    print("pinned avatar")
+                    PtDebugPrint("pinned avatar")
                     ride.run(self.key,avatar=theAvatar)
         
         if (id == eject1.id and state):
@@ -117,14 +117,14 @@ class AhnyVogondolaRide(ptResponder):
             PtDetachObject(theAvatar.getKey(),dummy.value.getKey())
             theAvatar.avatar.exitSubWorld()
             theAvatar.physics.warpObj(ejectPt1.value.getKey())
-            print("ejecting at the hub")
+            PtDebugPrint("ejecting at the hub")
             
         if (id == ejectResp2.id and state):
             theAvatar=PtGetLocalAvatar()
             PtDetachObject(theAvatar.getKey(),dummy.value.getKey())
             theAvatar.avatar.exitSubWorld()
             theAvatar.physics.warpObj(ejectPt2.value.getKey())
-            print("ejecting at the hut")        
+            PtDebugPrint("ejecting at the hut")        
         
         
              

--- a/Python/Cleft.py
+++ b/Python/Cleft.py
@@ -122,11 +122,11 @@ class Cleft(ptResponder):
             pages += ["ZandiJC04aFace","ZandiJC04bFace","ZandiJC05aFace","ZandiJC05bFace","ZandiJC06aFace","ZandiJC06bFace"]
             pages += ["ZandiJC07aFace","ZandiJC07bFace"]
         else:
-            print "Zandi seems to have stepped away from the Airstream. Hmmm..."
+            print("Zandi seems to have stepped away from the Airstream. Hmmm...")
         if loadBook:
             pages += ["clftYeeshaBookVis","FemaleGetPersonalBook","MaleGetPersonalBook"]
         else:
-            print "Zandi seems to have stepped away from the Airstream. Hmmm..."
+            print("Zandi seems to have stepped away from the Airstream. Hmmm...")
 
         # Put in all the common pages
         pages += ["BookRoom","clftAtrusNote"]
@@ -221,7 +221,7 @@ class Cleft(ptResponder):
             try:
                 avatar = PtGetLocalAvatar()
             except:
-                print"failed to get local avatar"
+                print("failed to get local avatar")
                 return
             avatar.avatar.registerForBehaviorNotify(self.key)
             cam = ptCamera()
@@ -258,7 +258,7 @@ class Cleft(ptResponder):
         global fissureDrop
 
         if (id == respFissureDropMain.id):
-            print "FISSUREDROP.OnNotify:  respFissureDropMain.id callback"
+            print("FISSUREDROP.OnNotify:  respFissureDropMain.id callback")
             if fissureDrop:
                 cam = ptCamera()
                 cam.enableFirstPersonOverride()
@@ -274,7 +274,7 @@ class Cleft(ptResponder):
    
         #PtDebugPrint("Cleft.OnBehaviorNotify(): %d" % (type))
         if type == PtBehaviorTypes.kBehaviorTypeLinkIn and not state:
-            print "FISSUREDROP.OnBehaviorNotify: fissureDrop = %d" % (fissureDrop)
+            print("FISSUREDROP.OnBehaviorNotify: fissureDrop = %d" % (fissureDrop))
             if fissureDrop:
                 PtDebugPrint("Cleft.OnBehaviorNotify(): will run respFissureDropMain now.")
                 respFissureDropMain.run(self.key,avatar=PtGetLocalAvatar())

--- a/Python/Cleft.py
+++ b/Python/Cleft.py
@@ -122,11 +122,11 @@ class Cleft(ptResponder):
             pages += ["ZandiJC04aFace","ZandiJC04bFace","ZandiJC05aFace","ZandiJC05bFace","ZandiJC06aFace","ZandiJC06bFace"]
             pages += ["ZandiJC07aFace","ZandiJC07bFace"]
         else:
-            print("Zandi seems to have stepped away from the Airstream. Hmmm...")
+            PtDebugPrint("Zandi seems to have stepped away from the Airstream. Hmmm...")
         if loadBook:
             pages += ["clftYeeshaBookVis","FemaleGetPersonalBook","MaleGetPersonalBook"]
         else:
-            print("Zandi seems to have stepped away from the Airstream. Hmmm...")
+            PtDebugPrint("Zandi seems to have stepped away from the Airstream. Hmmm...")
 
         # Put in all the common pages
         pages += ["BookRoom","clftAtrusNote"]
@@ -221,7 +221,7 @@ class Cleft(ptResponder):
             try:
                 avatar = PtGetLocalAvatar()
             except:
-                print("failed to get local avatar")
+                PtDebugPrint("failed to get local avatar")
                 return
             avatar.avatar.registerForBehaviorNotify(self.key)
             cam = ptCamera()
@@ -258,7 +258,7 @@ class Cleft(ptResponder):
         global fissureDrop
 
         if (id == respFissureDropMain.id):
-            print("FISSUREDROP.OnNotify:  respFissureDropMain.id callback")
+            PtDebugPrint("FISSUREDROP.OnNotify:  respFissureDropMain.id callback")
             if fissureDrop:
                 cam = ptCamera()
                 cam.enableFirstPersonOverride()
@@ -274,7 +274,7 @@ class Cleft(ptResponder):
    
         #PtDebugPrint("Cleft.OnBehaviorNotify(): %d" % (type))
         if type == PtBehaviorTypes.kBehaviorTypeLinkIn and not state:
-            print("FISSUREDROP.OnBehaviorNotify: fissureDrop = %d" % (fissureDrop))
+            PtDebugPrint("FISSUREDROP.OnBehaviorNotify: fissureDrop = %d" % (fissureDrop))
             if fissureDrop:
                 PtDebugPrint("Cleft.OnBehaviorNotify(): will run respFissureDropMain now.")
                 respFissureDropMain.run(self.key,avatar=PtGetLocalAvatar())

--- a/Python/ErcanaCitySilo.py
+++ b/Python/ErcanaCitySilo.py
@@ -117,7 +117,7 @@ class ErcanaCitySilo(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "ErcanaCitySilo.OnServerInitComplete():\tERROR---Cannot find the ErcanaCitySilo Age SDL"
+            print("ErcanaCitySilo.OnServerInitComplete():\tERROR---Cannot find the ErcanaCitySilo Age SDL")
             ageSDL[SDLGotPellet.value] = (0,)
         
         ageSDL.setNotify(self.key,SDLGotPellet.value,0.0)
@@ -141,17 +141,17 @@ class ErcanaCitySilo(ptResponder):
                 cam.undoFirstPerson()
         elif type == PtBehaviorTypes.kBehaviorTypeLinkIn and not state:
             if self._gotTurd:
-                print "ErcanaCitySilo.OnBehaviorNotify: Will now call IDoMeter."
+                print("ErcanaCitySilo.OnBehaviorNotify: Will now call IDoMeter.")
                 self.IDoMeter()
             else:
-                print "Says we don't have a turd.  Shouldn't be possible, I'm in OnBehaviorNotify."
+                print("Says we don't have a turd.  Shouldn't be possible, I'm in OnBehaviorNotify.")
             avatar = PtGetLocalAvatar()
             avatar.avatar.unRegisterForBehaviorNotify(self.key)
 
 
     def IDoMeter(self):
         levelMeter = self.IEvalPellet()
-        print "ErcanaCitySilo.IDoMeter():  pellet is level: ",levelMeter
+        print("ErcanaCitySilo.IDoMeter():  pellet is level: ",levelMeter)
         if levelMeter == 1.0:
             RespScanMeter.run(self.key,state="Level1")
             PtAtTimeCallback(self.key,6.3,2)
@@ -243,8 +243,8 @@ class ErcanaCitySilo(ptResponder):
             self._lakePoints = self._pellet
         self._kiPoints = int(round(self._kiPoints * ((xRandom.randint(1,25) / 100.0) + 4.75)))
         self._lakePoints = int(round(self._lakePoints))
-        print "ErcanaCitySilo.IDoScores():  this pellet drop is worth %d KI points!" % (self._kiPoints)
-        print "ErcanaCitySilo.IDoScores():  and %d lake points!" % (self._lakePoints)
+        print("ErcanaCitySilo.IDoScores():  this pellet drop is worth %d KI points!" % (self._kiPoints))
+        print("ErcanaCitySilo.IDoScores():  and %d lake points!" % (self._lakePoints))
 
         #  Try to find the needed scores...
         #  The magic will happen in OnGameScoreMsg()
@@ -255,7 +255,7 @@ class ErcanaCitySilo(ptResponder):
 
     def OnNotify(self,state,id,events):
         if (id == RespScanMeter.id and self._gotTurd):
-            print "ErcanaCitySilo.OnNotify: Received callback from RespScanMeter, will now call IDropPellet."
+            print("ErcanaCitySilo.OnNotify: Received callback from RespScanMeter, will now call IDropPellet.")
             self.IDropPellet()
 
         elif (id == RespDropPellet.id and self._gotTurd):
@@ -304,45 +304,45 @@ class ErcanaCitySilo(ptResponder):
 
     def IPlayPellet(self,level):
         if level > 0.0:
-            print "ErcanaCitySilo.IPlayPellet(): and the pellet anim is..."
+            print("ErcanaCitySilo.IPlayPellet(): and the pellet anim is...")
             if level == 1.0:
-                print "steam & bubbles - HIGH"
+                print("steam & bubbles - HIGH")
                 RespPlaySteam.run(self.key,state="Hi")
                 RespPlayBubbles.run(self.key,state="Hi")
             elif level == 2.0:
-                print "steam & bubbles - MEDIUM"
+                print("steam & bubbles - MEDIUM")
                 RespPlaySteam.run(self.key,state="Med")
                 RespPlayBubbles.run(self.key,state="Med")
             elif level == 3.1:
-                print "steam & bubbles - LOW"
+                print("steam & bubbles - LOW")
                 RespPlaySteam.run(self.key,state="Low")
                 RespPlayBubbles.run(self.key,state="Low")
             elif level == 3.2:
-                print "dud"
+                print("dud")
                 RespPlayDud.run(self.key)
             elif level == 4.0:
-                print "orange glow - LOW"
+                print("orange glow - LOW")
                 RespPlayOrangeGlow.run(self.key,state="Low")
             elif level == 5.0:
-                print "orange glow - MEDIUM"
+                print("orange glow - MEDIUM")
                 RespPlayOrangeGlow.run(self.key,state="Med")
             elif level == 6.0:
-                print "orange glow - HIGH"
+                print("orange glow - HIGH")
                 RespPlayOrangeGlow.run(self.key,state="Hi")
             elif level == 7.0:
-                print "white glow"
+                print("white glow")
                 RespPlayWhiteGlow.run(self.key)
             elif level == 8.0:
-                print "explosion - LOW"
+                print("explosion - LOW")
                 RespPlayBoom.run(self.key,state="Low")
             elif level == 9.0:
-                print "explosion - MEDIUM"
+                print("explosion - MEDIUM")
                 RespPlayBoom.run(self.key,state="Med")
             elif level == 10.0:
-                print "explosion - HIGH"
+                print("explosion - HIGH")
                 RespPlayBoom.run(self.key,state="Hi")
         else:
-            print "ErcanaCitySilo.IPlayPellet():  ERROR.  Level must be greater than 0"
+            print("ErcanaCitySilo.IPlayPellet():  ERROR.  Level must be greater than 0")
 
 
     def OnBackdoorMsg(self,target,param):
@@ -351,10 +351,10 @@ class ErcanaCitySilo(ptResponder):
             #print "param = ",param
             if param > 0.0 and param <= 10.0:
                 if param == 3.0:
-                    print "can't use 3.0, must be either 3.1 or 3.2"
+                    print("can't use 3.0, must be either 3.1 or 3.2")
                     return
                 else:
                     self.IPlayPellet(param)
             else:
-                print "must be between 0.0 and 10.0"
+                print("must be between 0.0 and 10.0")
 

--- a/Python/ErcanaCitySilo.py
+++ b/Python/ErcanaCitySilo.py
@@ -117,7 +117,7 @@ class ErcanaCitySilo(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("ErcanaCitySilo.OnServerInitComplete():\tERROR---Cannot find the ErcanaCitySilo Age SDL")
+            PtDebugPrint("ErcanaCitySilo.OnServerInitComplete():\tERROR---Cannot find the ErcanaCitySilo Age SDL")
             ageSDL[SDLGotPellet.value] = (0,)
         
         ageSDL.setNotify(self.key,SDLGotPellet.value,0.0)
@@ -141,17 +141,17 @@ class ErcanaCitySilo(ptResponder):
                 cam.undoFirstPerson()
         elif type == PtBehaviorTypes.kBehaviorTypeLinkIn and not state:
             if self._gotTurd:
-                print("ErcanaCitySilo.OnBehaviorNotify: Will now call IDoMeter.")
+                PtDebugPrint("ErcanaCitySilo.OnBehaviorNotify: Will now call IDoMeter.")
                 self.IDoMeter()
             else:
-                print("Says we don't have a turd.  Shouldn't be possible, I'm in OnBehaviorNotify.")
+                PtDebugPrint("Says we don't have a turd.  Shouldn't be possible, I'm in OnBehaviorNotify.")
             avatar = PtGetLocalAvatar()
             avatar.avatar.unRegisterForBehaviorNotify(self.key)
 
 
     def IDoMeter(self):
         levelMeter = self.IEvalPellet()
-        print("ErcanaCitySilo.IDoMeter():  pellet is level: ",levelMeter)
+        PtDebugPrint("ErcanaCitySilo.IDoMeter():  pellet is level: ",levelMeter)
         if levelMeter == 1.0:
             RespScanMeter.run(self.key,state="Level1")
             PtAtTimeCallback(self.key,6.3,2)
@@ -243,8 +243,8 @@ class ErcanaCitySilo(ptResponder):
             self._lakePoints = self._pellet
         self._kiPoints = int(round(self._kiPoints * ((xRandom.randint(1,25) / 100.0) + 4.75)))
         self._lakePoints = int(round(self._lakePoints))
-        print("ErcanaCitySilo.IDoScores():  this pellet drop is worth %d KI points!" % (self._kiPoints))
-        print("ErcanaCitySilo.IDoScores():  and %d lake points!" % (self._lakePoints))
+        PtDebugPrint("ErcanaCitySilo.IDoScores():  this pellet drop is worth %d KI points!" % (self._kiPoints))
+        PtDebugPrint("ErcanaCitySilo.IDoScores():  and %d lake points!" % (self._lakePoints))
 
         #  Try to find the needed scores...
         #  The magic will happen in OnGameScoreMsg()
@@ -255,7 +255,7 @@ class ErcanaCitySilo(ptResponder):
 
     def OnNotify(self,state,id,events):
         if (id == RespScanMeter.id and self._gotTurd):
-            print("ErcanaCitySilo.OnNotify: Received callback from RespScanMeter, will now call IDropPellet.")
+            PtDebugPrint("ErcanaCitySilo.OnNotify: Received callback from RespScanMeter, will now call IDropPellet.")
             self.IDropPellet()
 
         elif (id == RespDropPellet.id and self._gotTurd):
@@ -304,57 +304,57 @@ class ErcanaCitySilo(ptResponder):
 
     def IPlayPellet(self,level):
         if level > 0.0:
-            print("ErcanaCitySilo.IPlayPellet(): and the pellet anim is...")
+            PtDebugPrint("ErcanaCitySilo.IPlayPellet(): and the pellet anim is...")
             if level == 1.0:
-                print("steam & bubbles - HIGH")
+                PtDebugPrint("steam & bubbles - HIGH")
                 RespPlaySteam.run(self.key,state="Hi")
                 RespPlayBubbles.run(self.key,state="Hi")
             elif level == 2.0:
-                print("steam & bubbles - MEDIUM")
+                PtDebugPrint("steam & bubbles - MEDIUM")
                 RespPlaySteam.run(self.key,state="Med")
                 RespPlayBubbles.run(self.key,state="Med")
             elif level == 3.1:
-                print("steam & bubbles - LOW")
+                PtDebugPrint("steam & bubbles - LOW")
                 RespPlaySteam.run(self.key,state="Low")
                 RespPlayBubbles.run(self.key,state="Low")
             elif level == 3.2:
-                print("dud")
+                PtDebugPrint("dud")
                 RespPlayDud.run(self.key)
             elif level == 4.0:
-                print("orange glow - LOW")
+                PtDebugPrint("orange glow - LOW")
                 RespPlayOrangeGlow.run(self.key,state="Low")
             elif level == 5.0:
-                print("orange glow - MEDIUM")
+                PtDebugPrint("orange glow - MEDIUM")
                 RespPlayOrangeGlow.run(self.key,state="Med")
             elif level == 6.0:
-                print("orange glow - HIGH")
+                PtDebugPrint("orange glow - HIGH")
                 RespPlayOrangeGlow.run(self.key,state="Hi")
             elif level == 7.0:
-                print("white glow")
+                PtDebugPrint("white glow")
                 RespPlayWhiteGlow.run(self.key)
             elif level == 8.0:
-                print("explosion - LOW")
+                PtDebugPrint("explosion - LOW")
                 RespPlayBoom.run(self.key,state="Low")
             elif level == 9.0:
-                print("explosion - MEDIUM")
+                PtDebugPrint("explosion - MEDIUM")
                 RespPlayBoom.run(self.key,state="Med")
             elif level == 10.0:
-                print("explosion - HIGH")
+                PtDebugPrint("explosion - HIGH")
                 RespPlayBoom.run(self.key,state="Hi")
         else:
-            print("ErcanaCitySilo.IPlayPellet():  ERROR.  Level must be greater than 0")
+            PtDebugPrint("ErcanaCitySilo.IPlayPellet():  ERROR.  Level must be greater than 0")
 
 
     def OnBackdoorMsg(self,target,param):
         if target == "pelletfx":
             param = float(param)
-            #print "param = ",param
+            #PtDebugPrint("param = ",param)
             if param > 0.0 and param <= 10.0:
                 if param == 3.0:
-                    print("can't use 3.0, must be either 3.1 or 3.2")
+                    PtDebugPrint("can't use 3.0, must be either 3.1 or 3.2")
                     return
                 else:
                     self.IPlayPellet(param)
             else:
-                print("must be between 0.0 and 10.0")
+                PtDebugPrint("must be between 0.0 and 10.0")
 

--- a/Python/GardenBugs.py
+++ b/Python/GardenBugs.py
@@ -105,23 +105,23 @@ class GardenBugs(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print "GardenBugs.OnFirstUpdate():\tfailed to get local avatar"
+            print("GardenBugs.OnFirstUpdate():\tfailed to get local avatar")
             return
         
         avatar.avatar.registerForBehaviorNotify(self.key)
         
         self.bugCount = self.IGetBugCount()
-        print "GardenBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount
+        print("GardenBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount)
         
         # first, kill all bugs on the avatar that might have been brought over
         PtKillParticles(0,1,avatar.getKey())
         
         if (self.bugCount > 0):
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, True)
-            print"GardenBugs.OnFirstUpdate():\tTurning lights on at start"
+            print("GardenBugs.OnFirstUpdate():\tTurning lights on at start")
         else:
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print"GardenBugs.OnFirstUpdate():\tTurning lights off at start"
+            print("GardenBugs.OnFirstUpdate():\tTurning lights off at start")
         
         # this will add the bugs back that we have
         PtAtTimeCallback(self.key,0.1,kAddBugs)
@@ -151,11 +151,11 @@ class GardenBugs(ptResponder):
                 # kill some particles
                 particlesToKill = -particlesToTransfer
                 percentToKill = float(particlesToKill) / float(self.bugCount)
-                print "GardenBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)"
+                print("GardenBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)")
                 PtKillParticles(0,percentToKill,avatar.getKey())
             elif (particlesToTransfer != 0):
                 # add some particles
-                print "GardenBugs.OnTimer() - Particles to add: " + str(particlesToTransfer)
+                print("GardenBugs.OnTimer() - Particles to add: " + str(particlesToTransfer))
                 PtTransferParticlesToObject(bugEmitter.value.getKey(),avatar.getKey(),particlesToTransfer)
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             return
@@ -164,9 +164,9 @@ class GardenBugs(ptResponder):
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL[raining.value] = (1,)
             PtSetParticleOffset(0,0,100,bugEmitter.value.getKey())
-            print "GardenBugs.OnTimer():\tIt's rain, bug cloud gone"
+            print("GardenBugs.OnTimer():\tIt's rain, bug cloud gone")
             if (localInTunnel or self.bugCount == 0):
-                print "GardenBugs.OnTimer():\tIn tunnel, bugs safe for now or no local bugs"
+                print("GardenBugs.OnTimer():\tIn tunnel, bugs safe for now or no local bugs")
                 return
             PtSetParticleDissentPoint(0,0,100,avatar.getKey())
             PtKillParticles(3.0,1,avatar.getKey())
@@ -183,7 +183,7 @@ class GardenBugs(ptResponder):
                 
             if (id == PtBehaviorTypes.kBehaviorTypeRun):
                 if (running or (PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving())):
-                    print "GardenBugs.OnTimer():\tRunning, kill more bugs"
+                    print("GardenBugs.OnTimer():\tRunning, kill more bugs")
                     PtKillParticles(3.0,0.1,avatar.getKey())
                     PtAtTimeCallback(self.key, 0.4, PtBehaviorTypes.kBehaviorTypeRun)
                     self.bugCount = self.bugCount * 0.1
@@ -203,45 +203,45 @@ class GardenBugs(ptResponder):
         triggerer = PtFindAvatar(events)
         avatar = PtGetLocalAvatar()
         if (avatar != triggerer):
-            print "GardenBugs.OnNotify():\tWrong avatar, notifies run locally"
+            print("GardenBugs.OnNotify():\tWrong avatar, notifies run locally")
             return
 
         self.bugCount = PtGetNumParticles(avatar.getKey())
 
         if (id == bugRgn.id):
-            print "GardenBugs.OnNotify():\tEntered bug cloud region"
+            print("GardenBugs.OnNotify():\tEntered bug cloud region")
 
             if (self.bugCount > 19):
                 return
             self.ageSDL = PtGetAgeSDL()
             rain = self.ageSDL[raining.value][0]
             if (rain):
-                print "gardenBugs.OnNotify()-->\tnope, it's raining"
+                print("gardenBugs.OnNotify()-->\tnope, it's raining")
                 return
             if running:
-                print "gardenBugs.OnNotify()-->\tcan't add bugs as we're still running"
+                print("gardenBugs.OnNotify()-->\tcan't add bugs as we're still running")
                 return
             if PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving():
-                print "gardenBugs.OnNotify()-->\tcan't add bugs as we're still running (but our running flag is False?)"
+                print("gardenBugs.OnNotify()-->\tcan't add bugs as we're still running (but our running flag is False?)")
                 return
 
-            print "gardenBugs.OnNotify()-->\ttansferring Bugs!"
+            print("gardenBugs.OnNotify()-->\ttansferring Bugs!")
             avatar = PtFindAvatar(events)
             PtTransferParticlesToObject(bugEmitter.value.getKey(),avatar.getKey(),10)
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
-            print"gardenBugs.OnNotify()-->\tset bugs at 10"
+            print("gardenBugs.OnNotify()-->\tset bugs at 10")
             PtAtTimeCallback(self.key,0.1,kCheckForBugs)
             numJumps = 0
             self.bugCount = self.bugCount + 10
             self.ISaveBugCount(self.bugCount)
         
         if (id == rainStart.id):
-            print "gardenBugs.OnNotify()-->\tstart rain timer"
+            print("gardenBugs.OnNotify()-->\tstart rain timer")
             PtAtTimeCallback(self.key, 30.0, kRainStarting)
             return            
 
         if (id == rainEnd.id):
-            print "gardenBugs.OnNotify()-->\train stopping"
+            print("gardenBugs.OnNotify()-->\train stopping")
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL[raining.value] = (0,)
             PtSetParticleOffset(0,0,4,bugEmitter.value.getKey())
@@ -250,7 +250,7 @@ class GardenBugs(ptResponder):
             PtSetParticleDissentPoint(0,0,100,avatar.getKey())
             PtKillParticles(3.0,1,avatar.getKey())
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print"gardenBugs.OnNotify()-->\tbharo cave too scary for bugs!"
+            print("gardenBugs.OnNotify()-->\tbharo cave too scary for bugs!")
             self.bugCount = 0
             self.ISaveBugCount(self.bugCount)
             import xSndLogTracks
@@ -261,11 +261,11 @@ class GardenBugs(ptResponder):
             for event in events:
                 if event[0]==1 and event[1]==1:
                     localInTunnel = True
-                    print "gardenBugs.OnNotify()-->\tlocal in tunnel"
+                    print("gardenBugs.OnNotify()-->\tlocal in tunnel")
                     return
                 elif event[0]==1 and event[1]==0:
                     localInTunnel = False
-                    print "gardenBugs.OnNotify()-->\tlocal exit tunnel"
+                    print("gardenBugs.OnNotify()-->\tlocal exit tunnel")
                     self.ageSDL = PtGetAgeSDL()
                     rain = self.ageSDL[raining.value][0]
                     if (rain):
@@ -281,14 +281,14 @@ class GardenBugs(ptResponder):
         try:
             local = PtGetLocalAvatar()
         except:
-            print"gardenBugs.BeginAgeUnLoad()-->\tfailed to get local avatar"
+            print("gardenBugs.BeginAgeUnLoad()-->\tfailed to get local avatar")
             return
         if (local == avObj):
-            print "gardenBugs.BeginAgeUnLoad()-->\tavatar page out"
+            print("gardenBugs.BeginAgeUnLoad()-->\tavatar page out")
             
             # update with the number currently on the avatar and save it to the chronicle
             self.bugCount = PtGetNumParticles(local.getKey())
-            print "gardenBugs.BeginAgeUnLoad()-->\tparticles at age unload ",self.bugCount
+            print("gardenBugs.BeginAgeUnLoad()-->\tparticles at age unload ",self.bugCount)
             self.ISaveBugCount(self.bugCount)
             
             # help ensure all bugs are dead
@@ -308,7 +308,7 @@ class GardenBugs(ptResponder):
             if (behavior == PtBehaviorTypes.kBehaviorTypeRun):
                 running = False
                 if PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving():
-                    print "gardenBugs.OnBehaviorNotify()-->\tWARN: Running behavior turned off, but avatar still reports run and movement keys are held down"
+                    print("gardenBugs.OnBehaviorNotify()-->\tWARN: Running behavior turned off, but avatar still reports run and movement keys are held down")
             return
         else:
             currentBehavior = behavior
@@ -339,7 +339,7 @@ class GardenBugs(ptResponder):
                     return
                     
             if (behavior == PtBehaviorTypes.kBehaviorTypeRunningImpact or behavior == PtBehaviorTypes.kBehaviorTypeRunningJump):
-                print "gardenBugs.BehaviorNotify()-->\tkill all bugs"
+                print("gardenBugs.BehaviorNotify()-->\tkill all bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,1,avatar.getKey())
                 PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
@@ -349,7 +349,7 @@ class GardenBugs(ptResponder):
 
             if (running or (PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving())):
                 #kill some of them and set a timer
-                print "gardenBugs.BehaviorNotify()-->\tstarted running, kill some bugs"
+                print("gardenBugs.BehaviorNotify()-->\tstarted running, kill some bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,0.1,avatar.getKey())
                 PtAtTimeCallback(self.key, 0.4, PtBehaviorTypes.kBehaviorTypeRun)

--- a/Python/GardenBugs.py
+++ b/Python/GardenBugs.py
@@ -105,23 +105,23 @@ class GardenBugs(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print("GardenBugs.OnFirstUpdate():\tfailed to get local avatar")
+            PtDebugPrint("GardenBugs.OnFirstUpdate():\tfailed to get local avatar")
             return
         
         avatar.avatar.registerForBehaviorNotify(self.key)
         
         self.bugCount = self.IGetBugCount()
-        print("GardenBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount)
+        PtDebugPrint("GardenBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount)
         
         # first, kill all bugs on the avatar that might have been brought over
         PtKillParticles(0,1,avatar.getKey())
         
         if (self.bugCount > 0):
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, True)
-            print("GardenBugs.OnFirstUpdate():\tTurning lights on at start")
+            PtDebugPrint("GardenBugs.OnFirstUpdate():\tTurning lights on at start")
         else:
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print("GardenBugs.OnFirstUpdate():\tTurning lights off at start")
+            PtDebugPrint("GardenBugs.OnFirstUpdate():\tTurning lights off at start")
         
         # this will add the bugs back that we have
         PtAtTimeCallback(self.key,0.1,kAddBugs)
@@ -151,11 +151,11 @@ class GardenBugs(ptResponder):
                 # kill some particles
                 particlesToKill = -particlesToTransfer
                 percentToKill = float(particlesToKill) / float(self.bugCount)
-                print("GardenBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)")
+                PtDebugPrint("GardenBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)")
                 PtKillParticles(0,percentToKill,avatar.getKey())
             elif (particlesToTransfer != 0):
                 # add some particles
-                print("GardenBugs.OnTimer() - Particles to add: " + str(particlesToTransfer))
+                PtDebugPrint("GardenBugs.OnTimer() - Particles to add: " + str(particlesToTransfer))
                 PtTransferParticlesToObject(bugEmitter.value.getKey(),avatar.getKey(),particlesToTransfer)
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             return
@@ -164,9 +164,9 @@ class GardenBugs(ptResponder):
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL[raining.value] = (1,)
             PtSetParticleOffset(0,0,100,bugEmitter.value.getKey())
-            print("GardenBugs.OnTimer():\tIt's rain, bug cloud gone")
+            PtDebugPrint("GardenBugs.OnTimer():\tIt's rain, bug cloud gone")
             if (localInTunnel or self.bugCount == 0):
-                print("GardenBugs.OnTimer():\tIn tunnel, bugs safe for now or no local bugs")
+                PtDebugPrint("GardenBugs.OnTimer():\tIn tunnel, bugs safe for now or no local bugs")
                 return
             PtSetParticleDissentPoint(0,0,100,avatar.getKey())
             PtKillParticles(3.0,1,avatar.getKey())
@@ -183,7 +183,7 @@ class GardenBugs(ptResponder):
                 
             if (id == PtBehaviorTypes.kBehaviorTypeRun):
                 if (running or (PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving())):
-                    print("GardenBugs.OnTimer():\tRunning, kill more bugs")
+                    PtDebugPrint("GardenBugs.OnTimer():\tRunning, kill more bugs")
                     PtKillParticles(3.0,0.1,avatar.getKey())
                     PtAtTimeCallback(self.key, 0.4, PtBehaviorTypes.kBehaviorTypeRun)
                     self.bugCount = self.bugCount * 0.1
@@ -203,45 +203,45 @@ class GardenBugs(ptResponder):
         triggerer = PtFindAvatar(events)
         avatar = PtGetLocalAvatar()
         if (avatar != triggerer):
-            print("GardenBugs.OnNotify():\tWrong avatar, notifies run locally")
+            PtDebugPrint("GardenBugs.OnNotify():\tWrong avatar, notifies run locally")
             return
 
         self.bugCount = PtGetNumParticles(avatar.getKey())
 
         if (id == bugRgn.id):
-            print("GardenBugs.OnNotify():\tEntered bug cloud region")
+            PtDebugPrint("GardenBugs.OnNotify():\tEntered bug cloud region")
 
             if (self.bugCount > 19):
                 return
             self.ageSDL = PtGetAgeSDL()
             rain = self.ageSDL[raining.value][0]
             if (rain):
-                print("gardenBugs.OnNotify()-->\tnope, it's raining")
+                PtDebugPrint("gardenBugs.OnNotify()-->\tnope, it's raining")
                 return
             if running:
-                print("gardenBugs.OnNotify()-->\tcan't add bugs as we're still running")
+                PtDebugPrint("gardenBugs.OnNotify()-->\tcan't add bugs as we're still running")
                 return
             if PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving():
-                print("gardenBugs.OnNotify()-->\tcan't add bugs as we're still running (but our running flag is False?)")
+                PtDebugPrint("gardenBugs.OnNotify()-->\tcan't add bugs as we're still running (but our running flag is False?)")
                 return
 
-            print("gardenBugs.OnNotify()-->\ttansferring Bugs!")
+            PtDebugPrint("gardenBugs.OnNotify()-->\ttansferring Bugs!")
             avatar = PtFindAvatar(events)
             PtTransferParticlesToObject(bugEmitter.value.getKey(),avatar.getKey(),10)
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
-            print("gardenBugs.OnNotify()-->\tset bugs at 10")
+            PtDebugPrint("gardenBugs.OnNotify()-->\tset bugs at 10")
             PtAtTimeCallback(self.key,0.1,kCheckForBugs)
             numJumps = 0
             self.bugCount = self.bugCount + 10
             self.ISaveBugCount(self.bugCount)
         
         if (id == rainStart.id):
-            print("gardenBugs.OnNotify()-->\tstart rain timer")
+            PtDebugPrint("gardenBugs.OnNotify()-->\tstart rain timer")
             PtAtTimeCallback(self.key, 30.0, kRainStarting)
             return            
 
         if (id == rainEnd.id):
-            print("gardenBugs.OnNotify()-->\train stopping")
+            PtDebugPrint("gardenBugs.OnNotify()-->\train stopping")
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL[raining.value] = (0,)
             PtSetParticleOffset(0,0,4,bugEmitter.value.getKey())
@@ -250,7 +250,7 @@ class GardenBugs(ptResponder):
             PtSetParticleDissentPoint(0,0,100,avatar.getKey())
             PtKillParticles(3.0,1,avatar.getKey())
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print("gardenBugs.OnNotify()-->\tbharo cave too scary for bugs!")
+            PtDebugPrint("gardenBugs.OnNotify()-->\tbharo cave too scary for bugs!")
             self.bugCount = 0
             self.ISaveBugCount(self.bugCount)
             import xSndLogTracks
@@ -261,11 +261,11 @@ class GardenBugs(ptResponder):
             for event in events:
                 if event[0]==1 and event[1]==1:
                     localInTunnel = True
-                    print("gardenBugs.OnNotify()-->\tlocal in tunnel")
+                    PtDebugPrint("gardenBugs.OnNotify()-->\tlocal in tunnel")
                     return
                 elif event[0]==1 and event[1]==0:
                     localInTunnel = False
-                    print("gardenBugs.OnNotify()-->\tlocal exit tunnel")
+                    PtDebugPrint("gardenBugs.OnNotify()-->\tlocal exit tunnel")
                     self.ageSDL = PtGetAgeSDL()
                     rain = self.ageSDL[raining.value][0]
                     if (rain):
@@ -281,14 +281,14 @@ class GardenBugs(ptResponder):
         try:
             local = PtGetLocalAvatar()
         except:
-            print("gardenBugs.BeginAgeUnLoad()-->\tfailed to get local avatar")
+            PtDebugPrint("gardenBugs.BeginAgeUnLoad()-->\tfailed to get local avatar")
             return
         if (local == avObj):
-            print("gardenBugs.BeginAgeUnLoad()-->\tavatar page out")
+            PtDebugPrint("gardenBugs.BeginAgeUnLoad()-->\tavatar page out")
             
             # update with the number currently on the avatar and save it to the chronicle
             self.bugCount = PtGetNumParticles(local.getKey())
-            print("gardenBugs.BeginAgeUnLoad()-->\tparticles at age unload ",self.bugCount)
+            PtDebugPrint("gardenBugs.BeginAgeUnLoad()-->\tparticles at age unload ",self.bugCount)
             self.ISaveBugCount(self.bugCount)
             
             # help ensure all bugs are dead
@@ -308,7 +308,7 @@ class GardenBugs(ptResponder):
             if (behavior == PtBehaviorTypes.kBehaviorTypeRun):
                 running = False
                 if PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving():
-                    print("gardenBugs.OnBehaviorNotify()-->\tWARN: Running behavior turned off, but avatar still reports run and movement keys are held down")
+                    PtDebugPrint("gardenBugs.OnBehaviorNotify()-->\tWARN: Running behavior turned off, but avatar still reports run and movement keys are held down")
             return
         else:
             currentBehavior = behavior
@@ -339,7 +339,7 @@ class GardenBugs(ptResponder):
                     return
                     
             if (behavior == PtBehaviorTypes.kBehaviorTypeRunningImpact or behavior == PtBehaviorTypes.kBehaviorTypeRunningJump):
-                print("gardenBugs.BehaviorNotify()-->\tkill all bugs")
+                PtDebugPrint("gardenBugs.BehaviorNotify()-->\tkill all bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,1,avatar.getKey())
                 PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
@@ -349,7 +349,7 @@ class GardenBugs(ptResponder):
 
             if (running or (PtLocalAvatarRunKeyDown() and PtLocalAvatarIsMoving())):
                 #kill some of them and set a timer
-                print("gardenBugs.BehaviorNotify()-->\tstarted running, kill some bugs")
+                PtDebugPrint("gardenBugs.BehaviorNotify()-->\tstarted running, kill some bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,0.1,avatar.getKey())
                 PtAtTimeCallback(self.key, 0.4, PtBehaviorTypes.kBehaviorTypeRun)

--- a/Python/Garrison.py
+++ b/Python/Garrison.py
@@ -68,7 +68,7 @@ class Garrison(ptResponder):
 
         thisComponent = self.key.getName()
         if thisComponent != "VeryVerySpecialPythonFileMod":
-            print "Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script"
+            print("Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script")
             return
 
         parentname = None
@@ -84,16 +84,16 @@ class Garrison(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            print "Garrison.OnFirstUpdate(): this Garrison is the public instance, as its parent = ",parentname
+            print("Garrison.OnFirstUpdate(): this Garrison is the public instance, as its parent = ",parentname)
         else:
-            print "Garrison.OnFirstUpdate(): this Garrison is the regular aka Yeesha version, as its parent = ",parentname
+            print("Garrison.OnFirstUpdate(): this Garrison is the regular aka Yeesha version, as its parent = ",parentname)
 
 
     
     def OnServerInitComplete(self):
         thisComponent = self.key.getName()
         if thisComponent != "VeryVerySpecialPythonFileMod":
-            print "Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script"
+            print("Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script")
             return
 
         global boolWellBlocker

--- a/Python/Garrison.py
+++ b/Python/Garrison.py
@@ -68,7 +68,7 @@ class Garrison(ptResponder):
 
         thisComponent = self.key.getName()
         if thisComponent != "VeryVerySpecialPythonFileMod":
-            print("Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script")
+            PtDebugPrint("Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script")
             return
 
         parentname = None
@@ -84,16 +84,16 @@ class Garrison(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            print("Garrison.OnFirstUpdate(): this Garrison is the public instance, as its parent = ",parentname)
+            PtDebugPrint("Garrison.OnFirstUpdate(): this Garrison is the public instance, as its parent = ",parentname)
         else:
-            print("Garrison.OnFirstUpdate(): this Garrison is the regular aka Yeesha version, as its parent = ",parentname)
+            PtDebugPrint("Garrison.OnFirstUpdate(): this Garrison is the regular aka Yeesha version, as its parent = ",parentname)
 
 
     
     def OnServerInitComplete(self):
         thisComponent = self.key.getName()
         if thisComponent != "VeryVerySpecialPythonFileMod":
-            print("Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script")
+            PtDebugPrint("Garrison.OnFirstUpdate(): this isn't the right script instance, ignoring rest of script")
             return
 
         global boolWellBlocker

--- a/Python/GiraBugs.py
+++ b/Python/GiraBugs.py
@@ -108,22 +108,22 @@ class GiraBugs(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print("GiraBugs.OnFirstUpdate():\tfailed to get local avatar")
+            PtDebugPrint("GiraBugs.OnFirstUpdate():\tfailed to get local avatar")
             return
         avatar.avatar.registerForBehaviorNotify(self.key)
         
         self.bugCount = self.IGetBugCount()
-        print("GiraBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount)
+        PtDebugPrint("GiraBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount)
         
         # first, kill all bugs on the avatar that might have been brought over
         PtKillParticles(0,1,avatar.getKey())
         
         if (self.bugCount > 0):
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, True)
-            print("GiraBugs.OnFirstUpdate():\tlights on at start")
+            PtDebugPrint("GiraBugs.OnFirstUpdate():\tlights on at start")
         else:
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print("GiraBugs.OnFirstUpdate():\tlights off at start")
+            PtDebugPrint("GiraBugs.OnFirstUpdate():\tlights off at start")
         
         # this will add the bugs back that we have
         PtAtTimeCallback(self.key,0.1,kAddBugs)
@@ -132,15 +132,15 @@ class GiraBugs(ptResponder):
         try:
             local = PtGetLocalAvatar()
         except:
-            print("ERROR: GiraBugs.BeginAgeUnload()-->\tFailed to get local avatar!")
+            PtDebugPrint("ERROR: GiraBugs.BeginAgeUnload()-->\tFailed to get local avatar!")
             return
         if (local == avObj):
-            print("GiraBugs.BeginAgeUnload():\tavatar page out")
+            PtDebugPrint("GiraBugs.BeginAgeUnload():\tavatar page out")
             local.avatar.unRegisterForBehaviorNotify(self.key)
             
             # update with the number currently on the avatar and save it to the chronicle
             self.bugCount = PtGetNumParticles(local.getKey())
-            print("GiraBugs.BeginAgeUnload():\tparticles at age unload ",self.bugCount)
+            PtDebugPrint("GiraBugs.BeginAgeUnload():\tparticles at age unload ",self.bugCount)
             self.ISaveBugCount(self.bugCount)
             
             # help ensure all bugs are dead
@@ -167,11 +167,11 @@ class GiraBugs(ptResponder):
                 # kill some particles
                 particlesToKill = -particlesToTransfer
                 percentToKill = float(particlesToKill) / float(self.bugCount)
-                print("GiraBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)")
+                PtDebugPrint("GiraBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)")
                 PtKillParticles(0,percentToKill,avatar.getKey())
             elif (particlesToTransfer != 0):
                 # add some particles
-                print("GiraBugs.OnTimer() - Particles to add: " + str(particlesToTransfer))
+                PtDebugPrint("GiraBugs.OnTimer() - Particles to add: " + str(particlesToTransfer))
                 PtTransferParticlesToObject(particleSystem.value.getKey(),avatar.getKey(),particlesToTransfer)
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             return
@@ -201,10 +201,10 @@ class GiraBugs(ptResponder):
             id == fumerol07.id or id == fumerol08.id or id == fumerol09.id or \
             id == fumerol10.id or id == fumerol11.id or id == fumerol12.id or \
             id == fumerol13.id or id == fumerol14.id or id == fumerol15.id):
-            print("GiraBugs.OnNotify():\tsplashdown! ",id)
+            PtDebugPrint("GiraBugs.OnNotify():\tsplashdown! ",id)
             if (self.bugCount):
                 self.bugCount = 0
-                print("GiraBugs.OnNotify():\tkill all bugs")
+                PtDebugPrint("GiraBugs.OnNotify():\tkill all bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,1,avatar.getKey())
                 PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
@@ -252,7 +252,7 @@ class GiraBugs(ptResponder):
                     return
                     
             if ( behavior == PtBehaviorTypes.kBehaviorTypeRunningJump):
-                print("GiraBugs.OnBehaviorNotify():\tkill all bugs")
+                PtDebugPrint("GiraBugs.OnBehaviorNotify():\tkill all bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,1,avatar.getKey())
                 PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
@@ -262,7 +262,7 @@ class GiraBugs(ptResponder):
 
             if (behavior == PtBehaviorTypes.kBehaviorTypeRun):
                 #kill some of them and set a timer
-                print("GiraBugs.OnBehaviorNotify():\tstarted running, kill some bugs")
+                PtDebugPrint("GiraBugs.OnBehaviorNotify():\tstarted running, kill some bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,0.1,avatar.getKey())
                 PtAtTimeCallback(self.key, 0.25, PtBehaviorTypes.kBehaviorTypeRun)

--- a/Python/GiraBugs.py
+++ b/Python/GiraBugs.py
@@ -108,22 +108,22 @@ class GiraBugs(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print "GiraBugs.OnFirstUpdate():\tfailed to get local avatar"
+            print("GiraBugs.OnFirstUpdate():\tfailed to get local avatar")
             return
         avatar.avatar.registerForBehaviorNotify(self.key)
         
         self.bugCount = self.IGetBugCount()
-        print "GiraBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount
+        print("GiraBugs.OnFirstUpdate():\tStarting with %d bugs" % self.bugCount)
         
         # first, kill all bugs on the avatar that might have been brought over
         PtKillParticles(0,1,avatar.getKey())
         
         if (self.bugCount > 0):
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, True)
-            print "GiraBugs.OnFirstUpdate():\tlights on at start"
+            print("GiraBugs.OnFirstUpdate():\tlights on at start")
         else:
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print "GiraBugs.OnFirstUpdate():\tlights off at start"
+            print("GiraBugs.OnFirstUpdate():\tlights off at start")
         
         # this will add the bugs back that we have
         PtAtTimeCallback(self.key,0.1,kAddBugs)
@@ -132,15 +132,15 @@ class GiraBugs(ptResponder):
         try:
             local = PtGetLocalAvatar()
         except:
-            print "ERROR: GiraBugs.BeginAgeUnload()-->\tFailed to get local avatar!"
+            print("ERROR: GiraBugs.BeginAgeUnload()-->\tFailed to get local avatar!")
             return
         if (local == avObj):
-            print "GiraBugs.BeginAgeUnload():\tavatar page out"
+            print("GiraBugs.BeginAgeUnload():\tavatar page out")
             local.avatar.unRegisterForBehaviorNotify(self.key)
             
             # update with the number currently on the avatar and save it to the chronicle
             self.bugCount = PtGetNumParticles(local.getKey())
-            print "GiraBugs.BeginAgeUnload():\tparticles at age unload ",self.bugCount
+            print("GiraBugs.BeginAgeUnload():\tparticles at age unload ",self.bugCount)
             self.ISaveBugCount(self.bugCount)
             
             # help ensure all bugs are dead
@@ -167,11 +167,11 @@ class GiraBugs(ptResponder):
                 # kill some particles
                 particlesToKill = -particlesToTransfer
                 percentToKill = float(particlesToKill) / float(self.bugCount)
-                print "GiraBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)"
+                print("GiraBugs.OnTimer() - Particles to kill: " + str(particlesToKill) + " (" + str(percentToKill * 100) + "%)")
                 PtKillParticles(0,percentToKill,avatar.getKey())
             elif (particlesToTransfer != 0):
                 # add some particles
-                print "GiraBugs.OnTimer() - Particles to add: " + str(particlesToTransfer)
+                print("GiraBugs.OnTimer() - Particles to add: " + str(particlesToTransfer))
                 PtTransferParticlesToObject(particleSystem.value.getKey(),avatar.getKey(),particlesToTransfer)
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             return
@@ -201,10 +201,10 @@ class GiraBugs(ptResponder):
             id == fumerol07.id or id == fumerol08.id or id == fumerol09.id or \
             id == fumerol10.id or id == fumerol11.id or id == fumerol12.id or \
             id == fumerol13.id or id == fumerol14.id or id == fumerol15.id):
-            print "GiraBugs.OnNotify():\tsplashdown! ",id
+            print("GiraBugs.OnNotify():\tsplashdown! ",id)
             if (self.bugCount):
                 self.bugCount = 0
-                print "GiraBugs.OnNotify():\tkill all bugs"
+                print("GiraBugs.OnNotify():\tkill all bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,1,avatar.getKey())
                 PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
@@ -252,7 +252,7 @@ class GiraBugs(ptResponder):
                     return
                     
             if ( behavior == PtBehaviorTypes.kBehaviorTypeRunningJump):
-                print "GiraBugs.OnBehaviorNotify():\tkill all bugs"
+                print("GiraBugs.OnBehaviorNotify():\tkill all bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,1,avatar.getKey())
                 PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
@@ -262,7 +262,7 @@ class GiraBugs(ptResponder):
 
             if (behavior == PtBehaviorTypes.kBehaviorTypeRun):
                 #kill some of them and set a timer
-                print "GiraBugs.OnBehaviorNotify():\tstarted running, kill some bugs"
+                print("GiraBugs.OnBehaviorNotify():\tstarted running, kill some bugs")
                 PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
                 PtKillParticles(3.0,0.1,avatar.getKey())
                 PtAtTimeCallback(self.key, 0.25, PtBehaviorTypes.kBehaviorTypeRun)

--- a/Python/GiraDoor.py
+++ b/Python/GiraDoor.py
@@ -82,10 +82,10 @@ class GiraDoor(ptResponder):
             doorOpen = True
         
         if (doorOpen):
-            print("gira door open")
+            PtDebugPrint("gira door open")
             doorOpenInitResp.run(self.key,avatar = PtGetLocalAvatar())
         else:
-            print("gira door closed")
+            PtDebugPrint("gira door closed")
             
     #def OnSDLNotify(self,VARname,SDLname,playerID,tag):
     def OnNotify(self, state, id, events):

--- a/Python/GiraDoor.py
+++ b/Python/GiraDoor.py
@@ -82,10 +82,10 @@ class GiraDoor(ptResponder):
             doorOpen = True
         
         if (doorOpen):
-            print"gira door open"
+            print("gira door open")
             doorOpenInitResp.run(self.key,avatar = PtGetLocalAvatar())
         else:
-            print"gira door closed"
+            print("gira door closed")
             
     #def OnSDLNotify(self,VARname,SDLname,playerID,tag):
     def OnNotify(self, state, id, events):

--- a/Python/GiraSteam.py
+++ b/Python/GiraSteam.py
@@ -180,12 +180,12 @@ class GiraSteam(ptResponder):
         
         for x in range(6):
             var = "giraSteamvent0" + str(x + 1) + "Open"
-            print("GiraSteam.OnServerInitComplete():\tsetting up for SDL var: ",var)
+            PtDebugPrint("GiraSteam.OnServerInitComplete():\tsetting up for SDL var: ",var)
             ageSDL.setFlags(var, 1, 1)
             ageSDL.sendToClients(var)
         
         open = ageSDL["giraSteamvent01Open"][0]
-        print("GiraSteam.OnServerInitComplete():\tfumerol 1 open = ",open)
+        PtDebugPrint("GiraSteam.OnServerInitComplete():\tfumerol 1 open = ",open)
         if (open):
             fumerol1Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol1BlastResp, avatar)
@@ -194,7 +194,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol1Resp, avatar)
         
         open = ageSDL["giraSteamvent02Open"][0]
-        print("GiraSteam.OnServerInitComplete():\tfumerol 2 open = ",open)
+        PtDebugPrint("GiraSteam.OnServerInitComplete():\tfumerol 2 open = ",open)
         if (open):
             fumerol2Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol2BlastResp, avatar)
@@ -203,7 +203,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol2Resp, avatar)
         
         open = ageSDL["giraSteamvent03Open"][0]
-        print("GiraSteam.OnServerInitComplete():\tfumerol 3 open = ",open)
+        PtDebugPrint("GiraSteam.OnServerInitComplete():\tfumerol 3 open = ",open)
         if (open):
             fumerol3Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol3BlastResp, avatar)
@@ -212,7 +212,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol3Resp, avatar)
         
         open = ageSDL["giraSteamvent04Open"][0]
-        print("GiraSteam.OnServerInitComplete():\tfumerol 4 open = ",open)
+        PtDebugPrint("GiraSteam.OnServerInitComplete():\tfumerol 4 open = ",open)
         if (open):
             fumerol4Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol4BlastResp, avatar)
@@ -221,7 +221,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol4Resp, avatar)
         
         open = ageSDL["giraSteamvent05Open"][0]
-        print("GiraSteam.OnServerInitComplete():\tfumerol 5 open = ",open)
+        PtDebugPrint("GiraSteam.OnServerInitComplete():\tfumerol 5 open = ",open)
         if (open):
             fumerol5Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol5BlastResp, avatar)
@@ -230,7 +230,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol5Resp, avatar)
         
         open = ageSDL["giraSteamvent06Open"][0]
-        print("GiraSteam.OnServerInitComplete():\tfumerol 6 open = ",open)
+        PtDebugPrint("GiraSteam.OnServerInitComplete():\tfumerol 6 open = ",open)
         if (open):
             fumerol6Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol6BlastResp, avatar)
@@ -241,21 +241,21 @@ class GiraSteam(ptResponder):
         
     def SetRumble(self,resp, theavatar):
         numClosed = self.GetNumClosed()
-        print("GiraSteam.SetRumble():\tnumClosed = ",numClosed)
-        print("GiraSteam.SetRumble():\tresponder = ",resp.id)
+        PtDebugPrint("GiraSteam.SetRumble():\tnumClosed = ",numClosed)
+        PtDebugPrint("GiraSteam.SetRumble():\tresponder = ",resp.id)
         if (numClosed == 1):
             resp.run(self.key,state='MuffledBlastOnly',avatar=theavatar)
         elif (numClosed == 2):
-            ##print"running rumble 1"
+            ##PtDebugPrint("running rumble 1")
             resp.run(self.key,state='Rumble1',avatar=theavatar)
         elif(numClosed == 3):
-            ##print"running rumble 2"
+            ##PtDebugPrint("running rumble 2")
             resp.run(self.key,state='Rumble2',avatar=theavatar)
         elif(numClosed == 4):
-            ##print"running rumble 3"
+            ##PtDebugPrint("running rumble 3")
             resp.run(self.key,state='Rumble3',avatar=theavatar)
         elif(numClosed == 5):
-            ##print"running rumble 4"
+            ##PtDebugPrint("running rumble 4")
             resp.run(self.key,state='Rumble4',avatar=theavatar)
         if (resp.id == fumerol1Resp.id):
             fumerol1BlastResp.run(self.key,state='Smoke',avatar=theavatar)
@@ -279,26 +279,26 @@ class GiraSteam(ptResponder):
         
     def SetSteam(self,resp, theavatar):
         numClosed = self.GetNumClosed()
-        print("GiraSteam.SetSteam():\tnumClosed = ",numClosed)
-        print("GiraSteam.SetSteam():\tresponder = ",resp.id)
+        PtDebugPrint("GiraSteam.SetSteam():\tnumClosed = ",numClosed)
+        PtDebugPrint("GiraSteam.SetSteam():\tresponder = ",resp.id)
 
         if (numClosed == 0):
-            ##print"running steam blast 2"
+            ##PtDebugPrint("running steam blast 2")
             resp.run(self.key,state='Blast1',avatar=theavatar)
         elif (numClosed == 1):
-            ##print"running steam blast 3"
+            ##PtDebugPrint("running steam blast 3")
             resp.run(self.key,state='Blast2',avatar=theavatar)
         elif (numClosed == 2):
-            ##print"running steam blast 4"
+            ##PtDebugPrint("running steam blast 4")
             resp.run(self.key,state='Blast3',avatar=theavatar)
         elif (numClosed == 3):
-            ##print"running steam blast 5"
+            ##PtDebugPrint("running steam blast 5")
             resp.run(self.key,state='Blast4',avatar=theavatar)
         elif (numClosed == 4):
-            ##print"running steam blast 6"
+            ##PtDebugPrint("running steam blast 6")
             resp.run(self.key,state='Blast5',avatar=theavatar)
         elif (numClosed == 5):
-            ##print"running steam blast 6"
+            ##PtDebugPrint("running steam blast 6")
             resp.run(self.key,state='Blast6',avatar=theavatar)
         
         if (resp.id == fumerol1Resp.id):
@@ -317,46 +317,46 @@ class GiraSteam(ptResponder):
     
     def JumpAvatar(self,resp, theavatar):
         numClosed=self.GetNumClosed()
-        print("GiraSteam.JumpAvatar():\tnumClosed = ",numClosed)
-        print("GiraSteam.JumpAvatar():\tresponder = ",resp.id)
+        PtDebugPrint("GiraSteam.JumpAvatar():\tnumClosed = ",numClosed)
+        PtDebugPrint("GiraSteam.JumpAvatar():\tresponder = ",resp.id)
         if (numClosed == 0):
-            ##print"blast level 2"
+            ##PtDebugPrint("blast level 2")
             resp.run(self.key,state='Level1',avatar=theavatar)
         if (numClosed == 1):
-            ##print"blast level 3"
+            ##PtDebugPrint("blast level 3")
             resp.run(self.key,state='Level2',avatar=theavatar)
         if (numClosed == 2):
-            ##print"blast level 4"
+            ##PtDebugPrint("blast level 4")
             resp.run(self.key,state='Level3',avatar=theavatar)
         if (numClosed == 3):
-            ##print"blast level 5"
+            ##PtDebugPrint("blast level 5")
             resp.run(self.key,state='Level4',avatar=theavatar)
         if (numClosed == 4):
-            ##print"blast level 6"
+            ##PtDebugPrint("blast level 6")
             resp.run(self.key,state='Level5',avatar=theavatar)
         if (numClosed == 5):
-            ##print"blast level 6"
+            ##PtDebugPrint("blast level 6")
             resp.run(self.key,state='Level6',avatar=theavatar)
     
     def PlayBlastSfx(self,resp, theavatar):
         numClosed = self.GetNumClosed()
         if (numClosed == 0):
-            #print"blast sfx 1"
+            #PtDebugPrint("blast sfx 1")
             resp.run(self.key,state='Blast1',avatar=theavatar)
         if (numClosed == 1):
-            #print"blast sfx 2"
+            #PtDebugPrint("blast sfx 2")
             resp.run(self.key,state='Blast2',avatar=theavatar)
         if (numClosed == 2):
-            #print"blast sfx 3"
+            #PtDebugPrint("blast sfx 3")
             resp.run(self.key,state='Blast3',avatar=theavatar)
         if (numClosed == 3):
-            #print"blast sfx 4"
+            #PtDebugPrint("blast sfx 4")
             resp.run(self.key,state='Blast4',avatar=theavatar)
         if (numClosed == 4):
-            #print"blast sfx 5"
+            #PtDebugPrint("blast sfx 5")
             resp.run(self.key,state='Blast5',avatar=theavatar)
         if (numClosed == 5):
-            #print"blast sfx 6"
+            #PtDebugPrint("blast sfx 6")
             resp.run(self.key,state='Blast6',avatar=theavatar)
 
 
@@ -364,7 +364,7 @@ class GiraSteam(ptResponder):
         pass
         
     def OnTimer(self,id):
-        print("GiraSteam.OnTimer():\tid = ",id)
+        PtDebugPrint("GiraSteam.OnTimer():\tid = ",id)
         global onFumerol1
         global onFumerol2
         global onFumerol3
@@ -374,7 +374,7 @@ class GiraSteam(ptResponder):
 
         if (id == 0):
             #trigger failsafe here
-            ##print"opening all valves"
+            ##PtDebugPrint("opening all valves")
             ageSDL = PtGetAgeSDL()
             open = ageSDL["giraSteamvent01Open"][0]
             if (not open):
@@ -460,11 +460,11 @@ class GiraSteam(ptResponder):
             fumerol5Act.disable()
             fumerol6Act.disable()
             
-        #print"num closed ",numClosed
+        #PtDebugPrint("num closed ",numClosed)
         return numClosed
 
     def OnNotify(self,state,id,events):
-        #print "GiraSteam.OnNotify():\tstate = %d, id = %s" % (state,id)
+        #PtDebugPrint("GiraSteam.OnNotify():\tstate = %d, id = %s" % (state,id))
         global inFumerol1
         global inFumerol2
         global inFumerol3
@@ -484,7 +484,7 @@ class GiraSteam(ptResponder):
         local = PtGetLocalAvatar()
         numClosed = self.GetNumClosed()
         ageSDL = PtGetAgeSDL()
-        ##print"id ",id
+        ##PtDebugPrint("id ",id)
 
         entry = False
         if avatar == local:
@@ -516,9 +516,9 @@ class GiraSteam(ptResponder):
         if (id == fumerol1Resp.id or id == fumerol2Resp.id or \
                id == fumerol3Resp.id or id == fumerol4Resp.id or \
                id == fumerol5Resp.id or id == fumerol6Resp.id):
-                ##print"responder callback"
+                ##PtDebugPrint("responder callback")
                 if (numClosed == 6):
-                    ##print"running release mechanism"
+                    ##PtDebugPrint("running release mechanism")
                     PtAtTimeCallback(self.key,1,0)
                 else:
                     #set rumble / steam for all fumerols
@@ -602,7 +602,7 @@ class GiraSteam(ptResponder):
         elif (id == fumerol5Act.id and state):
             fumerol5Act.disable()
             open = ageSDL["giraSteamvent05Open"][0]
-            print("GiraSteam.OnNotify():\tNotify from fumerol05Act; open = %d" % (open))
+            PtDebugPrint("GiraSteam.OnNotify():\tNotify from fumerol05Act; open = %d" % (open))
             if (open):
                 ageSDL["giraSteamvent05Open"] = (0,)
                 fumerol5Resp.run(self.key,state='Closing',avatar=avatar)
@@ -616,7 +616,7 @@ class GiraSteam(ptResponder):
         elif (id == fumerol6Act.id and state):
             fumerol6Act.disable()
             open = ageSDL["giraSteamvent06Open"][0]
-            print("GiraSteam.OnNotify():\tNotify from fumerol06Act; open = %d" % (open))
+            PtDebugPrint("GiraSteam.OnNotify():\tNotify from fumerol06Act; open = %d" % (open))
             if (open):
                 ageSDL["giraSteamvent06Open"] = (0,)
                 fumerol6Resp.run(self.key,state='Closing',avatar=avatar)
@@ -628,27 +628,27 @@ class GiraSteam(ptResponder):
                 fumerol6Resp.run(self.key,state='Opening',avatar=avatar)
         
         elif (id == fumerol1Det.id):
-            #print "1 entry ",entry
+            #PtDebugPrint("1 entry ",entry)
             inFumerol1 = entry
 
         elif (id == fumerol2Det.id):
-            #print "2 entry ",entry
+            #PtDebugPrint("2 entry ",entry)
             inFumerol2 = entry
         
         elif (id == fumerol3Det.id):
-            #print "3 entry ",entry
+            #PtDebugPrint("3 entry ",entry)
             inFumerol3 = entry
         
         elif (id == fumerol4Det.id):
-            #print "4 entry ",entry
+            #PtDebugPrint("4 entry ",entry)
             inFumerol4 = entry
         
         elif (id == fumerol5Det.id):
-            print("5 entry ",entry)
+            PtDebugPrint("5 entry ",entry)
             inFumerol5 = entry
         
         elif (id == fumerol6Det.id):
-            print("6 entry ",entry)
+            PtDebugPrint("6 entry ",entry)
             inFumerol6 = entry
         
         elif (id == rockJumpBeh.id):
@@ -668,7 +668,7 @@ class GiraSteam(ptResponder):
                     #fumerolJCClickable.enable()
                     PtAtTimeCallback(self.key, 1, 99)
                     fumerol6Det.enable()
-                    #print"enabled jc"
+                    #PtDebugPrint("enabled jc")
                     
         elif ((id == fumerol01SteamTrig01.id or id == fumerol01SteamTrig02.id or\
               id == fumerol01SteamTrig03.id or id == fumerol01SteamTrig04.id or\
@@ -712,7 +712,7 @@ class GiraSteam(ptResponder):
               id == fumerol05SteamTrig05.id or id == fumerol05SteamTrig06.id) and state):
             self.PlayBlastSfx(fumerol05SteamSfx, avatar)
             if id == fumerol05SteamTrig01.id:
-                print("notify from fumerol05SteamTrig01; inFumerol5 = ",inFumerol5)
+                PtDebugPrint("notify from fumerol05SteamTrig01; inFumerol5 = ",inFumerol5)
             if (inFumerol5):
                 #inFumerol5 = False
                 self.JumpAvatar(fumerol05JumpResp, avatar)
@@ -722,7 +722,7 @@ class GiraSteam(ptResponder):
               id == fumerol06SteamTrig05.id or id == fumerol06SteamTrig06.id) and state):
             self.PlayBlastSfx(fumerol06SteamSfx, avatar)
             if id == fumerol06SteamTrig01.id:
-                print("notify from fumerol06SteamTrig01; inFumerol6 = ",inFumerol6)
+                PtDebugPrint("notify from fumerol06SteamTrig01; inFumerol6 = ",inFumerol6)
             if (inFumerol6):
                 #inFumerol6=False
                 if (numClosed < 5):

--- a/Python/GiraSteam.py
+++ b/Python/GiraSteam.py
@@ -180,12 +180,12 @@ class GiraSteam(ptResponder):
         
         for x in range(6):
             var = "giraSteamvent0" + str(x + 1) + "Open"
-            print "GiraSteam.OnServerInitComplete():\tsetting up for SDL var: ",var
+            print("GiraSteam.OnServerInitComplete():\tsetting up for SDL var: ",var)
             ageSDL.setFlags(var, 1, 1)
             ageSDL.sendToClients(var)
         
         open = ageSDL["giraSteamvent01Open"][0]
-        print "GiraSteam.OnServerInitComplete():\tfumerol 1 open = ",open
+        print("GiraSteam.OnServerInitComplete():\tfumerol 1 open = ",open)
         if (open):
             fumerol1Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol1BlastResp, avatar)
@@ -194,7 +194,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol1Resp, avatar)
         
         open = ageSDL["giraSteamvent02Open"][0]
-        print "GiraSteam.OnServerInitComplete():\tfumerol 2 open = ",open
+        print("GiraSteam.OnServerInitComplete():\tfumerol 2 open = ",open)
         if (open):
             fumerol2Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol2BlastResp, avatar)
@@ -203,7 +203,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol2Resp, avatar)
         
         open = ageSDL["giraSteamvent03Open"][0]
-        print "GiraSteam.OnServerInitComplete():\tfumerol 3 open = ",open
+        print("GiraSteam.OnServerInitComplete():\tfumerol 3 open = ",open)
         if (open):
             fumerol3Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol3BlastResp, avatar)
@@ -212,7 +212,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol3Resp, avatar)
         
         open = ageSDL["giraSteamvent04Open"][0]
-        print "GiraSteam.OnServerInitComplete():\tfumerol 4 open = ",open
+        print("GiraSteam.OnServerInitComplete():\tfumerol 4 open = ",open)
         if (open):
             fumerol4Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol4BlastResp, avatar)
@@ -221,7 +221,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol4Resp, avatar)
         
         open = ageSDL["giraSteamvent05Open"][0]
-        print "GiraSteam.OnServerInitComplete():\tfumerol 5 open = ",open
+        print("GiraSteam.OnServerInitComplete():\tfumerol 5 open = ",open)
         if (open):
             fumerol5Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol5BlastResp, avatar)
@@ -230,7 +230,7 @@ class GiraSteam(ptResponder):
             self.SetRumble(fumerol5Resp, avatar)
         
         open = ageSDL["giraSteamvent06Open"][0]
-        print "GiraSteam.OnServerInitComplete():\tfumerol 6 open = ",open
+        print("GiraSteam.OnServerInitComplete():\tfumerol 6 open = ",open)
         if (open):
             fumerol6Resp.run(self.key,state='Opening',avatar=avatar,fastforward=True)
             self.SetSteam(fumerol6BlastResp, avatar)
@@ -241,8 +241,8 @@ class GiraSteam(ptResponder):
         
     def SetRumble(self,resp, theavatar):
         numClosed = self.GetNumClosed()
-        print "GiraSteam.SetRumble():\tnumClosed = ",numClosed
-        print "GiraSteam.SetRumble():\tresponder = ",resp.id
+        print("GiraSteam.SetRumble():\tnumClosed = ",numClosed)
+        print("GiraSteam.SetRumble():\tresponder = ",resp.id)
         if (numClosed == 1):
             resp.run(self.key,state='MuffledBlastOnly',avatar=theavatar)
         elif (numClosed == 2):
@@ -279,8 +279,8 @@ class GiraSteam(ptResponder):
         
     def SetSteam(self,resp, theavatar):
         numClosed = self.GetNumClosed()
-        print "GiraSteam.SetSteam():\tnumClosed = ",numClosed
-        print "GiraSteam.SetSteam():\tresponder = ",resp.id
+        print("GiraSteam.SetSteam():\tnumClosed = ",numClosed)
+        print("GiraSteam.SetSteam():\tresponder = ",resp.id)
 
         if (numClosed == 0):
             ##print"running steam blast 2"
@@ -317,8 +317,8 @@ class GiraSteam(ptResponder):
     
     def JumpAvatar(self,resp, theavatar):
         numClosed=self.GetNumClosed()
-        print "GiraSteam.JumpAvatar():\tnumClosed = ",numClosed
-        print "GiraSteam.JumpAvatar():\tresponder = ",resp.id
+        print("GiraSteam.JumpAvatar():\tnumClosed = ",numClosed)
+        print("GiraSteam.JumpAvatar():\tresponder = ",resp.id)
         if (numClosed == 0):
             ##print"blast level 2"
             resp.run(self.key,state='Level1',avatar=theavatar)
@@ -364,7 +364,7 @@ class GiraSteam(ptResponder):
         pass
         
     def OnTimer(self,id):
-        print "GiraSteam.OnTimer():\tid = ",id
+        print("GiraSteam.OnTimer():\tid = ",id)
         global onFumerol1
         global onFumerol2
         global onFumerol3
@@ -602,7 +602,7 @@ class GiraSteam(ptResponder):
         elif (id == fumerol5Act.id and state):
             fumerol5Act.disable()
             open = ageSDL["giraSteamvent05Open"][0]
-            print "GiraSteam.OnNotify():\tNotify from fumerol05Act; open = %d" % (open)
+            print("GiraSteam.OnNotify():\tNotify from fumerol05Act; open = %d" % (open))
             if (open):
                 ageSDL["giraSteamvent05Open"] = (0,)
                 fumerol5Resp.run(self.key,state='Closing',avatar=avatar)
@@ -616,7 +616,7 @@ class GiraSteam(ptResponder):
         elif (id == fumerol6Act.id and state):
             fumerol6Act.disable()
             open = ageSDL["giraSteamvent06Open"][0]
-            print "GiraSteam.OnNotify():\tNotify from fumerol06Act; open = %d" % (open)
+            print("GiraSteam.OnNotify():\tNotify from fumerol06Act; open = %d" % (open))
             if (open):
                 ageSDL["giraSteamvent06Open"] = (0,)
                 fumerol6Resp.run(self.key,state='Closing',avatar=avatar)
@@ -644,11 +644,11 @@ class GiraSteam(ptResponder):
             inFumerol4 = entry
         
         elif (id == fumerol5Det.id):
-            print "5 entry ",entry
+            print("5 entry ",entry)
             inFumerol5 = entry
         
         elif (id == fumerol6Det.id):
-            print "6 entry ",entry
+            print("6 entry ",entry)
             inFumerol6 = entry
         
         elif (id == rockJumpBeh.id):
@@ -712,7 +712,7 @@ class GiraSteam(ptResponder):
               id == fumerol05SteamTrig05.id or id == fumerol05SteamTrig06.id) and state):
             self.PlayBlastSfx(fumerol05SteamSfx, avatar)
             if id == fumerol05SteamTrig01.id:
-                print "notify from fumerol05SteamTrig01; inFumerol5 = ",inFumerol5
+                print("notify from fumerol05SteamTrig01; inFumerol5 = ",inFumerol5)
             if (inFumerol5):
                 #inFumerol5 = False
                 self.JumpAvatar(fumerol05JumpResp, avatar)
@@ -722,7 +722,7 @@ class GiraSteam(ptResponder):
               id == fumerol06SteamTrig05.id or id == fumerol06SteamTrig06.id) and state):
             self.PlayBlastSfx(fumerol06SteamSfx, avatar)
             if id == fumerol06SteamTrig01.id:
-                print "notify from fumerol06SteamTrig01; inFumerol6 = ",inFumerol6
+                print("notify from fumerol06SteamTrig01; inFumerol6 = ",inFumerol6)
             if (inFumerol6):
                 #inFumerol6=False
                 if (numClosed < 5):

--- a/Python/LiveBahroCaves.py
+++ b/Python/LiveBahroCaves.py
@@ -66,7 +66,7 @@ class LiveBahroCaves(ptResponder):
 
         pages = []
 
-        print "LiveBahroCaves.__init__(): came from: %s" % (ageFrom)
+        print("LiveBahroCaves.__init__(): came from: %s" % (ageFrom))
         if ageFrom in BlueSpiral:
             pages += ["BlueSpiralCave"]
         elif ageFrom in Pods:
@@ -76,10 +76,10 @@ class LiveBahroCaves(ptResponder):
         elif ageFrom in Live6:
         	pages += ["POTScave"]
         else:
-            print "LiveBahroCaves.__init__(): age not recognized, will page in BlueSpiralCave as default"
+            print("LiveBahroCaves.__init__(): age not recognized, will page in BlueSpiralCave as default")
             pages += ["BlueSpiralCave"]
 
-        print "LiveBahroCaves.__init__(): paging in: %s" % (pages)
+        print("LiveBahroCaves.__init__(): paging in: %s" % (pages))
         PtPageInNode(pages)
 
 

--- a/Python/LiveBahroCaves.py
+++ b/Python/LiveBahroCaves.py
@@ -66,7 +66,7 @@ class LiveBahroCaves(ptResponder):
 
         pages = []
 
-        print("LiveBahroCaves.__init__(): came from: %s" % (ageFrom))
+        PtDebugPrint("LiveBahroCaves.__init__(): came from: %s" % (ageFrom))
         if ageFrom in BlueSpiral:
             pages += ["BlueSpiralCave"]
         elif ageFrom in Pods:
@@ -76,10 +76,10 @@ class LiveBahroCaves(ptResponder):
         elif ageFrom in Live6:
         	pages += ["POTScave"]
         else:
-            print("LiveBahroCaves.__init__(): age not recognized, will page in BlueSpiralCave as default")
+            PtDebugPrint("LiveBahroCaves.__init__(): age not recognized, will page in BlueSpiralCave as default")
             pages += ["BlueSpiralCave"]
 
-        print("LiveBahroCaves.__init__(): paging in: %s" % (pages))
+        PtDebugPrint("LiveBahroCaves.__init__(): paging in: %s" % (pages))
         PtPageInNode(pages)
 
 

--- a/Python/PelletBahroCave.py
+++ b/Python/PelletBahroCave.py
@@ -129,12 +129,12 @@ class PelletBahroCave(ptResponder):
             chronString = chronString.split(",")
             for sol in chronString:
                 chronSolutions.append(string.atoi(sol))
-            print "found pellet cave solution: ",chronSolutions
-            print "current sdl values for solution = ",sdlSolutions
+            print("found pellet cave solution: ",chronSolutions)
+            print("current sdl values for solution = ",sdlSolutions)
             if self.sceneobject.isLocallyOwned():
                 self.ShowSymbols()
         except:
-            print "ERROR!  Couldn't get the solution information, symbols won't appear"
+            print("ERROR!  Couldn't get the solution information, symbols won't appear")
 
         linkmgr = ptNetLinkingMgr()
         link = linkmgr.getCurrAgeLink()
@@ -149,7 +149,7 @@ class PelletBahroCave(ptResponder):
             try:
                 avatar = PtGetLocalAvatar()
             except:
-                print"failed to get local avatar"
+                print("failed to get local avatar")
                 return
             avatar.avatar.registerForBehaviorNotify(self.key)
         else:
@@ -172,7 +172,7 @@ class PelletBahroCave(ptResponder):
             try:
                 ageSDL = PtGetAgeSDL()
             except:
-                print "PelletBahroCave.OnServerInitComplete():\tERROR---Cannot find the PelletBahroCave Age SDL"
+                print("PelletBahroCave.OnServerInitComplete():\tERROR---Cannot find the PelletBahroCave Age SDL")
                 ageSDL[SDLGotPellet.value] = (0,)
         
             ageSDL.setNotify(self.key,SDLGotPellet.value,0.0)
@@ -191,7 +191,7 @@ class PelletBahroCave(ptResponder):
             id = sdlSolutionNames.index(VARname)
             ageSDL = PtGetAgeSDL()
             sdlSolutions[id] = ageSDL[sdlSolutionNames[id]][0]
-            print "PelletBahroCave.OnSDLNotify(): ",sdlSolutionNames[id]," now = ",sdlSolutions[id]
+            print("PelletBahroCave.OnSDLNotify(): ",sdlSolutionNames[id]," now = ",sdlSolutions[id])
 
 
     def OnBehaviorNotify(self,type,id,state):
@@ -222,7 +222,7 @@ class PelletBahroCave(ptResponder):
             self.IDropUpper(gotPellet)
         
         if (id == RespDropPellet.id and gotPellet):
-            print "PelletBahroCave.OnNotify: RespDropPellet callback, will now play FX"
+            print("PelletBahroCave.OnNotify: RespDropPellet callback, will now play FX")
             pellet = (gotPellet - 300)
             if pellet <= 0:
                 if pellet <= -250:
@@ -277,7 +277,7 @@ class PelletBahroCave(ptResponder):
 
 
     def IDropUpper(self,recipe):       
-        print "in IDropUpper."
+        print("in IDropUpper.")
         RespDropPellet.run(self.key,state="upper")
 
 
@@ -289,7 +289,7 @@ class PelletBahroCave(ptResponder):
             ageInfoChild = ageInfoChildRef.getChild()
             folder = ageInfoChild.upcastToFolderNode()
             if folder and folder.folderGetName() == "AgeData":
-                print "Found age data folder"
+                print("Found age data folder")
                 ageDataChildren = folder.getChildNodeRefList()
                 for ageDataChildRef in ageDataChildren:
                     ageDataChild = ageDataChildRef.getChild()
@@ -311,7 +311,7 @@ class PelletBahroCave(ptResponder):
                 ageSDL[sdlSolutionNames[n]] = (newVal,)
                 sdlSolutions[n] = newVal
             n += 1
-        print "SDL solutions list now = ",sdlSolutions
+        print("SDL solutions list now = ",sdlSolutions)
 
 
     def PlaySymbols(self,state):

--- a/Python/PelletBahroCave.py
+++ b/Python/PelletBahroCave.py
@@ -124,17 +124,17 @@ class PelletBahroCave(ptResponder):
             val = ageSDL[sdl][0]
             sdlSolutions.append(val)
         chronString = self.GetPelletCaveSolution()
-        #print "found pellet cave solution: ",chronString
+        #PtDebugPrint("found pellet cave solution: ",chronString)
         try:
             chronString = chronString.split(",")
             for sol in chronString:
                 chronSolutions.append(string.atoi(sol))
-            print("found pellet cave solution: ",chronSolutions)
-            print("current sdl values for solution = ",sdlSolutions)
+            PtDebugPrint("found pellet cave solution: ",chronSolutions)
+            PtDebugPrint("current sdl values for solution = ",sdlSolutions)
             if self.sceneobject.isLocallyOwned():
                 self.ShowSymbols()
         except:
-            print("ERROR!  Couldn't get the solution information, symbols won't appear")
+            PtDebugPrint("ERROR!  Couldn't get the solution information, symbols won't appear")
 
         linkmgr = ptNetLinkingMgr()
         link = linkmgr.getCurrAgeLink()
@@ -149,7 +149,7 @@ class PelletBahroCave(ptResponder):
             try:
                 avatar = PtGetLocalAvatar()
             except:
-                print("failed to get local avatar")
+                PtDebugPrint("failed to get local avatar")
                 return
             avatar.avatar.registerForBehaviorNotify(self.key)
         else:
@@ -172,7 +172,7 @@ class PelletBahroCave(ptResponder):
             try:
                 ageSDL = PtGetAgeSDL()
             except:
-                print("PelletBahroCave.OnServerInitComplete():\tERROR---Cannot find the PelletBahroCave Age SDL")
+                PtDebugPrint("PelletBahroCave.OnServerInitComplete():\tERROR---Cannot find the PelletBahroCave Age SDL")
                 ageSDL[SDLGotPellet.value] = (0,)
         
             ageSDL.setNotify(self.key,SDLGotPellet.value,0.0)
@@ -191,7 +191,7 @@ class PelletBahroCave(ptResponder):
             id = sdlSolutionNames.index(VARname)
             ageSDL = PtGetAgeSDL()
             sdlSolutions[id] = ageSDL[sdlSolutionNames[id]][0]
-            print("PelletBahroCave.OnSDLNotify(): ",sdlSolutionNames[id]," now = ",sdlSolutions[id])
+            PtDebugPrint("PelletBahroCave.OnSDLNotify(): ",sdlSolutionNames[id]," now = ",sdlSolutions[id])
 
 
     def OnBehaviorNotify(self,type,id,state):
@@ -222,7 +222,7 @@ class PelletBahroCave(ptResponder):
             self.IDropUpper(gotPellet)
         
         if (id == RespDropPellet.id and gotPellet):
-            print("PelletBahroCave.OnNotify: RespDropPellet callback, will now play FX")
+            PtDebugPrint("PelletBahroCave.OnNotify: RespDropPellet callback, will now play FX")
             pellet = (gotPellet - 300)
             if pellet <= 0:
                 if pellet <= -250:
@@ -277,7 +277,7 @@ class PelletBahroCave(ptResponder):
 
 
     def IDropUpper(self,recipe):       
-        print("in IDropUpper.")
+        PtDebugPrint("in IDropUpper.")
         RespDropPellet.run(self.key,state="upper")
 
 
@@ -289,7 +289,7 @@ class PelletBahroCave(ptResponder):
             ageInfoChild = ageInfoChildRef.getChild()
             folder = ageInfoChild.upcastToFolderNode()
             if folder and folder.folderGetName() == "AgeData":
-                print("Found age data folder")
+                PtDebugPrint("Found age data folder")
                 ageDataChildren = folder.getChildNodeRefList()
                 for ageDataChildRef in ageDataChildren:
                     ageDataChild = ageDataChildRef.getChild()
@@ -311,7 +311,7 @@ class PelletBahroCave(ptResponder):
                 ageSDL[sdlSolutionNames[n]] = (newVal,)
                 sdlSolutions[n] = newVal
             n += 1
-        print("SDL solutions list now = ",sdlSolutions)
+        PtDebugPrint("SDL solutions list now = ",sdlSolutions)
 
 
     def PlaySymbols(self,state):

--- a/Python/SpyRoom.py
+++ b/Python/SpyRoom.py
@@ -72,8 +72,8 @@ class SpyRoom(ptResponder):
         # i know this isn't bevin but this is just in case they haven't gone to bevin yet
         entry = vault.findChronicleEntry("sjBevinVisted")
         if not entry:
-            print "spyroom: did not find the chron var"
+            print("spyroom: did not find the chron var")
             vault.addChronicleEntry("sjBevinVisted", 0, str(int( time.time() )) )
         else:
-            print "spyroom: found the chron var"
+            print("spyroom: found the chron var")
 

--- a/Python/SpyRoom.py
+++ b/Python/SpyRoom.py
@@ -72,8 +72,8 @@ class SpyRoom(ptResponder):
         # i know this isn't bevin but this is just in case they haven't gone to bevin yet
         entry = vault.findChronicleEntry("sjBevinVisted")
         if not entry:
-            print("spyroom: did not find the chron var")
+            PtDebugPrint("spyroom: did not find the chron var")
             vault.addChronicleEntry("sjBevinVisted", 0, str(int( time.time() )) )
         else:
-            print("spyroom: found the chron var")
+            PtDebugPrint("spyroom: found the chron var")
 

--- a/Python/ahnyIslandHut.py
+++ b/Python/ahnyIslandHut.py
@@ -98,7 +98,7 @@ class ahnyIslandHut(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "ahnySphere1MaintBtn.OnServerInitComplete():\tERROR---Cannot find the Ahnonay Age SDL"
+            print("ahnySphere1MaintBtn.OnServerInitComplete():\tERROR---Cannot find the Ahnonay Age SDL")
             ageSDL[SDLWaterCurrent.value] = (0,)
             ageSDL[SDLHutDoor.value] = (0,)
 
@@ -116,14 +116,14 @@ class ahnyIslandHut(ptResponder):
 
         if boolCurrent:
             RespCurrentChange.run(self.key,state='on',fastforward=1)
-            print "OnInit, will now enable current"
+            print("OnInit, will now enable current")
             WaterCurrent1.current.enable()
             WaterCurrent2.current.enable()
             WaterCurrent3.current.enable()
             WaterCurrent4.current.enable()
         else:
             RespCurrentChange.run(self.key,state='off',fastforward=1)
-            print "OnInit, will now disable current"
+            print("OnInit, will now disable current")
             WaterCurrent1.current.disable()
             WaterCurrent2.current.disable()
             WaterCurrent3.current.disable()
@@ -198,13 +198,13 @@ class ahnyIslandHut(ptResponder):
 
         elif id == RespCurrentChange.id:
             if boolCurrent:
-                print "will now enable current"
+                print("will now enable current")
                 WaterCurrent1.current.enable()
                 WaterCurrent2.current.enable()
                 WaterCurrent3.current.enable()
                 WaterCurrent4.current.enable()
             else:
-                print "will now disable current"
+                print("will now disable current")
                 WaterCurrent1.current.disable()
                 WaterCurrent2.current.disable()
                 WaterCurrent3.current.disable()

--- a/Python/ahnyIslandHut.py
+++ b/Python/ahnyIslandHut.py
@@ -98,7 +98,7 @@ class ahnyIslandHut(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("ahnySphere1MaintBtn.OnServerInitComplete():\tERROR---Cannot find the Ahnonay Age SDL")
+            PtDebugPrint("ahnySphere1MaintBtn.OnServerInitComplete():\tERROR---Cannot find the Ahnonay Age SDL")
             ageSDL[SDLWaterCurrent.value] = (0,)
             ageSDL[SDLHutDoor.value] = (0,)
 
@@ -116,14 +116,14 @@ class ahnyIslandHut(ptResponder):
 
         if boolCurrent:
             RespCurrentChange.run(self.key,state='on',fastforward=1)
-            print("OnInit, will now enable current")
+            PtDebugPrint("OnInit, will now enable current")
             WaterCurrent1.current.enable()
             WaterCurrent2.current.enable()
             WaterCurrent3.current.enable()
             WaterCurrent4.current.enable()
         else:
             RespCurrentChange.run(self.key,state='off',fastforward=1)
-            print("OnInit, will now disable current")
+            PtDebugPrint("OnInit, will now disable current")
             WaterCurrent1.current.disable()
             WaterCurrent2.current.disable()
             WaterCurrent3.current.disable()
@@ -162,7 +162,7 @@ class ahnyIslandHut(ptResponder):
         global actingAvatarDoor
         ageSDL = PtGetAgeSDL()
         
-        #~ print"anhySphere1MaintBtn::OnNotify id ",id," state ",state
+        #~ PtDebugPrint("anhySphere1MaintBtn::OnNotify id ",id," state ",state)
         #~ if (state == 0):
             #~ return
 
@@ -198,13 +198,13 @@ class ahnyIslandHut(ptResponder):
 
         elif id == RespCurrentChange.id:
             if boolCurrent:
-                print("will now enable current")
+                PtDebugPrint("will now enable current")
                 WaterCurrent1.current.enable()
                 WaterCurrent2.current.enable()
                 WaterCurrent3.current.enable()
                 WaterCurrent4.current.enable()
             else:
-                print("will now disable current")
+                PtDebugPrint("will now disable current")
                 WaterCurrent1.current.disable()
                 WaterCurrent2.current.disable()
                 WaterCurrent3.current.disable()

--- a/Python/ahnyKadishDoor.py
+++ b/Python/ahnyKadishDoor.py
@@ -101,15 +101,15 @@ class ahnyKadishDoor(ptResponder):
         for button in ActButtons.value:
             tempName = button.getName()
             btnList.append(tempName)
-        print "btnList = ",btnList
+        print("btnList = ",btnList)
         for resp in RespButtons.value:
             tempResp = resp.getName()
             respList.append(tempResp)
-        print "respList = ",respList
+        print("respList = ",respList)
         for obj in ObjButtons.value:
             tempObj = obj.getName()
             objList.append(tempObj)
-        print "objList = ",objList
+        print("objList = ",objList)
 
         PtAtTimeCallback(self.key, 0, 1)
 
@@ -120,7 +120,7 @@ class ahnyKadishDoor(ptResponder):
         if VARname == SDLDoor.value:
             boolDoor = ageSDL[SDLDoor.value][0]
             if boolDoor:
-                print "open too"
+                print("open too")
                 RespDoor.run(self.key,state="open")
             else:
                 RespDoor.run(self.key,state="close")
@@ -134,7 +134,7 @@ class ahnyKadishDoor(ptResponder):
         if id == ActConsole.id and state:
             actingAvatar = PtFindAvatar(events)
             if actingAvatar == PtGetLocalAvatar():
-                print"switch to console close up"
+                print("switch to console close up")
                 ActConsole.disableActivator()
                 PtEnableControlKeyEvents(self.key)
                 MltStgSeek.run(actingAvatar)
@@ -158,7 +158,7 @@ class ahnyKadishDoor(ptResponder):
         if id == ActButtons.id and state:
             i = 0
             for btn in ActButtons.value:
-                print "ahnyKadishDoor.OnNotify: disabling 8 button clickables"
+                print("ahnyKadishDoor.OnNotify: disabling 8 button clickables")
                 ActButtons.value[i].disable()
                 i += 1
             for event in events:
@@ -173,7 +173,7 @@ class ahnyKadishDoor(ptResponder):
                         else:
                             i += 1
                     
-                    print "btnNum =",btnNum+1
+                    print("btnNum =",btnNum+1)
                     RespButtons.run(self.key,objectName=respList[btnNum])
         
         if id == RespButtons.id and actingAvatar == PtGetLocalAvatar():
@@ -181,7 +181,7 @@ class ahnyKadishDoor(ptResponder):
 
 
     def ICheckButtons(self):
-        print "ahnyKadishDoor.ICheckButtons"
+        print("ahnyKadishDoor.ICheckButtons")
         global currentList
         
         ageSDL = PtGetAgeSDL()
@@ -191,11 +191,11 @@ class ahnyKadishDoor(ptResponder):
         while len(currentList) > len(solutionList):
             del currentList[0]
         
-        print "solution list: " + str(solutionList)
-        print "current list: " + str(currentList)
+        print("solution list: " + str(solutionList))
+        print("current list: " + str(currentList))
         
         if self.AreListsEquiv(solutionList, currentList):
-            print "Open!"
+            print("Open!")
             self.IExitConsole()
             ageSDL[SDLDoor.value] = (1,)
             #RespDoor.run(self.key,state="open")
@@ -237,7 +237,7 @@ class ahnyKadishDoor(ptResponder):
 
 
     def IExitConsole(self):
-        print "disengage and exit the console"
+        print("disengage and exit the console")
         i = 0
         for btn in ActButtons.value:
             #print "ahnyKadishDoor.IExitConsole: disabling 8 button clickables"
@@ -266,7 +266,7 @@ class ahnyKadishDoor(ptResponder):
             try:
                 ageSDL = PtGetAgeSDL()
             except:
-                print "ahnyKadishDoor.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL"
+                print("ahnyKadishDoor.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL")
                 ageSDL[SDLDoor.value] = (0,)
             boolDoor = ageSDL[SDLDoor.value][0]
             if boolDoor:
@@ -277,12 +277,12 @@ class ahnyKadishDoor(ptResponder):
         elif id == 2:
             i = 0
             for btn in ActButtons.value:
-                print "ahnyKadishDoor.onTimer: reenabling 8 button clickables"
+                print("ahnyKadishDoor.onTimer: reenabling 8 button clickables")
                 ActButtons.value[i].enable()
                 i += 1
         
         elif id == 3:
-            print "ahnyKadishDoor.onTimer: reenabling the console's clickable"
+            print("ahnyKadishDoor.onTimer: reenabling the console's clickable")
             ActConsole.enableActivator()
 
 

--- a/Python/ahnyKadishDoor.py
+++ b/Python/ahnyKadishDoor.py
@@ -101,15 +101,15 @@ class ahnyKadishDoor(ptResponder):
         for button in ActButtons.value:
             tempName = button.getName()
             btnList.append(tempName)
-        print("btnList = ",btnList)
+        PtDebugPrint("btnList = ",btnList)
         for resp in RespButtons.value:
             tempResp = resp.getName()
             respList.append(tempResp)
-        print("respList = ",respList)
+        PtDebugPrint("respList = ",respList)
         for obj in ObjButtons.value:
             tempObj = obj.getName()
             objList.append(tempObj)
-        print("objList = ",objList)
+        PtDebugPrint("objList = ",objList)
 
         PtAtTimeCallback(self.key, 0, 1)
 
@@ -120,7 +120,7 @@ class ahnyKadishDoor(ptResponder):
         if VARname == SDLDoor.value:
             boolDoor = ageSDL[SDLDoor.value][0]
             if boolDoor:
-                print("open too")
+                PtDebugPrint("open too")
                 RespDoor.run(self.key,state="open")
             else:
                 RespDoor.run(self.key,state="close")
@@ -134,7 +134,7 @@ class ahnyKadishDoor(ptResponder):
         if id == ActConsole.id and state:
             actingAvatar = PtFindAvatar(events)
             if actingAvatar == PtGetLocalAvatar():
-                print("switch to console close up")
+                PtDebugPrint("switch to console close up")
                 ActConsole.disableActivator()
                 PtEnableControlKeyEvents(self.key)
                 MltStgSeek.run(actingAvatar)
@@ -158,7 +158,7 @@ class ahnyKadishDoor(ptResponder):
         if id == ActButtons.id and state:
             i = 0
             for btn in ActButtons.value:
-                print("ahnyKadishDoor.OnNotify: disabling 8 button clickables")
+                PtDebugPrint("ahnyKadishDoor.OnNotify: disabling 8 button clickables")
                 ActButtons.value[i].disable()
                 i += 1
             for event in events:
@@ -173,7 +173,7 @@ class ahnyKadishDoor(ptResponder):
                         else:
                             i += 1
                     
-                    print("btnNum =",btnNum+1)
+                    PtDebugPrint("btnNum =",btnNum+1)
                     RespButtons.run(self.key,objectName=respList[btnNum])
         
         if id == RespButtons.id and actingAvatar == PtGetLocalAvatar():
@@ -181,7 +181,7 @@ class ahnyKadishDoor(ptResponder):
 
 
     def ICheckButtons(self):
-        print("ahnyKadishDoor.ICheckButtons")
+        PtDebugPrint("ahnyKadishDoor.ICheckButtons")
         global currentList
         
         ageSDL = PtGetAgeSDL()
@@ -191,11 +191,11 @@ class ahnyKadishDoor(ptResponder):
         while len(currentList) > len(solutionList):
             del currentList[0]
         
-        print("solution list: " + str(solutionList))
-        print("current list: " + str(currentList))
+        PtDebugPrint("solution list: " + str(solutionList))
+        PtDebugPrint("current list: " + str(currentList))
         
         if self.AreListsEquiv(solutionList, currentList):
-            print("Open!")
+            PtDebugPrint("Open!")
             self.IExitConsole()
             ageSDL[SDLDoor.value] = (1,)
             #RespDoor.run(self.key,state="open")
@@ -207,7 +207,7 @@ class ahnyKadishDoor(ptResponder):
             else:
                 i = 0
                 for btn in ActButtons.value:
-                    #print "ahnyKadishDoor.ICheckButtons: reenabling 8 button clickables"
+                    #PtDebugPrint("ahnyKadishDoor.ICheckButtons: reenabling 8 button clickables")
                     ActButtons.value[i].enable()
                     i += 1
 
@@ -237,10 +237,10 @@ class ahnyKadishDoor(ptResponder):
 
 
     def IExitConsole(self):
-        print("disengage and exit the console")
+        PtDebugPrint("disengage and exit the console")
         i = 0
         for btn in ActButtons.value:
-            #print "ahnyKadishDoor.IExitConsole: disabling 8 button clickables"
+            #PtDebugPrint("ahnyKadishDoor.IExitConsole: disabling 8 button clickables")
             ActButtons.value[i].disable()
             i += 1
         #PtFadeLocalAvatar(0)
@@ -266,7 +266,7 @@ class ahnyKadishDoor(ptResponder):
             try:
                 ageSDL = PtGetAgeSDL()
             except:
-                print("ahnyKadishDoor.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL")
+                PtDebugPrint("ahnyKadishDoor.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL")
                 ageSDL[SDLDoor.value] = (0,)
             boolDoor = ageSDL[SDLDoor.value][0]
             if boolDoor:
@@ -277,12 +277,12 @@ class ahnyKadishDoor(ptResponder):
         elif id == 2:
             i = 0
             for btn in ActButtons.value:
-                print("ahnyKadishDoor.onTimer: reenabling 8 button clickables")
+                PtDebugPrint("ahnyKadishDoor.onTimer: reenabling 8 button clickables")
                 ActButtons.value[i].enable()
                 i += 1
         
         elif id == 3:
-            print("ahnyKadishDoor.onTimer: reenabling the console's clickable")
+            PtDebugPrint("ahnyKadishDoor.onTimer: reenabling the console's clickable")
             ActConsole.enableActivator()
 
 

--- a/Python/ahnyKadishHut.py
+++ b/Python/ahnyKadishHut.py
@@ -92,7 +92,7 @@ class ahnyKadishHut(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "ahnyKadishHut.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL"
+            print("ahnyKadishHut.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL")
             ageSDL[SDLWindows.value] = (0,)
             #ageSDL[SDLDniTimer.value] = (0,)
 
@@ -103,10 +103,10 @@ class ahnyKadishHut(ptResponder):
         boolWindows = ageSDL[SDLWindows.value][0]
         
         if boolWindows:
-            print "ahnyKadishHut.OnServerInitComplete(): Windows are open"
+            print("ahnyKadishHut.OnServerInitComplete(): Windows are open")
             RespWindows.run(self.key,state="open",fastforward=1)
         else:
-            print "ahnyKadishHut.OnServerInitComplete(): Windows are closed"
+            print("ahnyKadishHut.OnServerInitComplete(): Windows are closed")
             RespWindows.run(self.key,state="close",fastforward=1)
 
         #ageSDL.setFlags(SDLDniTimer.value,1,1)
@@ -142,10 +142,10 @@ class ahnyKadishHut(ptResponder):
             ageSDL = PtGetAgeSDL()
             boolWindows = ageSDL[SDLWindows.value][0]
             if boolWindows:
-                print "ahnyKadishHut.OnSDLNotify(): Windows will now open"
+                print("ahnyKadishHut.OnSDLNotify(): Windows will now open")
                 RespWindows.run(self.key,state="open")
             else:
-                print "ahnyKadishHut.OnSDLNotify(): Windows will now close"
+                print("ahnyKadishHut.OnSDLNotify(): Windows will now close")
                 RespWindows.run(self.key,state="close")
 
         #if VARname == SDLDniTimer.value:

--- a/Python/ahnyKadishHut.py
+++ b/Python/ahnyKadishHut.py
@@ -92,7 +92,7 @@ class ahnyKadishHut(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("ahnyKadishHut.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL")
+            PtDebugPrint("ahnyKadishHut.OnServerInitComplete():\tERROR---Cannot find AhnySphere04 age SDL")
             ageSDL[SDLWindows.value] = (0,)
             #ageSDL[SDLDniTimer.value] = (0,)
 
@@ -103,10 +103,10 @@ class ahnyKadishHut(ptResponder):
         boolWindows = ageSDL[SDLWindows.value][0]
         
         if boolWindows:
-            print("ahnyKadishHut.OnServerInitComplete(): Windows are open")
+            PtDebugPrint("ahnyKadishHut.OnServerInitComplete(): Windows are open")
             RespWindows.run(self.key,state="open",fastforward=1)
         else:
-            print("ahnyKadishHut.OnServerInitComplete(): Windows are closed")
+            PtDebugPrint("ahnyKadishHut.OnServerInitComplete(): Windows are closed")
             RespWindows.run(self.key,state="close",fastforward=1)
 
         #ageSDL.setFlags(SDLDniTimer.value,1,1)
@@ -115,17 +115,17 @@ class ahnyKadishHut(ptResponder):
         #EndTime =  ageSDL[SDLDniTimer.value][0]
         #InitTime = PtGetDniTime()
         #if InitTime < EndTime:
-        #    print "ahnyKadishHut.OnServerInitComplete(): Timer is on"
+        #    PtDebugPrint("ahnyKadishHut.OnServerInitComplete(): Timer is on")
         #    RespDniTimer.run(self.key,state="on")
         #    dniSecsLeft = (EndTime - InitTime)
         #    dniSecsElapsed = (kTimeWarp - dniSecsLeft)
         #    #realSecsElapsed = (dniSecsElapsed * 1.3928573888441378)
-        #    print "dniSecsElapsed = ",dniSecsElapsed
+        #    PtDebugPrint("dniSecsElapsed = ",dniSecsElapsed)
         #    MatAnimDniTimer.animation.skipToTime(dniSecsElapsed)
         #    MatAnimDniTimer.animation.resume()
         #    PtAtTimeCallback(self.key,1,2)
         #else:
-        #    print "ahnyKadishHut.OnServerInitComplete(): Timer is off"
+        #    PtDebugPrint("ahnyKadishHut.OnServerInitComplete(): Timer is off")
         #    RespDniTimer.run(self.key,state="off")
         #if id == 2:
         #    CurTime = PtGetDniTime()
@@ -142,22 +142,22 @@ class ahnyKadishHut(ptResponder):
             ageSDL = PtGetAgeSDL()
             boolWindows = ageSDL[SDLWindows.value][0]
             if boolWindows:
-                print("ahnyKadishHut.OnSDLNotify(): Windows will now open")
+                PtDebugPrint("ahnyKadishHut.OnSDLNotify(): Windows will now open")
                 RespWindows.run(self.key,state="open")
             else:
-                print("ahnyKadishHut.OnSDLNotify(): Windows will now close")
+                PtDebugPrint("ahnyKadishHut.OnSDLNotify(): Windows will now close")
                 RespWindows.run(self.key,state="close")
 
         #if VARname == SDLDniTimer.value:
         #    EndTime = ageSDL[SDLDniTimer.value][0]
         #    if EndTime:
-        #        print "ahnyKadishHut.OnSDLNotify(): Timer is now on"
+        #        PtDebugPrint("ahnyKadishHut.OnSDLNotify(): Timer is now on")
         #        RespDniTimer.run(self.key,state="on")
         #        MatAnimDniTimer.animation.skipToTime(0)
         #        MatAnimDniTimer.animation.play()
         #        PtAtTimeCallback(self.key,1,2)
         #    else:
-        #        print "ahnyKadishHut.OnSDLNotify(): Timer is now off"
+        #        PtDebugPrint("ahnyKadishHut.OnSDLNotify(): Timer is now off")
         #        RespDniTimer.run(self.key,state="off")
         #        MatAnimDniTimer.animation.stop()
 

--- a/Python/ahnyLinkBookGUIPopup.py
+++ b/Python/ahnyLinkBookGUIPopup.py
@@ -154,11 +154,11 @@ class ahnyLinkBookGUIPopup(ptModifier):
 
         # is it the seek behavior because we clicked on a book ourself?    
         elif id == SeekBehavior.id and PtFindAvatar(events) == PtGetLocalAvatar():
-            print(events)
+            PtDebugPrint(events)
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kEnterStage: # Smart seek completed. Exit multistage, and show GUI.
                     SeekBehavior.gotoStage(LocalAvatar, -1) 
-                    print("ahnyLinkBookGUIPopup: attempting to draw link panel gui")
+                    PtDebugPrint("ahnyLinkBookGUIPopup: attempting to draw link panel gui")
                     self.IShowBookNoTreasure()
                     OfferedBookMode = False
                     BookOfferer = None
@@ -167,10 +167,10 @@ class ahnyLinkBookGUIPopup(ptModifier):
             for event in events:
                 # is it from the OpenBook? (we only have one book to worry about)
                 if event[0] == PtEventType.kBook:
-                    print("ahnyLinkBookGUIPopup: BookNotify  event=%d, id=%d" % (event[1],event[2]))
+                    PtDebugPrint("ahnyLinkBookGUIPopup: BookNotify  event=%d, id=%d" % (event[1],event[2]))
                     if event[1] == PtBookEventTypes.kNotifyImageLink:
                         if event[2] >= xLinkingBookDefs.kFirstLinkPanelID or event[2] == xLinkingBookDefs.kBookMarkID:
-                            print("ahnyLinkBookGUIPopup:Book: hit linking panel %s" % (event[2]))
+                            PtDebugPrint("ahnyLinkBookGUIPopup:Book: hit linking panel %s" % (event[2]))
                             self.HideBook(1)
                             respLinkSphere01.run(self.key,avatar=PtGetLocalAvatar(),netPropagate=0)
                             
@@ -178,7 +178,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
                             
                             #respNum = self.GetCurrentSphere()
 
-                            #print "respNum:", respNum
+                            #PtDebugPrint("respNum:", respNum)
 
                             '''
                             # check if we need to reset sdl
@@ -196,7 +196,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
                                         if name == "Ahnonay": # or name == "AhnySphere01" or name == "AhnySphere02" or name == "AhnySphere03" or name == "AhnySphere04":
                                             # its not working if we reset all of the sdl here
                                             # so we'll just create some chronicle vars and reset the sdl in the age
-                                            print "attempting to reset sdl for", name
+                                            PtDebugPrint("attempting to reset sdl for", name)
                                             asdl = info.getAgeSDL()
                                             sdr = asdl.getStateDataRecord()
                                             sdr.setFromDefaults(1)
@@ -224,7 +224,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
                             elif (respNum == 4):
                                 respLinkSphere04.run(self.key,avatar=PtGetLocalAvatar())
                             else:
-                                print"Whoa - invalid current sphere!"
+                                PtDebugPrint("Whoa - invalid current sphere!")
                                 return
                             '''
         
@@ -274,7 +274,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
             else:
                 return
 
-            print(bookdef)
+            PtDebugPrint(bookdef)
             PtSendKIMessage(kDisableKIandBB,0)
             gLinkingBook = ptBook(bookdef,self.key)
             gLinkingBook.setSize( width, height )
@@ -282,7 +282,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
             gLinkingBook.show(1)
 
         except LookupError:
-            print("ahnyLinkBookGUIPopup: could not find age Ahnonay's linking panel")
+            PtDebugPrint("ahnyLinkBookGUIPopup: could not find age Ahnonay's linking panel")
 
         '''
         showOpen = 0
@@ -384,7 +384,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
         global gLinkingBook
         global kGrsnTeamBook
         if id == kGrsnTeamBook:
-            print("\nahnyLinkBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book.")
+            PtDebugPrint("\nahnyLinkBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book.")
             gLinkingBook.hide()
 
     def GetCurrentSphere(self):

--- a/Python/ahnyLinkBookGUIPopup.py
+++ b/Python/ahnyLinkBookGUIPopup.py
@@ -154,11 +154,11 @@ class ahnyLinkBookGUIPopup(ptModifier):
 
         # is it the seek behavior because we clicked on a book ourself?    
         elif id == SeekBehavior.id and PtFindAvatar(events) == PtGetLocalAvatar():
-            print events
+            print(events)
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kEnterStage: # Smart seek completed. Exit multistage, and show GUI.
                     SeekBehavior.gotoStage(LocalAvatar, -1) 
-                    print "ahnyLinkBookGUIPopup: attempting to draw link panel gui"
+                    print("ahnyLinkBookGUIPopup: attempting to draw link panel gui")
                     self.IShowBookNoTreasure()
                     OfferedBookMode = False
                     BookOfferer = None
@@ -167,10 +167,10 @@ class ahnyLinkBookGUIPopup(ptModifier):
             for event in events:
                 # is it from the OpenBook? (we only have one book to worry about)
                 if event[0] == PtEventType.kBook:
-                    print "ahnyLinkBookGUIPopup: BookNotify  event=%d, id=%d" % (event[1],event[2])
+                    print("ahnyLinkBookGUIPopup: BookNotify  event=%d, id=%d" % (event[1],event[2]))
                     if event[1] == PtBookEventTypes.kNotifyImageLink:
                         if event[2] >= xLinkingBookDefs.kFirstLinkPanelID or event[2] == xLinkingBookDefs.kBookMarkID:
-                            print "ahnyLinkBookGUIPopup:Book: hit linking panel %s" % (event[2])
+                            print("ahnyLinkBookGUIPopup:Book: hit linking panel %s" % (event[2]))
                             self.HideBook(1)
                             respLinkSphere01.run(self.key,avatar=PtGetLocalAvatar(),netPropagate=0)
                             
@@ -274,7 +274,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
             else:
                 return
 
-            print bookdef
+            print(bookdef)
             PtSendKIMessage(kDisableKIandBB,0)
             gLinkingBook = ptBook(bookdef,self.key)
             gLinkingBook.setSize( width, height )
@@ -282,7 +282,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
             gLinkingBook.show(1)
 
         except LookupError:
-            print "ahnyLinkBookGUIPopup: could not find age Ahnonay's linking panel"
+            print("ahnyLinkBookGUIPopup: could not find age Ahnonay's linking panel")
 
         '''
         showOpen = 0
@@ -384,7 +384,7 @@ class ahnyLinkBookGUIPopup(ptModifier):
         global gLinkingBook
         global kGrsnTeamBook
         if id == kGrsnTeamBook:
-            print "\nahnyLinkBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book."
+            print("\nahnyLinkBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book.")
             gLinkingBook.hide()
 
     def GetCurrentSphere(self):

--- a/Python/ahnyMaintRoom.py
+++ b/Python/ahnyMaintRoom.py
@@ -85,7 +85,7 @@ class ahnyMaintRoom(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "ahnyMaintRoom.OnTimer():\tERROR---Cannot find the Ahnonay Age SDL"
+            print("ahnyMaintRoom.OnTimer():\tERROR---Cannot find the Ahnonay Age SDL")
         
         ageSDL.setFlags("ahnyHubDoor",1,1)
         ageSDL.sendToClients("ahnyHubDoor")
@@ -117,7 +117,7 @@ class ahnyMaintRoom(ptResponder):
             RespAdvanceUse.run(self.key,state="down0",fastforward=1)
         else:
             if SphereNum.value != 1 and SphereNum.value != 2 and SphereNum.value != 3:
-                print "ahnyMaintRoom.OnServerInitComplete():\tERROR---Invalid sphere# set in component.  Disabling clickable."
+                print("ahnyMaintRoom.OnServerInitComplete():\tERROR---Invalid sphere# set in component.  Disabling clickable.")
                 ActAdvanceSwitch.disableActivator()
         
         self.SphereDifference()
@@ -129,16 +129,16 @@ class ahnyMaintRoom(ptResponder):
             if actingAvatar == PtGetLocalAvatar():
                 ageSDL = PtGetAgeSDL()
                 ageSDL["ahnyCurrentSphere"] = (SphereNum.value,)
-                print "advanced from sphere %d with maintainence button" % (ageSDL["ahnyCurrentSphere"][0])
-                print "sphere %d will now be the active sphere" % (SphereNum.value)
+                print("advanced from sphere %d with maintainence button" % (ageSDL["ahnyCurrentSphere"][0]))
+                print("sphere %d will now be the active sphere" % (SphereNum.value))
                 if SphereNum.value == 4:
                     ageSDL["ahnyImagerSphere"] = (SphereNum.value,)
                     boolHubDoor = ageSDL["ahnyHubDoor"][0]
                     if boolHubDoor and ageSDL["ahnyCurrentSphere"][0] != 4:
-                        print "ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it."
+                        print("ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it.")
                         ageSDL["ahnyHubDoor"] = (0,)
                     elif not boolHubDoor and ageSDL["ahnyCurrentSphere"][0] == 4:
-                        print "ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it."
+                        print("ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it.")
         
         elif id == 2:
             ActAdvanceSwitch.enableActivator()
@@ -160,10 +160,10 @@ class ahnyMaintRoom(ptResponder):
             elif VARname == "ahnyCurrentSphere":
                 boolHubDoor = ageSDL["ahnyHubDoor"][0]
                 if boolHubDoor and ageSDL["ahnyCurrentSphere"][0] != 4:
-                    print "ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it."
+                    print("ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it.")
                     ageSDL["ahnyHubDoor"] = (0,)
                 elif not boolHubDoor and ageSDL["ahnyCurrentSphere"][0] == 4:
-                    print "ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it."
+                    print("ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it.")
                     PtAtTimeCallback(self.key,7,2)
         
         if VARname == "ahnyCurrentSphere":
@@ -198,7 +198,7 @@ class ahnyMaintRoom(ptResponder):
                     RespAdvanceUse.run(self.key,state="down3")
                     PtAtTimeCallback(self.key,21,1)
                 else:
-                    print "ahnyMaintRoom.py: ERROR.  Sphere advancement# not possible??"
+                    print("ahnyMaintRoom.py: ERROR.  Sphere advancement# not possible??")
 
     def SphereDifference(self):
         global diffsphere
@@ -207,5 +207,5 @@ class ahnyMaintRoom(ptResponder):
         activeSphere = ageSDL["ahnyCurrentSphere"][0]
         currentSphere = SphereNum.value
         diffsphere = (activeSphere - currentSphere) % 4
-        print "ahnyMaintRoom.SphereDifference(): Setting sphere difference for Maint Room switch to %d" % (diffsphere)
+        print("ahnyMaintRoom.SphereDifference(): Setting sphere difference for Maint Room switch to %d" % (diffsphere))
         

--- a/Python/ahnyMaintRoom.py
+++ b/Python/ahnyMaintRoom.py
@@ -85,7 +85,7 @@ class ahnyMaintRoom(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("ahnyMaintRoom.OnTimer():\tERROR---Cannot find the Ahnonay Age SDL")
+            PtDebugPrint("ahnyMaintRoom.OnTimer():\tERROR---Cannot find the Ahnonay Age SDL")
         
         ageSDL.setFlags("ahnyHubDoor",1,1)
         ageSDL.sendToClients("ahnyHubDoor")
@@ -117,7 +117,7 @@ class ahnyMaintRoom(ptResponder):
             RespAdvanceUse.run(self.key,state="down0",fastforward=1)
         else:
             if SphereNum.value != 1 and SphereNum.value != 2 and SphereNum.value != 3:
-                print("ahnyMaintRoom.OnServerInitComplete():\tERROR---Invalid sphere# set in component.  Disabling clickable.")
+                PtDebugPrint("ahnyMaintRoom.OnServerInitComplete():\tERROR---Invalid sphere# set in component.  Disabling clickable.")
                 ActAdvanceSwitch.disableActivator()
         
         self.SphereDifference()
@@ -129,16 +129,16 @@ class ahnyMaintRoom(ptResponder):
             if actingAvatar == PtGetLocalAvatar():
                 ageSDL = PtGetAgeSDL()
                 ageSDL["ahnyCurrentSphere"] = (SphereNum.value,)
-                print("advanced from sphere %d with maintainence button" % (ageSDL["ahnyCurrentSphere"][0]))
-                print("sphere %d will now be the active sphere" % (SphereNum.value))
+                PtDebugPrint("advanced from sphere %d with maintainence button" % (ageSDL["ahnyCurrentSphere"][0]))
+                PtDebugPrint("sphere %d will now be the active sphere" % (SphereNum.value))
                 if SphereNum.value == 4:
                     ageSDL["ahnyImagerSphere"] = (SphereNum.value,)
                     boolHubDoor = ageSDL["ahnyHubDoor"][0]
                     if boolHubDoor and ageSDL["ahnyCurrentSphere"][0] != 4:
-                        print("ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it.")
+                        PtDebugPrint("ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it.")
                         ageSDL["ahnyHubDoor"] = (0,)
                     elif not boolHubDoor and ageSDL["ahnyCurrentSphere"][0] == 4:
-                        print("ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it.")
+                        PtDebugPrint("ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it.")
         
         elif id == 2:
             ActAdvanceSwitch.enableActivator()
@@ -160,10 +160,10 @@ class ahnyMaintRoom(ptResponder):
             elif VARname == "ahnyCurrentSphere":
                 boolHubDoor = ageSDL["ahnyHubDoor"][0]
                 if boolHubDoor and ageSDL["ahnyCurrentSphere"][0] != 4:
-                    print("ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it.")
+                    PtDebugPrint("ahnyMaintRoom.OnSDLNotify(): Door is open and we're not going to Sphere 4, so close it.")
                     ageSDL["ahnyHubDoor"] = (0,)
                 elif not boolHubDoor and ageSDL["ahnyCurrentSphere"][0] == 4:
-                    print("ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it.")
+                    PtDebugPrint("ahnyMaintRoom.OnSDLNotify(): Door is not open and we're going to Sphere 4, so open it.")
                     PtAtTimeCallback(self.key,7,2)
         
         if VARname == "ahnyCurrentSphere":
@@ -198,7 +198,7 @@ class ahnyMaintRoom(ptResponder):
                     RespAdvanceUse.run(self.key,state="down3")
                     PtAtTimeCallback(self.key,21,1)
                 else:
-                    print("ahnyMaintRoom.py: ERROR.  Sphere advancement# not possible??")
+                    PtDebugPrint("ahnyMaintRoom.py: ERROR.  Sphere advancement# not possible??")
 
     def SphereDifference(self):
         global diffsphere
@@ -207,5 +207,5 @@ class ahnyMaintRoom(ptResponder):
         activeSphere = ageSDL["ahnyCurrentSphere"][0]
         currentSphere = SphereNum.value
         diffsphere = (activeSphere - currentSphere) % 4
-        print("ahnyMaintRoom.SphereDifference(): Setting sphere difference for Maint Room switch to %d" % (diffsphere))
+        PtDebugPrint("ahnyMaintRoom.SphereDifference(): Setting sphere difference for Maint Room switch to %d" % (diffsphere))
         

--- a/Python/ahnyPressurePlates.py
+++ b/Python/ahnyPressurePlates.py
@@ -82,7 +82,7 @@ class ahnyPressurePlates(ptModifier):
         self.id = 5947
         version = 1
         self.version = version
-        print "__init__ahnyPressurePlates v%d " % (version)
+        print("__init__ahnyPressurePlates v%d " % (version))
 
     ###########################
     def OnFirstUpdate(self):
@@ -94,7 +94,7 @@ class ahnyPressurePlates(ptModifier):
             ageSDL = PtGetAgeSDL()
             ageSDL[SDLOccupied.value][0]
         except:
-            print "ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL"
+            print("ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL")
             ageSDL[SDLOccupied.value] = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
 
         ageSDL.setFlags("ahnyCurrentSphere",1,1)
@@ -127,7 +127,7 @@ class ahnyPressurePlates(ptModifier):
             try:
                 ageSDL[SDLTrees.value][0]
             except:
-                print "ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL"
+                print("ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL")
                 ageSDL[SDLTrees.value] = (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
 
             ageSDL.setFlags(SDLTrees.value,1,1)
@@ -149,7 +149,7 @@ class ahnyPressurePlates(ptModifier):
     ###########################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         if VARname == "ahnyCurrentSphere" and respSphereRotate.value != []:
-            print "ahnyPressurePlates.OnSDLNotify(): playing audio SFX"
+            print("ahnyPressurePlates.OnSDLNotify(): playing audio SFX")
             respSphereRotate.run(self.key)
 
     ###########################
@@ -178,7 +178,7 @@ class ahnyPressurePlates(ptModifier):
                                     occupiedZones[index]= occupiedZones[index] + 1
                                 if respLightList != [] and occupiedZones[index]==1: # if we are now equal to one run the responder 
                                     respClockLights.run(self.key, state='on', objectName=respLightList[index], netForce=1 )
-                                print "%s - enter %s" % (str(occupiedZones), str(index))
+                                print("%s - enter %s" % (str(occupiedZones), str(index)))
                             else: #this should be exiting
                                 if occupiedZones[index] != 0: #only subtract if we are not zero don't want to overflow
                                     occupiedZones[index] = occupiedZones[index] -1
@@ -190,7 +190,7 @@ class ahnyPressurePlates(ptModifier):
 
                                     if (respLightList != []) and (occupiedZones[index] == 0):# 
                                         respClockLights.run(self.key, state='off', objectName=respLightList[index] , netForce=1)
-                                print "%s - exit %s" % (str(occupiedZones), str(index))
+                                print("%s - exit %s" % (str(occupiedZones), str(index)))
                             ageSDL[SDLOccupied.value] = tuple(occupiedZones)
                             #print "Occupied: %s" % (str(occupiedZones))
 
@@ -212,16 +212,16 @@ class ahnyPressurePlates(ptModifier):
             for event in events:
                 # is it from the OpenBook? (we only have one book to worry about)
                 if event[0] == PtEventType.kBook:
-                    print "ahnyPressurePlates: BookNotify  event=%d, id=%d" % (event[1],event[2])
+                    print("ahnyPressurePlates: BookNotify  event=%d, id=%d" % (event[1],event[2]))
                     if event[1] == PtBookEventTypes.kNotifyImageLink:
                         if event[2] >= xLinkingBookDefs.kFirstLinkPanelID or event[2] == xLinkingBookDefs.kBookMarkID:
-                            print "ahnyPressurePlates:Book: hit linking panel %s" % (event[2])
+                            print("ahnyPressurePlates:Book: hit linking panel %s" % (event[2]))
                             self.HideBook(1)
 
                             ageSDL = PtGetAgeSDL()
-                            print ageSDL[SDLOccupied.value]
+                            print(ageSDL[SDLOccupied.value])
                             if self.RegionsEmpty():
-                                print "Sphere rotating"
+                                print("Sphere rotating")
                                 ageSDL = PtGetAgeSDL()
                                 currentSphere = ageSDL["ahnyCurrentSphere"][0]
                                 if currentSphere == 3 or currentSphere == 4:
@@ -229,7 +229,7 @@ class ahnyPressurePlates(ptModifier):
                                 else:
                                     ageSDL["ahnyCurrentSphere"] = ((currentSphere + 1),)
                             else:
-                                print "Sphere staying put"
+                                print("Sphere staying put")
 
                             respLinkResponder.run(self.key, avatar=PtGetLocalAvatar(),netPropagate=0)
 
@@ -267,11 +267,11 @@ class ahnyPressurePlates(ptModifier):
                             '''
         
                     elif event[1] == PtBookEventTypes.kNotifyShow:
-                        print "ahnyLinkBookGUIPopup:Book: NotifyShow"
+                        print("ahnyLinkBookGUIPopup:Book: NotifyShow")
                         PtSendKIMessage(kEnableKIandBB,0)
 
                     elif event[1] == PtBookEventTypes.kNotifyHide:
-                        print "ahnyLinkBookGUIPopup:Book: NotifyHide"
+                        print("ahnyLinkBookGUIPopup:Book: NotifyHide")
                         PtToggleAvatarClickability(True)
                         bookClickable.enable()
 
@@ -283,24 +283,24 @@ class ahnyPressurePlates(ptModifier):
         if Sphere.value == "Sphere01":
             quabs = ageSDL["ahnyQuabs"][0]
             if quabs:
-                print "ahnyPressurePlates: not all quabs kicked off"
+                print("ahnyPressurePlates: not all quabs kicked off")
                 return False
         elif Sphere.value == "Sphere02":
             treeList = list(ageSDL[SDLTrees.value])
             for tree in treeList:
                 if tree:
-                    print "ahnyPressurePlates: not all trees knocked over"
+                    print("ahnyPressurePlates: not all trees knocked over")
                     return False
 
         for zone in occupantList[1:]:
             if zone:
-                print "ahnyPressurePlates: some zones still occupied"
+                print("ahnyPressurePlates: some zones still occupied")
                 return False
 
         if occupantList[0] == 1:
             return True
 
-        print "ahnyPressurePlates: book zone still occupied"
+        print("ahnyPressurePlates: book zone still occupied")
         return False
 
     ###########################
@@ -326,7 +326,7 @@ class ahnyPressurePlates(ptModifier):
             gLinkingBook.show(1)
 
         except LookupError:
-            print "ahnyLinkBookGUIPopup: could not find age AhnonayCathedral's linking panel"
+            print("ahnyLinkBookGUIPopup: could not find age AhnonayCathedral's linking panel")
 
     ###########################
     def HideBook(self, islinking = 0):

--- a/Python/ahnyPressurePlates.py
+++ b/Python/ahnyPressurePlates.py
@@ -82,7 +82,7 @@ class ahnyPressurePlates(ptModifier):
         self.id = 5947
         version = 1
         self.version = version
-        print("__init__ahnyPressurePlates v%d " % (version))
+        PtDebugPrint("__init__ahnyPressurePlates v%d " % (version))
 
     ###########################
     def OnFirstUpdate(self):
@@ -94,7 +94,7 @@ class ahnyPressurePlates(ptModifier):
             ageSDL = PtGetAgeSDL()
             ageSDL[SDLOccupied.value][0]
         except:
-            print("ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL")
+            PtDebugPrint("ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL")
             ageSDL[SDLOccupied.value] = (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
 
         ageSDL.setFlags("ahnyCurrentSphere",1,1)
@@ -127,7 +127,7 @@ class ahnyPressurePlates(ptModifier):
             try:
                 ageSDL[SDLTrees.value][0]
             except:
-                print("ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL")
+                PtDebugPrint("ahnyPressurePlates.OnFirstUpdate(): ERROR --- Cannot find the Ahnonay Age SDL")
                 ageSDL[SDLTrees.value] = (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
 
             ageSDL.setFlags(SDLTrees.value,1,1)
@@ -149,7 +149,7 @@ class ahnyPressurePlates(ptModifier):
     ###########################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         if VARname == "ahnyCurrentSphere" and respSphereRotate.value != []:
-            print("ahnyPressurePlates.OnSDLNotify(): playing audio SFX")
+            PtDebugPrint("ahnyPressurePlates.OnSDLNotify(): playing audio SFX")
             respSphereRotate.run(self.key)
 
     ###########################
@@ -158,7 +158,7 @@ class ahnyPressurePlates(ptModifier):
         global objZoneList
         global LocalAvatar
         
-        #print "ahnyPressurePlates.OnNotify: state=%s id=%d events=" % (state, id), events
+        #PtDebugPrint("ahnyPressurePlates.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == zones.id:
             for event in events:
@@ -172,13 +172,13 @@ class ahnyPressurePlates(ptModifier):
                             ageSDL = PtGetAgeSDL()
                             index = objZoneList.index(zoneName)
                             occupiedZones = list(ageSDL[SDLOccupied.value])
-                            #print "Zone: %s Index: %d Occupied: %s" % (zoneName,index,str(occupiedZones))
+                            #PtDebugPrint("Zone: %s Index: %d Occupied: %s" % (zoneName,index,str(occupiedZones)))
                             if event[1] == 1: #We are entering
                                 if occupiedZones[index] != 255: #avoid overflow
                                     occupiedZones[index]= occupiedZones[index] + 1
                                 if respLightList != [] and occupiedZones[index]==1: # if we are now equal to one run the responder 
                                     respClockLights.run(self.key, state='on', objectName=respLightList[index], netForce=1 )
-                                print("%s - enter %s" % (str(occupiedZones), str(index)))
+                                PtDebugPrint("%s - enter %s" % (str(occupiedZones), str(index)))
                             else: #this should be exiting
                                 if occupiedZones[index] != 0: #only subtract if we are not zero don't want to overflow
                                     occupiedZones[index] = occupiedZones[index] -1
@@ -190,9 +190,9 @@ class ahnyPressurePlates(ptModifier):
 
                                     if (respLightList != []) and (occupiedZones[index] == 0):# 
                                         respClockLights.run(self.key, state='off', objectName=respLightList[index] , netForce=1)
-                                print("%s - exit %s" % (str(occupiedZones), str(index)))
+                                PtDebugPrint("%s - exit %s" % (str(occupiedZones), str(index)))
                             ageSDL[SDLOccupied.value] = tuple(occupiedZones)
-                            #print "Occupied: %s" % (str(occupiedZones))
+                            #PtDebugPrint("Occupied: %s" % (str(occupiedZones)))
 
         # is it a clickable book on a pedestal?
         elif id == bookClickable.id and PtFindAvatar(events) == PtGetLocalAvatar() and state:
@@ -212,16 +212,16 @@ class ahnyPressurePlates(ptModifier):
             for event in events:
                 # is it from the OpenBook? (we only have one book to worry about)
                 if event[0] == PtEventType.kBook:
-                    print("ahnyPressurePlates: BookNotify  event=%d, id=%d" % (event[1],event[2]))
+                    PtDebugPrint("ahnyPressurePlates: BookNotify  event=%d, id=%d" % (event[1],event[2]))
                     if event[1] == PtBookEventTypes.kNotifyImageLink:
                         if event[2] >= xLinkingBookDefs.kFirstLinkPanelID or event[2] == xLinkingBookDefs.kBookMarkID:
-                            print("ahnyPressurePlates:Book: hit linking panel %s" % (event[2]))
+                            PtDebugPrint("ahnyPressurePlates:Book: hit linking panel %s" % (event[2]))
                             self.HideBook(1)
 
                             ageSDL = PtGetAgeSDL()
-                            print(ageSDL[SDLOccupied.value])
+                            PtDebugPrint(ageSDL[SDLOccupied.value])
                             if self.RegionsEmpty():
-                                print("Sphere rotating")
+                                PtDebugPrint("Sphere rotating")
                                 ageSDL = PtGetAgeSDL()
                                 currentSphere = ageSDL["ahnyCurrentSphere"][0]
                                 if currentSphere == 3 or currentSphere == 4:
@@ -229,7 +229,7 @@ class ahnyPressurePlates(ptModifier):
                                 else:
                                     ageSDL["ahnyCurrentSphere"] = ((currentSphere + 1),)
                             else:
-                                print("Sphere staying put")
+                                PtDebugPrint("Sphere staying put")
 
                             respLinkResponder.run(self.key, avatar=PtGetLocalAvatar(),netPropagate=0)
 
@@ -259,19 +259,19 @@ class ahnyPressurePlates(ptModifier):
                                     elif (sphere.value == "4"):
                                         currentSphere.setInt(1,0)
                                     else:
-                                        print"missing sphere identifier string!"
+                                        PtDebugPrint("missing sphere identifier string!")
                                     ahnySDL.setStateDataRecord(ahnyRecord)
                                     ahnySDL.save()
-                                    print"advanced from sphere ",sphere.value
+                                    PtDebugPrint("advanced from sphere ",sphere.value)
                                     return
                             '''
         
                     elif event[1] == PtBookEventTypes.kNotifyShow:
-                        print("ahnyLinkBookGUIPopup:Book: NotifyShow")
+                        PtDebugPrint("ahnyLinkBookGUIPopup:Book: NotifyShow")
                         PtSendKIMessage(kEnableKIandBB,0)
 
                     elif event[1] == PtBookEventTypes.kNotifyHide:
-                        print("ahnyLinkBookGUIPopup:Book: NotifyHide")
+                        PtDebugPrint("ahnyLinkBookGUIPopup:Book: NotifyHide")
                         PtToggleAvatarClickability(True)
                         bookClickable.enable()
 
@@ -283,24 +283,24 @@ class ahnyPressurePlates(ptModifier):
         if Sphere.value == "Sphere01":
             quabs = ageSDL["ahnyQuabs"][0]
             if quabs:
-                print("ahnyPressurePlates: not all quabs kicked off")
+                PtDebugPrint("ahnyPressurePlates: not all quabs kicked off")
                 return False
         elif Sphere.value == "Sphere02":
             treeList = list(ageSDL[SDLTrees.value])
             for tree in treeList:
                 if tree:
-                    print("ahnyPressurePlates: not all trees knocked over")
+                    PtDebugPrint("ahnyPressurePlates: not all trees knocked over")
                     return False
 
         for zone in occupantList[1:]:
             if zone:
-                print("ahnyPressurePlates: some zones still occupied")
+                PtDebugPrint("ahnyPressurePlates: some zones still occupied")
                 return False
 
         if occupantList[0] == 1:
             return True
 
-        print("ahnyPressurePlates: book zone still occupied")
+        PtDebugPrint("ahnyPressurePlates: book zone still occupied")
         return False
 
     ###########################
@@ -326,7 +326,7 @@ class ahnyPressurePlates(ptModifier):
             gLinkingBook.show(1)
 
         except LookupError:
-            print("ahnyLinkBookGUIPopup: could not find age AhnonayCathedral's linking panel")
+            PtDebugPrint("ahnyLinkBookGUIPopup: could not find age AhnonayCathedral's linking panel")
 
     ###########################
     def HideBook(self, islinking = 0):

--- a/Python/ahnyQuabs.py
+++ b/Python/ahnyQuabs.py
@@ -71,7 +71,7 @@ class ahnyQuabs(ptModifier, object):
         self.version = 2
         self.brains = []
         random.seed()
-        print "__init__ahnyQuabs v%d " % (self.version)
+        print("__init__ahnyQuabs v%d " % (self.version))
 
     def _last_update_get(self):
         ageSDL = PtGetAgeSDL()

--- a/Python/ahnyQuabs.py
+++ b/Python/ahnyQuabs.py
@@ -71,7 +71,7 @@ class ahnyQuabs(ptModifier, object):
         self.version = 2
         self.brains = []
         random.seed()
-        print("__init__ahnyQuabs v%d " % (self.version))
+        PtDebugPrint("__init__ahnyQuabs v%d " % (self.version))
 
     def _last_update_get(self):
         ageSDL = PtGetAgeSDL()

--- a/Python/ahnySaveCloth.py
+++ b/Python/ahnySaveCloth.py
@@ -67,7 +67,7 @@ class ahnySaveCloth(ptModifier):
         ptModifier.__init__(self)
         self.id = 5424
         self.version = 1
-        print "DEBUG: ahnySaveCloth.__init__: v.", self.version
+        print("DEBUG: ahnySaveCloth.__init__: v.", self.version)
 
     def OnFirstUpdate(self):
         global sdlSC
@@ -112,17 +112,17 @@ class ahnySaveCloth(ptModifier):
 
             if spTitle == "SCSavePoint":
                 if spName == "SaveClothPoint7" or spName == "SaveClothPoint8":
-                    print "linking to hub or hut"
+                    print("linking to hub or hut")
                     whereAmI = 4
                 else:
                     offset = str(ageSDL["ahnyCurrentOffset"][0])
-                    print "Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset)
+                    print("Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset))
                     whereAmI = (int(sphere) - int(offset)) % 4
                     if whereAmI == 0:
                         whereAmI = 4
             else:
                 whereAmI = sphere
-            print "ahnySaveCloth.OnServerInitComplete(): I am age owner in %d" % (whereAmI)
+            print("ahnySaveCloth.OnServerInitComplete(): I am age owner in %d" % (whereAmI))
 
         # SaveCloth SDL stuff, for use with POTS symbols
         sdlSC = "ahnyGotSaveCloth" + clothID.value
@@ -132,9 +132,9 @@ class ahnySaveCloth(ptModifier):
             ageSDL.sendToClients(sdlSC)
             ageSDL.setNotify(self.key,sdlSC,0.0)
             gotSC = ageSDL[sdlSC][0]
-            print "ahnySaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC
+            print("ahnySaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC)
         except:
-            print "ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0"
+            print("ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0")
 
         ageSDL.setFlags("ahnyCurrentSphere",1,1)
         ageSDL.sendToClients("ahnyCurrentSphere")
@@ -159,7 +159,7 @@ class ahnySaveCloth(ptModifier):
         global whereAmI
         global link
 
-        print "DEBUG: ahnySaveCloth::onNotify, id ",id
+        print("DEBUG: ahnySaveCloth::onNotify, id ",id)
 
         if not state:
             return
@@ -175,13 +175,13 @@ class ahnySaveCloth(ptModifier):
             guid = ageinfo.getAgeInstanceGuid()
 
             if guid == link:
-                print "I'm the age owner, setting spawnpoint"
+                print("I'm the age owner, setting spawnpoint")
                 #Activator.enable()
                 
                 ageSDL = PtGetAgeSDL()
                 sphere = ageSDL["ahnyCurrentSphere"][0]
                 offset = (sphere - whereAmI) % 4
-                print "ahnySaveCloth.OnNotify: Offset = %d" % (offset)
+                print("ahnySaveCloth.OnNotify: Offset = %d" % (offset))
                 ageSDL["ahnyCurrentOffset"] = (offset,)
 
                 agevault = ptAgeVault()
@@ -208,18 +208,18 @@ class ahnySaveCloth(ptModifier):
                                 if chron and chron.getName() == "AhnonaySpawnPoints":
                                     spawn = chron.getValue().split(";")
                                     newSpawn = "%s;SCSavePoint,SaveClothPoint%s" % (spawn[0],clothID.value)
-                                    print newSpawn
+                                    print(newSpawn)
                                     chron.setValue(newSpawn) 
                                     if not gotSC:
                                         ageSDL = PtGetAgeSDL()
                                         ageSDL[sdlSC] = (1,)
                                     return
 
-                print "ahnySaveCloth.OnNotify(): ERROR: couldn't find chron node"
+                print("ahnySaveCloth.OnNotify(): ERROR: couldn't find chron node")
 
 
             else:
-                print "I'm not the age owner, so I don't do anything."
+                print("I'm not the age owner, so I don't do anything.")
 
 
 

--- a/Python/ahnySaveCloth.py
+++ b/Python/ahnySaveCloth.py
@@ -67,7 +67,7 @@ class ahnySaveCloth(ptModifier):
         ptModifier.__init__(self)
         self.id = 5424
         self.version = 1
-        print("DEBUG: ahnySaveCloth.__init__: v.", self.version)
+        PtDebugPrint("DEBUG: ahnySaveCloth.__init__: v.", self.version)
 
     def OnFirstUpdate(self):
         global sdlSC
@@ -112,17 +112,17 @@ class ahnySaveCloth(ptModifier):
 
             if spTitle == "SCSavePoint":
                 if spName == "SaveClothPoint7" or spName == "SaveClothPoint8":
-                    print("linking to hub or hut")
+                    PtDebugPrint("linking to hub or hut")
                     whereAmI = 4
                 else:
                     offset = str(ageSDL["ahnyCurrentOffset"][0])
-                    print("Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset))
+                    PtDebugPrint("Ahnonay.OnPageLoad(): Sphere0%s loaded with offset:%s" % (sphere, offset))
                     whereAmI = (int(sphere) - int(offset)) % 4
                     if whereAmI == 0:
                         whereAmI = 4
             else:
                 whereAmI = sphere
-            print("ahnySaveCloth.OnServerInitComplete(): I am age owner in %d" % (whereAmI))
+            PtDebugPrint("ahnySaveCloth.OnServerInitComplete(): I am age owner in %d" % (whereAmI))
 
         # SaveCloth SDL stuff, for use with POTS symbols
         sdlSC = "ahnyGotSaveCloth" + clothID.value
@@ -132,9 +132,9 @@ class ahnySaveCloth(ptModifier):
             ageSDL.sendToClients(sdlSC)
             ageSDL.setNotify(self.key,sdlSC,0.0)
             gotSC = ageSDL[sdlSC][0]
-            print("ahnySaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC)
+            PtDebugPrint("ahnySaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC)
         except:
-            print("ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0")
+            PtDebugPrint("ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0")
 
         ageSDL.setFlags("ahnyCurrentSphere",1,1)
         ageSDL.sendToClients("ahnyCurrentSphere")
@@ -159,7 +159,7 @@ class ahnySaveCloth(ptModifier):
         global whereAmI
         global link
 
-        print("DEBUG: ahnySaveCloth::onNotify, id ",id)
+        PtDebugPrint("DEBUG: ahnySaveCloth::onNotify, id ",id)
 
         if not state:
             return
@@ -175,13 +175,13 @@ class ahnySaveCloth(ptModifier):
             guid = ageinfo.getAgeInstanceGuid()
 
             if guid == link:
-                print("I'm the age owner, setting spawnpoint")
+                PtDebugPrint("I'm the age owner, setting spawnpoint")
                 #Activator.enable()
                 
                 ageSDL = PtGetAgeSDL()
                 sphere = ageSDL["ahnyCurrentSphere"][0]
                 offset = (sphere - whereAmI) % 4
-                print("ahnySaveCloth.OnNotify: Offset = %d" % (offset))
+                PtDebugPrint("ahnySaveCloth.OnNotify: Offset = %d" % (offset))
                 ageSDL["ahnyCurrentOffset"] = (offset,)
 
                 agevault = ptAgeVault()
@@ -208,18 +208,18 @@ class ahnySaveCloth(ptModifier):
                                 if chron and chron.getName() == "AhnonaySpawnPoints":
                                     spawn = chron.getValue().split(";")
                                     newSpawn = "%s;SCSavePoint,SaveClothPoint%s" % (spawn[0],clothID.value)
-                                    print(newSpawn)
+                                    PtDebugPrint(newSpawn)
                                     chron.setValue(newSpawn) 
                                     if not gotSC:
                                         ageSDL = PtGetAgeSDL()
                                         ageSDL[sdlSC] = (1,)
                                     return
 
-                print("ahnySaveCloth.OnNotify(): ERROR: couldn't find chron node")
+                PtDebugPrint("ahnySaveCloth.OnNotify(): ERROR: couldn't find chron node")
 
 
             else:
-                print("I'm not the age owner, so I don't do anything.")
+                PtDebugPrint("I'm not the age owner, so I don't do anything.")
 
 
 
@@ -252,7 +252,7 @@ class ahnySaveCloth(ptModifier):
 
                         agevault = ptAgeVault()
                         currentage = int(agevault.getAgeInfo().getAgeFilename()[-1])
-                        print "currently in sphere:", currentage
+                        PtDebugPrint("currently in sphere:", currentage)
 
                         currentpos = (currentage - activeSphere) % 4
 
@@ -265,10 +265,10 @@ class ahnySaveCloth(ptModifier):
                         
                         currentCloth.setInt(clothOffset,0)
                         currentCloth.setInt(currentpos,1)
-                        print"current save cloth updated to number", clothOffset, " from cloth value of", clothNumber
-                        print"current save position updated to:", currentpos
+                        PtDebugPrint("current save cloth updated to number", clothOffset, " from cloth value of", clothNumber)
+                        PtDebugPrint("current save position updated to:", currentpos)
                     else:
-                        print"missing sphere identifier string!"
+                        PtDebugPrint("missing sphere identifier string!")
                     ahnySDL.setStateDataRecord(ahnyRecord)
                     ahnySDL.save()
                     return

--- a/Python/ahnyTrees.py
+++ b/Python/ahnyTrees.py
@@ -70,7 +70,7 @@ class ahnyTrees(ptModifier):
         self.id = 5948
         version = 1
         self.version = version
-        print "__init__ahnyTrees v%d " % (version)
+        print("__init__ahnyTrees v%d " % (version))
 
     ###########################
     def OnFirstUpdate(self):
@@ -81,7 +81,7 @@ class ahnyTrees(ptModifier):
             ageSDL = PtGetAgeSDL()
             ageSDL[SDLTrees.value][0]
         except:
-            print "ahnyTrees.OnServerInitComplete(): ERROR --- Cannot find the Ahnonay Age SDL"
+            print("ahnyTrees.OnServerInitComplete(): ERROR --- Cannot find the Ahnonay Age SDL")
             ageSDL[SDLTrees.value] = (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
 
         ageSDL.setFlags(SDLTrees.value,1,1)
@@ -107,7 +107,7 @@ class ahnyTrees(ptModifier):
     def OnNotify(self,state,id,events):
         global respTreeAnimsList
         global objTreeList
-        print "ahnyTrees.OnNotify: state=%s id=%d events=" % (state, id), events
+        print("ahnyTrees.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == rgnTrees.id:
             for event in events:
@@ -123,5 +123,5 @@ class ahnyTrees(ptModifier):
                                 respTreeAnims.run(self.key, objectName=respTreeAnimsList[index], netForce = 1)
                                 treeSDL[index] = 0
                                 ageSDL[SDLTrees.value] = tuple(treeSDL)
-                                print "ahnyTrees.OnNotify: Tree knocked down"
+                                print("ahnyTrees.OnNotify: Tree knocked down")
 

--- a/Python/ahnyTrees.py
+++ b/Python/ahnyTrees.py
@@ -70,7 +70,7 @@ class ahnyTrees(ptModifier):
         self.id = 5948
         version = 1
         self.version = version
-        print("__init__ahnyTrees v%d " % (version))
+        PtDebugPrint("__init__ahnyTrees v%d " % (version))
 
     ###########################
     def OnFirstUpdate(self):
@@ -81,7 +81,7 @@ class ahnyTrees(ptModifier):
             ageSDL = PtGetAgeSDL()
             ageSDL[SDLTrees.value][0]
         except:
-            print("ahnyTrees.OnServerInitComplete(): ERROR --- Cannot find the Ahnonay Age SDL")
+            PtDebugPrint("ahnyTrees.OnServerInitComplete(): ERROR --- Cannot find the Ahnonay Age SDL")
             ageSDL[SDLTrees.value] = (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)
 
         ageSDL.setFlags(SDLTrees.value,1,1)
@@ -107,7 +107,7 @@ class ahnyTrees(ptModifier):
     def OnNotify(self,state,id,events):
         global respTreeAnimsList
         global objTreeList
-        print("ahnyTrees.OnNotify: state=%s id=%d events=" % (state, id), events)
+        PtDebugPrint("ahnyTrees.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == rgnTrees.id:
             for event in events:
@@ -123,5 +123,5 @@ class ahnyTrees(ptModifier):
                                 respTreeAnims.run(self.key, objectName=respTreeAnimsList[index], netForce = 1)
                                 treeSDL[index] = 0
                                 ageSDL[SDLTrees.value] = tuple(treeSDL)
-                                print("ahnyTrees.OnNotify: Tree knocked down")
+                                PtDebugPrint("ahnyTrees.OnNotify: Tree knocked down")
 

--- a/Python/ahnyVogondolaRideV2.py
+++ b/Python/ahnyVogondolaRideV2.py
@@ -179,22 +179,22 @@ def DisableVogControls( enabledControlList ):
 
 def VogondolaIsOccupied( occupant ):
     if occupant:
-        print "ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got in the Vog, disabling all access points"
+        print("ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got in the Vog, disabling all access points")
         
         actHubChairClick.disable()
         actEngHutChairClick.disable()
         actCallbuttonHub.disable()
         actCallbuttonEngHut.disable()
     else:
-        print "ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got out of the Vog, enabling all access points"
+        print("ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got out of the Vog, enabling all access points")
         
         sdl = PtGetAgeSDL()
         vogLoc = sdl["ahnyVogLocation"][0]
         if vogLoc == 0:
-            print "SDL set to 0, Hub Chair enabled"
+            print("SDL set to 0, Hub Chair enabled")
             actHubChairClick.enable()
         elif vogLoc == 2:
-            print "SDL set to 2, Hut Chair enabled"
+            print("SDL set to 2, Hut Chair enabled")
             actEngHutChairClick.enable()
 
 # brains - these determine what happens at the various stages
@@ -203,7 +203,7 @@ class InHubBrain:
         self.parent = parent
         self.name = "In Hub Brain"
 
-        print "initing", self.name
+        print("initing", self.name)
 
         PtDisableMovementKeys()
 
@@ -218,7 +218,7 @@ class InHubBrain:
 
     def OnNotify(self, state, id, events):
         if id == actHubChairClick.id and state:
-            print "Hub Brain says Hub Chair clicked, disable Hub Chair"
+            print("Hub Brain says Hub Chair clicked, disable Hub Chair")
             actHubChairClick.disable()
 
             avatar = PtFindAvatar(events)
@@ -228,13 +228,13 @@ class InHubBrain:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage:
                     respHubChairLower.run(self.parent.key, events = events, state = "lower")
-                    print self.name + ": finished smart-seek"
+                    print(self.name + ": finished smart-seek")
                     
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
                     theAvatar = PtGetLocalAvatar()
                     theAvatar.avatar.enterSubWorld(soVogSubworld.value)
                     theAvatar.physics.warpObj(soVogDummy.value.getKey())
-                    print self.name + ": pinned avatar"
+                    print(self.name + ": pinned avatar")
                     respVogChairLower.run(self.parent.key, events = events)
                     
         elif id == actVogDirection.id and state:
@@ -256,7 +256,7 @@ class InHubBrain:
             respVogEjectHub.run(self.parent.key, state = "norotate")
 
             sdl = PtGetAgeSDL()
-            print "SETTING SDL TO 0"
+            print("SETTING SDL TO 0")
             sdl["ahnyVogLocation"] = (0,)
 
         elif id == actVogEjectRear.id and state:
@@ -264,7 +264,7 @@ class InHubBrain:
             respVogEjectHub.run(self.parent.key, state = "rotate")
 
             sdl = PtGetAgeSDL()
-            print "SETTING SDL TO 0"
+            print("SETTING SDL TO 0")
             sdl["ahnyVogLocation"] = (0,)
 
         elif id == actVogThrottleB.id and state:
@@ -272,7 +272,7 @@ class InHubBrain:
             respVogRideStart.run(self.parent.key)
 
         elif id == respVogRideStart.id:
-            print "running respSounds: state - hubtubeout loc - hub brain respvogridestart"
+            print("running respSounds: state - hubtubeout loc - hub brain respvogridestart")
             respSounds.run(self.parent.key, state = "hubtubeout")
 
         elif id == actTubeEndFromHub.id:
@@ -291,14 +291,14 @@ class InHubBrain:
 
             self.parent.currentBrain = None
             PtEnableMovementKeys()
-            print "ejecting finished in vog at hub...setting current brain to none"
+            print("ejecting finished in vog at hub...setting current brain to none")
 
 class HubSailTubeTransitionBrain:
     def __init__(self, parent):
         self.parent = parent
         self.name = "Hub Sail Tube Transition Brain"
 
-        print "initing", self.name
+        print("initing", self.name)
 
 
         enabledControlList = [actVogThrottleB, actVogThrottleRevB]
@@ -340,7 +340,7 @@ class HubSailTubeTransitionBrain:
             respVogRideStartRev.run(self.parent.key)
 
         elif id == respVogRideStartRev.id:
-            print "running respSounds: state - hubtubein loc - hubtransistion respvogridestartrev"
+            print("running respSounds: state - hubtubein loc - hubtransistion respvogridestartrev")
             respSounds.run(self.parent.key, state = "hubtubein")
 
         #elif (id == respVogRideStop.id or id == respVogRideStopRev.id) and self.parent.direction == -1:
@@ -357,7 +357,7 @@ class SailingBrain:
         self.parent = parent
         self.name = "Sailing Brain"
 
-        print "initing", self.name
+        print("initing", self.name)
 
         enabledControlList = None
 
@@ -382,7 +382,7 @@ class SailingBrain:
             DisableVogControls( enabledControlList )
 
         elif id == respVogRideStop.id or id == respVogRideStopRev.id:
-            print "vog ride stop notify"
+            print("vog ride stop notify")
             respSounds.run(self.parent.key, state = "stop")
 
         elif id == actVogDirection.id and state:
@@ -412,11 +412,11 @@ class SailingBrain:
             #respSounds.run(self.parent.key, state = "sailtohub")
 
         elif id == respVogRideStart.id:
-            print "running respSounds: state - sailtohut loc - sail brain vogridestart"
+            print("running respSounds: state - sailtohut loc - sail brain vogridestart")
             respSounds.run(self.parent.key, state = "sailtohut")
 
         elif id == respVogRideStartRev.id:
-            print "running respSounds: state - sailtohub loc - sail brain vogridestartrev"
+            print("running respSounds: state - sailtohub loc - sail brain vogridestartrev")
             respSounds.run(self.parent.key, state = "sailtohub")
 
         elif id == actSailEndToEngHut.id and self.parent.direction == 1:
@@ -438,7 +438,7 @@ class EngHutSailTubeTransitionBrain:
         self.parent = parent
         self.name = "Eng Hut Sail Tube Transition Brain"
 
-        print "initing", self.name
+        print("initing", self.name)
 
         enabledControlList = [actVogThrottleB, actVogThrottleRevB]
 
@@ -482,7 +482,7 @@ class EngHutSailTubeTransitionBrain:
             respVogRideStart.run(self.parent.key)
 
         elif id == respVogRideStart.id:
-            print "running respSounds: state - huttubein loc - hut transition vogridestart"
+            print("running respSounds: state - huttubein loc - hut transition vogridestart")
             respSounds.run(self.parent.key, state = "huttubein")
 
         elif id == actEngHutRideEnd.id:
@@ -496,7 +496,7 @@ class InEngHutBrain:
         self.parent = parent
         self.name = "In Eng Hut Brain"
 
-        print "initing", self.name
+        print("initing", self.name)
 
         PtDisableMovementKeys()
 
@@ -511,7 +511,7 @@ class InEngHutBrain:
 
     def OnNotify(self, state, id, events):
         if id == actEngHutChairClick.id and state:
-            print "Hut Brain says Hut Chair clicked, disable Hut Chair"
+            print("Hut Brain says Hut Chair clicked, disable Hut Chair")
             actEngHutChairClick.disable()
 
             avatar = PtFindAvatar(events)
@@ -521,13 +521,13 @@ class InEngHutBrain:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage:
                     respEngHutChairLower.run(self.parent.key, events = events, state = "lower")
-                    print self.name + ": finished smart-seek"
+                    print(self.name + ": finished smart-seek")
                     
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
                     theAvatar = PtGetLocalAvatar()
                     theAvatar.avatar.enterSubWorld(soVogSubworld.value)
                     theAvatar.physics.warpObj(soVogDummy.value.getKey())
-                    print self.name + ": pinned avatar"
+                    print(self.name + ": pinned avatar")
                     respVogChairLower.run(self.parent.key, events = events)
                     
         elif id == actVogDirection.id and state:
@@ -551,7 +551,7 @@ class InEngHutBrain:
             #theAvatar.draw.disable()
             
             sdl = PtGetAgeSDL()
-            print "SETTING SDL TO 2"
+            print("SETTING SDL TO 2")
             sdl["ahnyVogLocation"] = (2,)
 
         elif id == actVogEjectRear.id and state:
@@ -559,7 +559,7 @@ class InEngHutBrain:
             respVogEjectEngHut.run(self.parent.key, state = "rotate")
 
             sdl = PtGetAgeSDL()
-            print "SETTING SDL TO 2"
+            print("SETTING SDL TO 2")
             sdl["ahnyVogLocation"] = (2,)
 
         elif id == actVogThrottleRevB.id and state:
@@ -568,7 +568,7 @@ class InEngHutBrain:
             #respSounds.run(self.parent.key, state = "huttubeout")
 
         elif id == respVogRideStartRev.id:
-            print "running respSounds: huttubeout - stop loc - hut brain vogridestartrev"
+            print("running respSounds: huttubeout - stop loc - hut brain vogridestartrev")
             respSounds.run(self.parent.key, state = "huttubeout")
 
         elif id == actTubeEndFromEngHut.id:
@@ -587,7 +587,7 @@ class InEngHutBrain:
             self.parent.currentBrain = None
             PtEnableMovementKeys()
             #theAvatar.draw.enable()
-            print "ejecting finished in vog at eng hut...setting current brain to none"
+            print("ejecting finished in vog at eng hut...setting current brain to none")
 
 
 # main class
@@ -601,13 +601,13 @@ class ahnyVogondolaRideV2(ptResponder):
         self.direction = 1
         self.throttle = 0
         self.occupant = None
-        print "Init: ahnyVogondolaRideV2"
+        print("Init: ahnyVogondolaRideV2")
 
     def OnFirstUpdate(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "uh oh... no SDL! Prepare to have lots of bugs."
+            print("uh oh... no SDL! Prepare to have lots of bugs.")
 
         ageSDL = PtGetAgeSDL()
         ageSDL.setFlags("ahnyVogLocation",1,1)
@@ -618,17 +618,17 @@ class ahnyVogondolaRideV2(ptResponder):
         ageSDL.sendToClients("ahnyVogOccupant")
         ageSDL.setNotify(self.key,"ahnyVogOccupant",0.0)
         
-        print "First Update, all buttons disabled"
+        print("First Update, all buttons disabled")
         actCallbuttonHub.disable()
         actCallbuttonEngHut.disable()
         actHubChairClick.disable()
         actEngHutChairClick.disable()
         
         if ageSDL["ahnyVogOccupant"][0]:
-            print "%d is in the Vogondola" % (ageSDL["ahnyVogOccupant"][0])
+            print("%d is in the Vogondola" % (ageSDL["ahnyVogOccupant"][0]))
             self.occupant = ageSDL["ahnyVogOccupant"][0]
         else:
-            print "Vogondola is empty"
+            print("Vogondola is empty")
             PtAtTimeCallback(self.key, 0, 1)
 
     def OnTimer(self, id):
@@ -638,19 +638,19 @@ class ahnyVogondolaRideV2(ptResponder):
 
             # vogLoc: 0 = hub, 1 = in between, 2 = eng hut
             if vogLoc == 0:
-                print "Timer says SDL set to 0, Hut call and Hub chair enabled"
+                print("Timer says SDL set to 0, Hut call and Hub chair enabled")
                 actCallbuttonEngHut.enable()
                 actHubChairClick.enable()
 
             elif vogLoc == 1:
-                print "Timer says SDL set to 1, Hut call and Hub call enabled"
+                print("Timer says SDL set to 1, Hut call and Hub call enabled")
                 actCallbuttonEngHut.enable()
                 actCallbuttonHub.enable()
 
                 respHubChairLower.run(self.key, state = "lower", fastforward = 1)
 
             elif vogLoc == 2:
-                print "Timer says SDL set to 2, Hut chair and Hub call enabled"
+                print("Timer says SDL set to 2, Hut chair and Hub call enabled")
                 actCallbuttonHub.enable()
                 actEngHutChairClick.enable()
 
@@ -660,11 +660,11 @@ class ahnyVogondolaRideV2(ptResponder):
                 respVogThrottle.run(self.key, state = "stop", fastforward = 1)
 
         elif id == 2:
-            print "timer id 2 returned...run responder"
+            print("timer id 2 returned...run responder")
             respHubChairLower.run(self.key, state = "raise")
 
         elif id == 3:
-            print "timer id 3 returned...run responder"
+            print("timer id 3 returned...run responder")
             respEngHutChairLower.run(self.key, state = "raise")
                 
 
@@ -672,7 +672,7 @@ class ahnyVogondolaRideV2(ptResponder):
         if not pageIn and self.occupant:
             avID = PtGetClientIDFromAvatarKey(avObj.getKey())
             if avID == PtGetClientIDFromAvatarKey(self.occupant.getKey()):
-                print "Vogondola rider left, enabling call buttons."
+                print("Vogondola rider left, enabling call buttons.")
                 actCallbuttonHub.enable()
                 actCallbuttonEngHut.enable()
                 sdl = PtGetAgeSDL()
@@ -680,16 +680,16 @@ class ahnyVogondolaRideV2(ptResponder):
                 self.occupant = None
 
     def OnNotify(self,state,id,events):
-        print "-------------------------------------------------"
-        print "     notify: id= %d    state= %d" % (id,state)
+        print("-------------------------------------------------")
+        print("     notify: id= %d    state= %d" % (id,state))
         if PtFindAvatar(events):
-            print "     notify: Trigger= %s    Self= %s" % (str(PtGetClientIDFromAvatarKey(PtFindAvatar(events).getKey())),str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey())))
-        print "     notify: events= %s" % (str(events))
-        print " "
+            print("     notify: Trigger= %s    Self= %s" % (str(PtGetClientIDFromAvatarKey(PtFindAvatar(events).getKey())),str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey()))))
+        print("     notify: events= %s" % (str(events)))
+        print(" ")
         
         if id == actHubChairClick.id and state:
             sdl = PtGetAgeSDL()
-            print "SETTING SDL TO 1"
+            print("SETTING SDL TO 1")
             sdl["ahnyVogLocation"] = (1,)
             sdl["ahnyVogOccupant"] = (PtFindAvatar(events).getKey(),)
             self.occupant = PtFindAvatar(events)
@@ -707,7 +707,7 @@ class ahnyVogondolaRideV2(ptResponder):
 
         elif id == actEngHutChairClick.id and state:
             sdl = PtGetAgeSDL()
-            print "SETTING SDL TO 1"
+            print("SETTING SDL TO 1")
             sdl["ahnyVogLocation"] = (1,)
             sdl["ahnyVogOccupant"] = (PtFindAvatar(events).getKey(),)
             self.occupant = PtFindAvatar(events)
@@ -724,38 +724,38 @@ class ahnyVogondolaRideV2(ptResponder):
                 self.currentBrain.OnNotify(state, id, events)
 
         elif id == actCallbuttonHub.id and state:
-            print "call button hub clicked"
+            print("call button hub clicked")
             VogondolaIsOccupied(1)
             respHubCallbutton.run(self.key, events = events)
             sdl = PtGetAgeSDL()
             if sdl["ahnyVogLocation"][0] == 2:
                 respEngHutChairLower.run(self.key, state = "lower")
 
-            print "SETTING SDL TO 0"
+            print("SETTING SDL TO 0")
             sdl["ahnyVogLocation"] = (0,)
 
         elif id == respHubCallbutton.id:
-            print "call button hub returned"
+            print("call button hub returned")
             PtAtTimeCallback(self.key, 5, 2)
 
         elif id == actCallbuttonEngHut.id and state:
-            print "call button hut clicked"
+            print("call button hut clicked")
             VogondolaIsOccupied(1)
             respEngHutCallbutton.run(self.key, events = events)
             sdl = PtGetAgeSDL()
             if sdl["ahnyVogLocation"][0] == 0:
                 respHubChairLower.run(self.key, state = "lower")
 
-            print "SETTING SDL TO 2"
+            print("SETTING SDL TO 2")
             sdl["ahnyVogLocation"] = (2,)
 
         elif id == respEngHutCallbutton.id:
-            print "call button hut returned"
+            print("call button hut returned")
             PtAtTimeCallback(self.key, 5, 3)
 
         elif id == respHubChairLower.id and self.currentBrain == None:
             if self.occupant == PtGetLocalAvatar():
-                print "Hub Chair came up, Hub chair enabled"
+                print("Hub Chair came up, Hub chair enabled")
                 actHubChairClick.enable()
 
                 cam = ptCamera()
@@ -766,12 +766,12 @@ class ahnyVogondolaRideV2(ptResponder):
             sdl = PtGetAgeSDL()
             sdl["ahnyVogOccupant"] = (0,)
             self.occupant = None
-            print "Hub Chair came up, Hut call enabled"
+            print("Hub Chair came up, Hut call enabled")
             actCallbuttonEngHut.enable()
             
         elif id == respEngHutChairLower.id and self.currentBrain == None:
             if self.occupant == PtGetLocalAvatar():
-                print "Hut Chair came up, Hut chair enabled"
+                print("Hut Chair came up, Hut chair enabled")
                 actEngHutChairClick.enable()
 
                 cam = ptCamera()
@@ -782,28 +782,28 @@ class ahnyVogondolaRideV2(ptResponder):
             sdl = PtGetAgeSDL()
             sdl["ahnyVogOccupant"] = (0,)
             self.occupant = None
-            print "Hut Chair came up, Hub call enabled"
+            print("Hut Chair came up, Hub call enabled")
             actCallbuttonHub.enable()
 
         elif (id == actStopVogSoundForward.id or id == actStopVogSoundBackward.id) and state:
             #DisableVogControls()
             actStopVogSoundForward.disable()
             actStopVogSoundBackward.disable()
-            print "running respSounds: state - stop loc - anim event det", id, state
+            print("running respSounds: state - stop loc - anim event det", id, state)
             respSounds.run(self.key, state = "stop")
 
         else:
             if self.currentBrain != None:
-                print "passing event on to sub-brain"
+                print("passing event on to sub-brain")
                 self.currentBrain.OnNotify(state, id, events)
 
     def OnBackdoorMsg(self, target, param):
         if target == "vog":
             if param == "currentbrain":
                 if self.currentBrain == None:
-                    print "Vog Current Brain: None"
+                    print("Vog Current Brain: None")
                 else:
-                    print "Vog Current Brain:", self.currentBrain.name
+                    print("Vog Current Brain:", self.currentBrain.name)
 
             elif param == "beh":
                 avatar = PtGetLocalAvatar()

--- a/Python/ahnyVogondolaRideV2.py
+++ b/Python/ahnyVogondolaRideV2.py
@@ -179,22 +179,22 @@ def DisableVogControls( enabledControlList ):
 
 def VogondolaIsOccupied( occupant ):
     if occupant:
-        print("ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got in the Vog, disabling all access points")
+        PtDebugPrint("ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got in the Vog, disabling all access points")
         
         actHubChairClick.disable()
         actEngHutChairClick.disable()
         actCallbuttonHub.disable()
         actCallbuttonEngHut.disable()
     else:
-        print("ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got out of the Vog, enabling all access points")
+        PtDebugPrint("ahnyVogondolaRideV2.VogondolaIsOccupied(): Someone got out of the Vog, enabling all access points")
         
         sdl = PtGetAgeSDL()
         vogLoc = sdl["ahnyVogLocation"][0]
         if vogLoc == 0:
-            print("SDL set to 0, Hub Chair enabled")
+            PtDebugPrint("SDL set to 0, Hub Chair enabled")
             actHubChairClick.enable()
         elif vogLoc == 2:
-            print("SDL set to 2, Hut Chair enabled")
+            PtDebugPrint("SDL set to 2, Hut Chair enabled")
             actEngHutChairClick.enable()
 
 # brains - these determine what happens at the various stages
@@ -203,7 +203,7 @@ class InHubBrain:
         self.parent = parent
         self.name = "In Hub Brain"
 
-        print("initing", self.name)
+        PtDebugPrint("initing", self.name)
 
         PtDisableMovementKeys()
 
@@ -218,7 +218,7 @@ class InHubBrain:
 
     def OnNotify(self, state, id, events):
         if id == actHubChairClick.id and state:
-            print("Hub Brain says Hub Chair clicked, disable Hub Chair")
+            PtDebugPrint("Hub Brain says Hub Chair clicked, disable Hub Chair")
             actHubChairClick.disable()
 
             avatar = PtFindAvatar(events)
@@ -228,13 +228,13 @@ class InHubBrain:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage:
                     respHubChairLower.run(self.parent.key, events = events, state = "lower")
-                    print(self.name + ": finished smart-seek")
+                    PtDebugPrint(self.name + ": finished smart-seek")
                     
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
                     theAvatar = PtGetLocalAvatar()
                     theAvatar.avatar.enterSubWorld(soVogSubworld.value)
                     theAvatar.physics.warpObj(soVogDummy.value.getKey())
-                    print(self.name + ": pinned avatar")
+                    PtDebugPrint(self.name + ": pinned avatar")
                     respVogChairLower.run(self.parent.key, events = events)
                     
         elif id == actVogDirection.id and state:
@@ -256,7 +256,7 @@ class InHubBrain:
             respVogEjectHub.run(self.parent.key, state = "norotate")
 
             sdl = PtGetAgeSDL()
-            print("SETTING SDL TO 0")
+            PtDebugPrint("SETTING SDL TO 0")
             sdl["ahnyVogLocation"] = (0,)
 
         elif id == actVogEjectRear.id and state:
@@ -264,7 +264,7 @@ class InHubBrain:
             respVogEjectHub.run(self.parent.key, state = "rotate")
 
             sdl = PtGetAgeSDL()
-            print("SETTING SDL TO 0")
+            PtDebugPrint("SETTING SDL TO 0")
             sdl["ahnyVogLocation"] = (0,)
 
         elif id == actVogThrottleB.id and state:
@@ -272,7 +272,7 @@ class InHubBrain:
             respVogRideStart.run(self.parent.key)
 
         elif id == respVogRideStart.id:
-            print("running respSounds: state - hubtubeout loc - hub brain respvogridestart")
+            PtDebugPrint("running respSounds: state - hubtubeout loc - hub brain respvogridestart")
             respSounds.run(self.parent.key, state = "hubtubeout")
 
         elif id == actTubeEndFromHub.id:
@@ -291,14 +291,14 @@ class InHubBrain:
 
             self.parent.currentBrain = None
             PtEnableMovementKeys()
-            print("ejecting finished in vog at hub...setting current brain to none")
+            PtDebugPrint("ejecting finished in vog at hub...setting current brain to none")
 
 class HubSailTubeTransitionBrain:
     def __init__(self, parent):
         self.parent = parent
         self.name = "Hub Sail Tube Transition Brain"
 
-        print("initing", self.name)
+        PtDebugPrint("initing", self.name)
 
 
         enabledControlList = [actVogThrottleB, actVogThrottleRevB]
@@ -340,7 +340,7 @@ class HubSailTubeTransitionBrain:
             respVogRideStartRev.run(self.parent.key)
 
         elif id == respVogRideStartRev.id:
-            print("running respSounds: state - hubtubein loc - hubtransistion respvogridestartrev")
+            PtDebugPrint("running respSounds: state - hubtubein loc - hubtransistion respvogridestartrev")
             respSounds.run(self.parent.key, state = "hubtubein")
 
         #elif (id == respVogRideStop.id or id == respVogRideStopRev.id) and self.parent.direction == -1:
@@ -357,7 +357,7 @@ class SailingBrain:
         self.parent = parent
         self.name = "Sailing Brain"
 
-        print("initing", self.name)
+        PtDebugPrint("initing", self.name)
 
         enabledControlList = None
 
@@ -382,7 +382,7 @@ class SailingBrain:
             DisableVogControls( enabledControlList )
 
         elif id == respVogRideStop.id or id == respVogRideStopRev.id:
-            print("vog ride stop notify")
+            PtDebugPrint("vog ride stop notify")
             respSounds.run(self.parent.key, state = "stop")
 
         elif id == actVogDirection.id and state:
@@ -412,11 +412,11 @@ class SailingBrain:
             #respSounds.run(self.parent.key, state = "sailtohub")
 
         elif id == respVogRideStart.id:
-            print("running respSounds: state - sailtohut loc - sail brain vogridestart")
+            PtDebugPrint("running respSounds: state - sailtohut loc - sail brain vogridestart")
             respSounds.run(self.parent.key, state = "sailtohut")
 
         elif id == respVogRideStartRev.id:
-            print("running respSounds: state - sailtohub loc - sail brain vogridestartrev")
+            PtDebugPrint("running respSounds: state - sailtohub loc - sail brain vogridestartrev")
             respSounds.run(self.parent.key, state = "sailtohub")
 
         elif id == actSailEndToEngHut.id and self.parent.direction == 1:
@@ -438,7 +438,7 @@ class EngHutSailTubeTransitionBrain:
         self.parent = parent
         self.name = "Eng Hut Sail Tube Transition Brain"
 
-        print("initing", self.name)
+        PtDebugPrint("initing", self.name)
 
         enabledControlList = [actVogThrottleB, actVogThrottleRevB]
 
@@ -482,7 +482,7 @@ class EngHutSailTubeTransitionBrain:
             respVogRideStart.run(self.parent.key)
 
         elif id == respVogRideStart.id:
-            print("running respSounds: state - huttubein loc - hut transition vogridestart")
+            PtDebugPrint("running respSounds: state - huttubein loc - hut transition vogridestart")
             respSounds.run(self.parent.key, state = "huttubein")
 
         elif id == actEngHutRideEnd.id:
@@ -496,7 +496,7 @@ class InEngHutBrain:
         self.parent = parent
         self.name = "In Eng Hut Brain"
 
-        print("initing", self.name)
+        PtDebugPrint("initing", self.name)
 
         PtDisableMovementKeys()
 
@@ -511,7 +511,7 @@ class InEngHutBrain:
 
     def OnNotify(self, state, id, events):
         if id == actEngHutChairClick.id and state:
-            print("Hut Brain says Hut Chair clicked, disable Hut Chair")
+            PtDebugPrint("Hut Brain says Hut Chair clicked, disable Hut Chair")
             actEngHutChairClick.disable()
 
             avatar = PtFindAvatar(events)
@@ -521,13 +521,13 @@ class InEngHutBrain:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage:
                     respEngHutChairLower.run(self.parent.key, events = events, state = "lower")
-                    print(self.name + ": finished smart-seek")
+                    PtDebugPrint(self.name + ": finished smart-seek")
                     
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
                     theAvatar = PtGetLocalAvatar()
                     theAvatar.avatar.enterSubWorld(soVogSubworld.value)
                     theAvatar.physics.warpObj(soVogDummy.value.getKey())
-                    print(self.name + ": pinned avatar")
+                    PtDebugPrint(self.name + ": pinned avatar")
                     respVogChairLower.run(self.parent.key, events = events)
                     
         elif id == actVogDirection.id and state:
@@ -551,7 +551,7 @@ class InEngHutBrain:
             #theAvatar.draw.disable()
             
             sdl = PtGetAgeSDL()
-            print("SETTING SDL TO 2")
+            PtDebugPrint("SETTING SDL TO 2")
             sdl["ahnyVogLocation"] = (2,)
 
         elif id == actVogEjectRear.id and state:
@@ -559,7 +559,7 @@ class InEngHutBrain:
             respVogEjectEngHut.run(self.parent.key, state = "rotate")
 
             sdl = PtGetAgeSDL()
-            print("SETTING SDL TO 2")
+            PtDebugPrint("SETTING SDL TO 2")
             sdl["ahnyVogLocation"] = (2,)
 
         elif id == actVogThrottleRevB.id and state:
@@ -568,7 +568,7 @@ class InEngHutBrain:
             #respSounds.run(self.parent.key, state = "huttubeout")
 
         elif id == respVogRideStartRev.id:
-            print("running respSounds: huttubeout - stop loc - hut brain vogridestartrev")
+            PtDebugPrint("running respSounds: huttubeout - stop loc - hut brain vogridestartrev")
             respSounds.run(self.parent.key, state = "huttubeout")
 
         elif id == actTubeEndFromEngHut.id:
@@ -587,7 +587,7 @@ class InEngHutBrain:
             self.parent.currentBrain = None
             PtEnableMovementKeys()
             #theAvatar.draw.enable()
-            print("ejecting finished in vog at eng hut...setting current brain to none")
+            PtDebugPrint("ejecting finished in vog at eng hut...setting current brain to none")
 
 
 # main class
@@ -601,13 +601,13 @@ class ahnyVogondolaRideV2(ptResponder):
         self.direction = 1
         self.throttle = 0
         self.occupant = None
-        print("Init: ahnyVogondolaRideV2")
+        PtDebugPrint("Init: ahnyVogondolaRideV2")
 
     def OnFirstUpdate(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("uh oh... no SDL! Prepare to have lots of bugs.")
+            PtDebugPrint("uh oh... no SDL! Prepare to have lots of bugs.")
 
         ageSDL = PtGetAgeSDL()
         ageSDL.setFlags("ahnyVogLocation",1,1)
@@ -618,17 +618,17 @@ class ahnyVogondolaRideV2(ptResponder):
         ageSDL.sendToClients("ahnyVogOccupant")
         ageSDL.setNotify(self.key,"ahnyVogOccupant",0.0)
         
-        print("First Update, all buttons disabled")
+        PtDebugPrint("First Update, all buttons disabled")
         actCallbuttonHub.disable()
         actCallbuttonEngHut.disable()
         actHubChairClick.disable()
         actEngHutChairClick.disable()
         
         if ageSDL["ahnyVogOccupant"][0]:
-            print("%d is in the Vogondola" % (ageSDL["ahnyVogOccupant"][0]))
+            PtDebugPrint("%d is in the Vogondola" % (ageSDL["ahnyVogOccupant"][0]))
             self.occupant = ageSDL["ahnyVogOccupant"][0]
         else:
-            print("Vogondola is empty")
+            PtDebugPrint("Vogondola is empty")
             PtAtTimeCallback(self.key, 0, 1)
 
     def OnTimer(self, id):
@@ -638,19 +638,19 @@ class ahnyVogondolaRideV2(ptResponder):
 
             # vogLoc: 0 = hub, 1 = in between, 2 = eng hut
             if vogLoc == 0:
-                print("Timer says SDL set to 0, Hut call and Hub chair enabled")
+                PtDebugPrint("Timer says SDL set to 0, Hut call and Hub chair enabled")
                 actCallbuttonEngHut.enable()
                 actHubChairClick.enable()
 
             elif vogLoc == 1:
-                print("Timer says SDL set to 1, Hut call and Hub call enabled")
+                PtDebugPrint("Timer says SDL set to 1, Hut call and Hub call enabled")
                 actCallbuttonEngHut.enable()
                 actCallbuttonHub.enable()
 
                 respHubChairLower.run(self.key, state = "lower", fastforward = 1)
 
             elif vogLoc == 2:
-                print("Timer says SDL set to 2, Hut chair and Hub call enabled")
+                PtDebugPrint("Timer says SDL set to 2, Hut chair and Hub call enabled")
                 actCallbuttonHub.enable()
                 actEngHutChairClick.enable()
 
@@ -660,11 +660,11 @@ class ahnyVogondolaRideV2(ptResponder):
                 respVogThrottle.run(self.key, state = "stop", fastforward = 1)
 
         elif id == 2:
-            print("timer id 2 returned...run responder")
+            PtDebugPrint("timer id 2 returned...run responder")
             respHubChairLower.run(self.key, state = "raise")
 
         elif id == 3:
-            print("timer id 3 returned...run responder")
+            PtDebugPrint("timer id 3 returned...run responder")
             respEngHutChairLower.run(self.key, state = "raise")
                 
 
@@ -672,7 +672,7 @@ class ahnyVogondolaRideV2(ptResponder):
         if not pageIn and self.occupant:
             avID = PtGetClientIDFromAvatarKey(avObj.getKey())
             if avID == PtGetClientIDFromAvatarKey(self.occupant.getKey()):
-                print("Vogondola rider left, enabling call buttons.")
+                PtDebugPrint("Vogondola rider left, enabling call buttons.")
                 actCallbuttonHub.enable()
                 actCallbuttonEngHut.enable()
                 sdl = PtGetAgeSDL()
@@ -680,16 +680,16 @@ class ahnyVogondolaRideV2(ptResponder):
                 self.occupant = None
 
     def OnNotify(self,state,id,events):
-        print("-------------------------------------------------")
-        print("     notify: id= %d    state= %d" % (id,state))
+        PtDebugPrint("-------------------------------------------------")
+        PtDebugPrint("     notify: id= %d    state= %d" % (id,state))
         if PtFindAvatar(events):
-            print("     notify: Trigger= %s    Self= %s" % (str(PtGetClientIDFromAvatarKey(PtFindAvatar(events).getKey())),str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey()))))
-        print("     notify: events= %s" % (str(events)))
-        print(" ")
+            PtDebugPrint("     notify: Trigger= %s    Self= %s" % (str(PtGetClientIDFromAvatarKey(PtFindAvatar(events).getKey())),str(PtGetClientIDFromAvatarKey(PtGetLocalAvatar().getKey()))))
+        PtDebugPrint("     notify: events= %s" % (str(events)))
+        PtDebugPrint(" ")
         
         if id == actHubChairClick.id and state:
             sdl = PtGetAgeSDL()
-            print("SETTING SDL TO 1")
+            PtDebugPrint("SETTING SDL TO 1")
             sdl["ahnyVogLocation"] = (1,)
             sdl["ahnyVogOccupant"] = (PtFindAvatar(events).getKey(),)
             self.occupant = PtFindAvatar(events)
@@ -707,7 +707,7 @@ class ahnyVogondolaRideV2(ptResponder):
 
         elif id == actEngHutChairClick.id and state:
             sdl = PtGetAgeSDL()
-            print("SETTING SDL TO 1")
+            PtDebugPrint("SETTING SDL TO 1")
             sdl["ahnyVogLocation"] = (1,)
             sdl["ahnyVogOccupant"] = (PtFindAvatar(events).getKey(),)
             self.occupant = PtFindAvatar(events)
@@ -724,38 +724,38 @@ class ahnyVogondolaRideV2(ptResponder):
                 self.currentBrain.OnNotify(state, id, events)
 
         elif id == actCallbuttonHub.id and state:
-            print("call button hub clicked")
+            PtDebugPrint("call button hub clicked")
             VogondolaIsOccupied(1)
             respHubCallbutton.run(self.key, events = events)
             sdl = PtGetAgeSDL()
             if sdl["ahnyVogLocation"][0] == 2:
                 respEngHutChairLower.run(self.key, state = "lower")
 
-            print("SETTING SDL TO 0")
+            PtDebugPrint("SETTING SDL TO 0")
             sdl["ahnyVogLocation"] = (0,)
 
         elif id == respHubCallbutton.id:
-            print("call button hub returned")
+            PtDebugPrint("call button hub returned")
             PtAtTimeCallback(self.key, 5, 2)
 
         elif id == actCallbuttonEngHut.id and state:
-            print("call button hut clicked")
+            PtDebugPrint("call button hut clicked")
             VogondolaIsOccupied(1)
             respEngHutCallbutton.run(self.key, events = events)
             sdl = PtGetAgeSDL()
             if sdl["ahnyVogLocation"][0] == 0:
                 respHubChairLower.run(self.key, state = "lower")
 
-            print("SETTING SDL TO 2")
+            PtDebugPrint("SETTING SDL TO 2")
             sdl["ahnyVogLocation"] = (2,)
 
         elif id == respEngHutCallbutton.id:
-            print("call button hut returned")
+            PtDebugPrint("call button hut returned")
             PtAtTimeCallback(self.key, 5, 3)
 
         elif id == respHubChairLower.id and self.currentBrain == None:
             if self.occupant == PtGetLocalAvatar():
-                print("Hub Chair came up, Hub chair enabled")
+                PtDebugPrint("Hub Chair came up, Hub chair enabled")
                 actHubChairClick.enable()
 
                 cam = ptCamera()
@@ -766,12 +766,12 @@ class ahnyVogondolaRideV2(ptResponder):
             sdl = PtGetAgeSDL()
             sdl["ahnyVogOccupant"] = (0,)
             self.occupant = None
-            print("Hub Chair came up, Hut call enabled")
+            PtDebugPrint("Hub Chair came up, Hut call enabled")
             actCallbuttonEngHut.enable()
             
         elif id == respEngHutChairLower.id and self.currentBrain == None:
             if self.occupant == PtGetLocalAvatar():
-                print("Hut Chair came up, Hut chair enabled")
+                PtDebugPrint("Hut Chair came up, Hut chair enabled")
                 actEngHutChairClick.enable()
 
                 cam = ptCamera()
@@ -782,28 +782,28 @@ class ahnyVogondolaRideV2(ptResponder):
             sdl = PtGetAgeSDL()
             sdl["ahnyVogOccupant"] = (0,)
             self.occupant = None
-            print("Hut Chair came up, Hub call enabled")
+            PtDebugPrint("Hut Chair came up, Hub call enabled")
             actCallbuttonHub.enable()
 
         elif (id == actStopVogSoundForward.id or id == actStopVogSoundBackward.id) and state:
             #DisableVogControls()
             actStopVogSoundForward.disable()
             actStopVogSoundBackward.disable()
-            print("running respSounds: state - stop loc - anim event det", id, state)
+            PtDebugPrint("running respSounds: state - stop loc - anim event det", id, state)
             respSounds.run(self.key, state = "stop")
 
         else:
             if self.currentBrain != None:
-                print("passing event on to sub-brain")
+                PtDebugPrint("passing event on to sub-brain")
                 self.currentBrain.OnNotify(state, id, events)
 
     def OnBackdoorMsg(self, target, param):
         if target == "vog":
             if param == "currentbrain":
                 if self.currentBrain == None:
-                    print("Vog Current Brain: None")
+                    PtDebugPrint("Vog Current Brain: None")
                 else:
-                    print("Vog Current Brain:", self.currentBrain.name)
+                    PtDebugPrint("Vog Current Brain:", self.currentBrain.name)
 
             elif param == "beh":
                 avatar = PtGetLocalAvatar()

--- a/Python/airstream.py
+++ b/Python/airstream.py
@@ -57,7 +57,7 @@ class airstream(ptResponder):
         self.id = 50439
         self.version = 1
         
-        print "__init__airstream v."
+        print("__init__airstream v.")
 
                         
     def OnNotify(self,state,id,events):

--- a/Python/airstream.py
+++ b/Python/airstream.py
@@ -57,7 +57,7 @@ class airstream(ptResponder):
         self.id = 50439
         self.version = 1
         
-        print("__init__airstream v.")
+        PtDebugPrint("__init__airstream v.")
 
                         
     def OnNotify(self,state,id,events):

--- a/Python/bhroBahroBlueSpiral.py
+++ b/Python/bhroBahroBlueSpiral.py
@@ -69,7 +69,7 @@ class bhroBahroBlueSpiral(ptResponder):
         ptResponder.__init__(self)
         self.id = 8813
         self.version = 1
-        print "bhroBahroBlueSpiral: init  version = %d" % self.version
+        print("bhroBahroBlueSpiral: init  version = %d" % self.version)
 
     ###########################
     def __del__(self):
@@ -86,7 +86,7 @@ class bhroBahroBlueSpiral(ptResponder):
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
         ageFrom = PtGetPrevAgeName()
-        print "bhroBahroBlueSpiral.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom)
+        print("bhroBahroBlueSpiral.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
         if ageFrom == "EderTsogal":
             respWedges.run(self.key, state="Delin", fastforward=1)
 
@@ -104,20 +104,20 @@ class bhroBahroBlueSpiral(ptResponder):
         #print "bhroBahroBlueSpiral.OnNotify: state=%s id=%d events=" % (state, id), events
 
         if id == clkBSTsogal.id and not state:
-            print "bhroBahroBlueSpiral.OnNotify: clicked Tsogal Spiral"
+            print("bhroBahroBlueSpiral.OnNotify: clicked Tsogal Spiral")
             respRings.run(self.key, state="Tsogal", avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge06"][0]
             if not sdlVal:
-                print "bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge06 to On"
+                print("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge06 to On")
                 psnlSDL["psnlBahroWedge06"] = (1,)
 
         elif id == clkBSDelin.id and not state:
-            print "bhroBahroBlueSpiral.OnNotify: clicked Delin Spiral"
+            print("bhroBahroBlueSpiral.OnNotify: clicked Delin Spiral")
             respRings.run(self.key, state="Delin", avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge05"][0]
             if not sdlVal:
-                print "bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge05 to On"
+                print("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge05 to On")
                 psnlSDL["psnlBahroWedge05"] = (1,)
 

--- a/Python/bhroBahroBlueSpiral.py
+++ b/Python/bhroBahroBlueSpiral.py
@@ -69,7 +69,7 @@ class bhroBahroBlueSpiral(ptResponder):
         ptResponder.__init__(self)
         self.id = 8813
         self.version = 1
-        print("bhroBahroBlueSpiral: init  version = %d" % self.version)
+        PtDebugPrint("bhroBahroBlueSpiral: init  version = %d" % self.version)
 
     ###########################
     def __del__(self):
@@ -86,7 +86,7 @@ class bhroBahroBlueSpiral(ptResponder):
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
         ageFrom = PtGetPrevAgeName()
-        print("bhroBahroBlueSpiral.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
+        PtDebugPrint("bhroBahroBlueSpiral.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
         if ageFrom == "EderTsogal":
             respWedges.run(self.key, state="Delin", fastforward=1)
 
@@ -101,23 +101,23 @@ class bhroBahroBlueSpiral(ptResponder):
 
     ###########################
     def OnNotify(self,state,id,events):
-        #print "bhroBahroBlueSpiral.OnNotify: state=%s id=%d events=" % (state, id), events
+        #PtDebugPrint("bhroBahroBlueSpiral.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == clkBSTsogal.id and not state:
-            print("bhroBahroBlueSpiral.OnNotify: clicked Tsogal Spiral")
+            PtDebugPrint("bhroBahroBlueSpiral.OnNotify: clicked Tsogal Spiral")
             respRings.run(self.key, state="Tsogal", avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge06"][0]
             if not sdlVal:
-                print("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge06 to On")
+                PtDebugPrint("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge06 to On")
                 psnlSDL["psnlBahroWedge06"] = (1,)
 
         elif id == clkBSDelin.id and not state:
-            print("bhroBahroBlueSpiral.OnNotify: clicked Delin Spiral")
+            PtDebugPrint("bhroBahroBlueSpiral.OnNotify: clicked Delin Spiral")
             respRings.run(self.key, state="Delin", avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge05"][0]
             if not sdlVal:
-                print("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge05 to On")
+                PtDebugPrint("bhroBahroBlueSpiral.OnNotify:  Tturning wedge SDL of psnlBahroWedge05 to On")
                 psnlSDL["psnlBahroWedge05"] = (1,)
 

--- a/Python/bhroBahroMink.py
+++ b/Python/bhroBahroMink.py
@@ -66,7 +66,7 @@ class bhroBahroMink(ptResponder):
         ptResponder.__init__(self)
         self.id = 8815
         self.version = 1
-        print "bhroBahroMink: init  version = %d" % self.version
+        print("bhroBahroMink: init  version = %d" % self.version)
 
     ###########################
     def __del__(self):
@@ -82,10 +82,10 @@ class bhroBahroMink(ptResponder):
     ###########################
     def OnServerInitComplete(self):
         psnlSDL = xPsnlVaultSDL()
-        print psnlSDL["psnlBahroWedge11"][0]
+        print(psnlSDL["psnlBahroWedge11"][0])
 
         if psnlSDL["psnlBahroWedge11"][0]:
-            print "bhroBahroMink.OnServerInitComplete: You have the Minkata wedge, no need to display it."
+            print("bhroBahroMink.OnServerInitComplete: You have the Minkata wedge, no need to display it.")
             respRing.run(self.key, fastforward=1)
 
     ###########################
@@ -93,10 +93,10 @@ class bhroBahroMink(ptResponder):
         #print "bhroBahroMink.OnNotify: state=%s id=%d events=" % (state, id), events
 
         if id == clickable.id and not state:
-            print "bhroBahroMink.OnNotify: clicked Minkata Spiral"
+            print("bhroBahroMink.OnNotify: clicked Minkata Spiral")
             respRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge11"][0]
             if not sdlVal:
-                print "bhroBahroMink.OnNotify:  Turning wedge SDL of psnlBahroWedge11 to On"
+                print("bhroBahroMink.OnNotify:  Turning wedge SDL of psnlBahroWedge11 to On")
                 psnlSDL["psnlBahroWedge11"] = (1,)

--- a/Python/bhroBahroMink.py
+++ b/Python/bhroBahroMink.py
@@ -66,7 +66,7 @@ class bhroBahroMink(ptResponder):
         ptResponder.__init__(self)
         self.id = 8815
         self.version = 1
-        print("bhroBahroMink: init  version = %d" % self.version)
+        PtDebugPrint("bhroBahroMink: init  version = %d" % self.version)
 
     ###########################
     def __del__(self):
@@ -82,21 +82,21 @@ class bhroBahroMink(ptResponder):
     ###########################
     def OnServerInitComplete(self):
         psnlSDL = xPsnlVaultSDL()
-        print(psnlSDL["psnlBahroWedge11"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge11"][0])
 
         if psnlSDL["psnlBahroWedge11"][0]:
-            print("bhroBahroMink.OnServerInitComplete: You have the Minkata wedge, no need to display it.")
+            PtDebugPrint("bhroBahroMink.OnServerInitComplete: You have the Minkata wedge, no need to display it.")
             respRing.run(self.key, fastforward=1)
 
     ###########################
     def OnNotify(self,state,id,events):
-        #print "bhroBahroMink.OnNotify: state=%s id=%d events=" % (state, id), events
+        #PtDebugPrint("bhroBahroMink.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == clickable.id and not state:
-            print("bhroBahroMink.OnNotify: clicked Minkata Spiral")
+            PtDebugPrint("bhroBahroMink.OnNotify: clicked Minkata Spiral")
             respRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge11"][0]
             if not sdlVal:
-                print("bhroBahroMink.OnNotify:  Turning wedge SDL of psnlBahroWedge11 to On")
+                PtDebugPrint("bhroBahroMink.OnNotify:  Turning wedge SDL of psnlBahroWedge11 to On")
                 psnlSDL["psnlBahroWedge11"] = (1,)

--- a/Python/bhroBahroPOTS.py
+++ b/Python/bhroBahroPOTS.py
@@ -66,7 +66,7 @@ class bhroBahroPOTS(ptResponder):
         ptResponder.__init__(self)
         self.id = 8816
         self.version = 1
-        print "bhroBahroPOTS: init  version = %d" % self.version
+        print("bhroBahroPOTS: init  version = %d" % self.version)
 
 
     def OnFirstUpdate(self):
@@ -79,21 +79,21 @@ class bhroBahroPOTS(ptResponder):
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
         ageFrom = PtGetPrevAgeName()
-        print "bhroBahroPOTS.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom)
+        print("bhroBahroPOTS.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
         if ageFrom == "Ercana":
             respWedges.run(self.key, state="Ahnonay", fastforward=1)
         elif ageFrom == "Ahnonay":
             respWedges.run(self.key, state="Ercana", fastforward=1)
 
         psnlSDL = xPsnlVaultSDL()
-        print psnlSDL["psnlBahroWedge12"][0]
-        print psnlSDL["psnlBahroWedge13"][0]
+        print(psnlSDL["psnlBahroWedge12"][0])
+        print(psnlSDL["psnlBahroWedge13"][0])
 
         if psnlSDL["psnlBahroWedge12"][0]:
-            print "bhroBahroPOTS.OnServerInitComplete: You have the Ercana wedge, no need to display it."
+            print("bhroBahroPOTS.OnServerInitComplete: You have the Ercana wedge, no need to display it.")
             respErcanaRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge13"][0]:
-            print "bhroBahroPOTS.OnServerInitComplete: You have the Ahnonay wedge, no need to display it."
+            print("bhroBahroPOTS.OnServerInitComplete: You have the Ahnonay wedge, no need to display it.")
             respAhnonayRing.run(self.key, fastforward=1)
 
 
@@ -101,21 +101,21 @@ class bhroBahroPOTS(ptResponder):
         #print "bhroBahroPOTS.OnNotify: state=%s id=%d events=" % (state, id), events
 
         if id == clkErcana.id and state:
-            print "bhroBahroPOTS.OnNotify: clicked Ercana symbol"
+            print("bhroBahroPOTS.OnNotify: clicked Ercana symbol")
             respErcanaRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge12"][0]
             if not sdlVal:
-                print "bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge12 to On"
+                print("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge12 to On")
                 psnlSDL["psnlBahroWedge12"] = (1,)
 
         elif id == clkAhnonay.id and state:
-            print "bhroBahroPOTS.OnNotify: clicked Ahnonay symbol"
+            print("bhroBahroPOTS.OnNotify: clicked Ahnonay symbol")
             respAhnonayRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge13"][0]
             if not sdlVal:
-                print "bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge13 to On"
+                print("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge13 to On")
                 psnlSDL["psnlBahroWedge13"] = (1,)
 
 

--- a/Python/bhroBahroPOTS.py
+++ b/Python/bhroBahroPOTS.py
@@ -66,7 +66,7 @@ class bhroBahroPOTS(ptResponder):
         ptResponder.__init__(self)
         self.id = 8816
         self.version = 1
-        print("bhroBahroPOTS: init  version = %d" % self.version)
+        PtDebugPrint("bhroBahroPOTS: init  version = %d" % self.version)
 
 
     def OnFirstUpdate(self):
@@ -79,43 +79,43 @@ class bhroBahroPOTS(ptResponder):
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
         ageFrom = PtGetPrevAgeName()
-        print("bhroBahroPOTS.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
+        PtDebugPrint("bhroBahroPOTS.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
         if ageFrom == "Ercana":
             respWedges.run(self.key, state="Ahnonay", fastforward=1)
         elif ageFrom == "Ahnonay":
             respWedges.run(self.key, state="Ercana", fastforward=1)
 
         psnlSDL = xPsnlVaultSDL()
-        print(psnlSDL["psnlBahroWedge12"][0])
-        print(psnlSDL["psnlBahroWedge13"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge12"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge13"][0])
 
         if psnlSDL["psnlBahroWedge12"][0]:
-            print("bhroBahroPOTS.OnServerInitComplete: You have the Ercana wedge, no need to display it.")
+            PtDebugPrint("bhroBahroPOTS.OnServerInitComplete: You have the Ercana wedge, no need to display it.")
             respErcanaRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge13"][0]:
-            print("bhroBahroPOTS.OnServerInitComplete: You have the Ahnonay wedge, no need to display it.")
+            PtDebugPrint("bhroBahroPOTS.OnServerInitComplete: You have the Ahnonay wedge, no need to display it.")
             respAhnonayRing.run(self.key, fastforward=1)
 
 
     def OnNotify(self,state,id,events):
-        #print "bhroBahroPOTS.OnNotify: state=%s id=%d events=" % (state, id), events
+        #PtDebugPrint("bhroBahroPOTS.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == clkErcana.id and state:
-            print("bhroBahroPOTS.OnNotify: clicked Ercana symbol")
+            PtDebugPrint("bhroBahroPOTS.OnNotify: clicked Ercana symbol")
             respErcanaRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge12"][0]
             if not sdlVal:
-                print("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge12 to On")
+                PtDebugPrint("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge12 to On")
                 psnlSDL["psnlBahroWedge12"] = (1,)
 
         elif id == clkAhnonay.id and state:
-            print("bhroBahroPOTS.OnNotify: clicked Ahnonay symbol")
+            PtDebugPrint("bhroBahroPOTS.OnNotify: clicked Ahnonay symbol")
             respAhnonayRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge13"][0]
             if not sdlVal:
-                print("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge13 to On")
+                PtDebugPrint("bhroBahroPOTS.OnNotify:  Turning wedge SDL of psnlBahroWedge13 to On")
                 psnlSDL["psnlBahroWedge13"] = (1,)
 
 

--- a/Python/bhroBahroPod.py
+++ b/Python/bhroBahroPod.py
@@ -74,7 +74,7 @@ class bhroBahroPod(ptResponder):
         ptResponder.__init__(self)
         self.id = 8814
         self.version = 1
-        print "bhroBahroPod: init  version = %d" % self.version
+        print("bhroBahroPod: init  version = %d" % self.version)
 
     ###########################
     def __del__(self):
@@ -91,7 +91,7 @@ class bhroBahroPod(ptResponder):
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
         ageFrom = PtGetPrevAgeName()
-        print "bhroBahroPod.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom)
+        print("bhroBahroPod.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
         if ageFrom == "Negilahn":
             respWedges.run(self.key, state="Dereno", fastforward=1)
             respWedges.run(self.key, state="Payiferen", fastforward=1)
@@ -113,22 +113,22 @@ class bhroBahroPod(ptResponder):
             respWedges.run(self.key, state="Payiferen", fastforward=1)
 
         psnlSDL = xPsnlVaultSDL()
-        print psnlSDL["psnlBahroWedge07"][0]
-        print psnlSDL["psnlBahroWedge08"][0]
-        print psnlSDL["psnlBahroWedge09"][0]
-        print psnlSDL["psnlBahroWedge10"][0]
+        print(psnlSDL["psnlBahroWedge07"][0])
+        print(psnlSDL["psnlBahroWedge08"][0])
+        print(psnlSDL["psnlBahroWedge09"][0])
+        print(psnlSDL["psnlBahroWedge10"][0])
 
         if psnlSDL["psnlBahroWedge07"][0]:
-            print "bhroBahroPod.OnServerInitComplete: You have the Negilahn wedge, no need to display it."
+            print("bhroBahroPod.OnServerInitComplete: You have the Negilahn wedge, no need to display it.")
             respNegilahnRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge08"][0]:
-            print "bhroBahroPod.OnServerInitComplete: You have the Dereno wedge, no need to display it."
+            print("bhroBahroPod.OnServerInitComplete: You have the Dereno wedge, no need to display it.")
             respDerenoRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge09"][0]:
-            print "bhroBahroPod.OnServerInitComplete: You have the Payiferen wedge, no need to display it."
+            print("bhroBahroPod.OnServerInitComplete: You have the Payiferen wedge, no need to display it.")
             respPayiferenRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge10"][0]:
-            print "bhroBahroPod.OnServerInitComplete: You have the Tetsonot wedge, no need to display it."
+            print("bhroBahroPod.OnServerInitComplete: You have the Tetsonot wedge, no need to display it.")
             respTetsonotRing.run(self.key, fastforward=1)
 
     ###########################
@@ -136,38 +136,38 @@ class bhroBahroPod(ptResponder):
         #print "bhroBahroPod.OnNotify: state=%s id=%d events=" % (state, id), events
 
         if id == clkNegilahn.id and not state:
-            print "bhroBahroPod.OnNotify: clicked Negilahn Spiral"
+            print("bhroBahroPod.OnNotify: clicked Negilahn Spiral")
             respNegilahnRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge07"][0]
             if not sdlVal:
-                print "bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge07 to On"
+                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge07 to On")
                 psnlSDL["psnlBahroWedge07"] = (1,)
 
         elif id == clkDereno.id and not state:
-            print "bhroBahroPod.OnNotify: clicked Dereno Spiral"
+            print("bhroBahroPod.OnNotify: clicked Dereno Spiral")
             respDerenoRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge08"][0]
             if not sdlVal:
-                print "bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge08 to On"
+                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge08 to On")
                 psnlSDL["psnlBahroWedge08"] = (1,)
 
         elif id == clkPayiferen.id and not state:
-            print "bhroBahroPod.OnNotify: clicked Payiferen Spiral"
+            print("bhroBahroPod.OnNotify: clicked Payiferen Spiral")
             respPayiferenRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge09"][0]
             if not sdlVal:
-                print "bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge09 to On"
+                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge09 to On")
                 psnlSDL["psnlBahroWedge09"] = (1,)
 
         elif id == clkTetsonot.id and not state:
-            print "bhroBahroPod.OnNotify: clicked Tetsonot Spiral"
+            print("bhroBahroPod.OnNotify: clicked Tetsonot Spiral")
             respTetsonotRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge10"][0]
             if not sdlVal:
-                print "bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge10 to On"
+                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge10 to On")
                 psnlSDL["psnlBahroWedge10"] = (1,)
 

--- a/Python/bhroBahroPod.py
+++ b/Python/bhroBahroPod.py
@@ -74,7 +74,7 @@ class bhroBahroPod(ptResponder):
         ptResponder.__init__(self)
         self.id = 8814
         self.version = 1
-        print("bhroBahroPod: init  version = %d" % self.version)
+        PtDebugPrint("bhroBahroPod: init  version = %d" % self.version)
 
     ###########################
     def __del__(self):
@@ -91,7 +91,7 @@ class bhroBahroPod(ptResponder):
     def OnServerInitComplete(self):
         # if the age is not the one that I'm from then run the responder to make it back off
         ageFrom = PtGetPrevAgeName()
-        print("bhroBahroPod.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
+        PtDebugPrint("bhroBahroPod.OnServerInitComplete: Came from %s, running opposite responder state" % (ageFrom))
         if ageFrom == "Negilahn":
             respWedges.run(self.key, state="Dereno", fastforward=1)
             respWedges.run(self.key, state="Payiferen", fastforward=1)
@@ -113,61 +113,61 @@ class bhroBahroPod(ptResponder):
             respWedges.run(self.key, state="Payiferen", fastforward=1)
 
         psnlSDL = xPsnlVaultSDL()
-        print(psnlSDL["psnlBahroWedge07"][0])
-        print(psnlSDL["psnlBahroWedge08"][0])
-        print(psnlSDL["psnlBahroWedge09"][0])
-        print(psnlSDL["psnlBahroWedge10"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge07"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge08"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge09"][0])
+        PtDebugPrint(psnlSDL["psnlBahroWedge10"][0])
 
         if psnlSDL["psnlBahroWedge07"][0]:
-            print("bhroBahroPod.OnServerInitComplete: You have the Negilahn wedge, no need to display it.")
+            PtDebugPrint("bhroBahroPod.OnServerInitComplete: You have the Negilahn wedge, no need to display it.")
             respNegilahnRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge08"][0]:
-            print("bhroBahroPod.OnServerInitComplete: You have the Dereno wedge, no need to display it.")
+            PtDebugPrint("bhroBahroPod.OnServerInitComplete: You have the Dereno wedge, no need to display it.")
             respDerenoRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge09"][0]:
-            print("bhroBahroPod.OnServerInitComplete: You have the Payiferen wedge, no need to display it.")
+            PtDebugPrint("bhroBahroPod.OnServerInitComplete: You have the Payiferen wedge, no need to display it.")
             respPayiferenRing.run(self.key, fastforward=1)
         if psnlSDL["psnlBahroWedge10"][0]:
-            print("bhroBahroPod.OnServerInitComplete: You have the Tetsonot wedge, no need to display it.")
+            PtDebugPrint("bhroBahroPod.OnServerInitComplete: You have the Tetsonot wedge, no need to display it.")
             respTetsonotRing.run(self.key, fastforward=1)
 
     ###########################
     def OnNotify(self,state,id,events):
-        #print "bhroBahroPod.OnNotify: state=%s id=%d events=" % (state, id), events
+        #PtDebugPrint("bhroBahroPod.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == clkNegilahn.id and not state:
-            print("bhroBahroPod.OnNotify: clicked Negilahn Spiral")
+            PtDebugPrint("bhroBahroPod.OnNotify: clicked Negilahn Spiral")
             respNegilahnRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge07"][0]
             if not sdlVal:
-                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge07 to On")
+                PtDebugPrint("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge07 to On")
                 psnlSDL["psnlBahroWedge07"] = (1,)
 
         elif id == clkDereno.id and not state:
-            print("bhroBahroPod.OnNotify: clicked Dereno Spiral")
+            PtDebugPrint("bhroBahroPod.OnNotify: clicked Dereno Spiral")
             respDerenoRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge08"][0]
             if not sdlVal:
-                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge08 to On")
+                PtDebugPrint("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge08 to On")
                 psnlSDL["psnlBahroWedge08"] = (1,)
 
         elif id == clkPayiferen.id and not state:
-            print("bhroBahroPod.OnNotify: clicked Payiferen Spiral")
+            PtDebugPrint("bhroBahroPod.OnNotify: clicked Payiferen Spiral")
             respPayiferenRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge09"][0]
             if not sdlVal:
-                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge09 to On")
+                PtDebugPrint("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge09 to On")
                 psnlSDL["psnlBahroWedge09"] = (1,)
 
         elif id == clkTetsonot.id and not state:
-            print("bhroBahroPod.OnNotify: clicked Tetsonot Spiral")
+            PtDebugPrint("bhroBahroPod.OnNotify: clicked Tetsonot Spiral")
             respTetsonotRing.run(self.key, avatar=PtFindAvatar(events))
             psnlSDL = xPsnlVaultSDL()
             sdlVal = psnlSDL["psnlBahroWedge10"][0]
             if not sdlVal:
-                print("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge10 to On")
+                PtDebugPrint("bhroBahroPod.OnNotify:  Turning wedge SDL of psnlBahroWedge10 to On")
                 psnlSDL["psnlBahroWedge10"] = (1,)
 

--- a/Python/bhroBahroYeeshaCave.py
+++ b/Python/bhroBahroYeeshaCave.py
@@ -243,7 +243,7 @@ class bhroBahroYeeshaCave(ptModifier):
         # check and see if the yeesha speech variable has been set yet
         self.UseYeeshaSpeech = self.GetAgeVariable(self.ageFrom, "YeeshaSpeech")
         if self.UseYeeshaSpeech != None:
-            print "bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",self.UseYeeshaSpeech
+            print("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",self.UseYeeshaSpeech)
             if int(self.UseYeeshaSpeech) == 0:
                 serieslen = self.GetNumYSSet()
                 #self.SetAgeVariable(self.ageFrom, "YeeshaSpeech", serieslen + 1)
@@ -251,13 +251,13 @@ class bhroBahroYeeshaCave(ptModifier):
                 if self.GetAutoStartLevel() < self.UseYeeshaSpeech:
                     autostart = 1
                     self.IncrementAutoStartLevel()
-                print "GetAutoStartLevel = ",self.GetAutoStartLevel()
+                print("GetAutoStartLevel = ",self.GetAutoStartLevel())
         else:
-            print "bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = None"
+            print("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = None")
 
         UseYS = self.UseYeeshaSpeech
-        print "bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",UseYS
-        print "bhroBahroYeeshaCave.OnServerInitComplete(): autostart = ",autostart
+        print("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",UseYS)
+        print("bhroBahroYeeshaCave.OnServerInitComplete(): autostart = ",autostart)
 
         journeyComplete = 0
         #vault = ptVault()
@@ -410,7 +410,7 @@ class bhroBahroYeeshaCave(ptModifier):
             cam = ptCamera()
             cam.undoFirstPerson()
             cam.disableFirstPersonOverride()
-            print "undid first person and disabled override"
+            print("undid first person and disabled override")
 
     
     def OnTimer(self, id):
@@ -547,9 +547,9 @@ class bhroBahroYeeshaCave(ptModifier):
                 ypageSDL = psnlSDL.findVar("YeeshaPage25")
                 if ypageSDL:
                     size, state = divmod(ypageSDL.getInt(), 10)
-                    print "YeeshaPage25 = ",state
+                    print("YeeshaPage25 = ",state)
                     if state == 1:
-                        print "bhroBahroYeeshaCave.DisablePole():  sending the pole and YeeshaPage25 is on!  will do the age's wedge..."
+                        print("bhroBahroYeeshaCave.DisablePole():  sending the pole and YeeshaPage25 is on!  will do the age's wedge...")
                         self.DoWedge()
 
 
@@ -584,9 +584,9 @@ class bhroBahroYeeshaCave(ptModifier):
             ypageSDL = psnlSDL.findVar("YeeshaPage25")
             if ypageSDL:
                 size, state = divmod(ypageSDL.getInt(), 10)
-                print "YeeshaPage25 = ",state
+                print("YeeshaPage25 = ",state)
                 if state != 1:
-                    print "bhroBahroYeeshaCave.PostJCOneShot():  can't send pole to Relto, YeeshaPage25 is off!  Returning the pole..."
+                    print("bhroBahroYeeshaCave.PostJCOneShot():  can't send pole to Relto, YeeshaPage25 is off!  Returning the pole...")
                     self.ageDict[age]['JCClickable'].disable()
                     self.ageDict[age]['PoleRemove'].run(self.key, state="Reject")
                     return
@@ -616,7 +616,7 @@ class bhroBahroYeeshaCave(ptModifier):
                 if self.ageDict[tage]['State'] == 9:
                     polesInPsnl += 1
             if polesInPsnl == 1:
-                print "Playing Bahro Cave bahro scream"
+                print("Playing Bahro Cave bahro scream")
                 respBahroScream.run(self.key)
             self.DisablePole(age)
             self.SetState(age, 9)
@@ -674,15 +674,15 @@ class bhroBahroYeeshaCave(ptModifier):
             self.currentYS = "a"
 
         if self.currentYS == "age":
-            print "playing 'age' YeeshaSpeech for: ",age
+            print("playing 'age' YeeshaSpeech for: ",age)
             self.ageDict[age]["YeeshaSpeech"].run(self.key)
             self.SpeechRespReset = 0
         elif self.currentYS != "zz":
-            print "playing 'sequential' YeeshaSpeech..."
-            print "speech = ",speech
-            print "self.currentYS = ",self.currentYS
+            print("playing 'sequential' YeeshaSpeech...")
+            print("speech = ",speech)
+            print("self.currentYS = ",self.currentYS)
             state = speech + self.currentYS
-            print "state = ",state
+            print("state = ",state)
             respSequentialYS.run(self.key, state)
             self.SpeechRespReset = 0
         else:
@@ -739,12 +739,12 @@ class bhroBahroYeeshaCave(ptModifier):
         elif self.ageFrom == "Teledahn":
             sdlName = "psnlBahroWedge04"
         else:
-            print "bhroBahroYeeshaCave.DoWedge():  ERROR.  Didn't recognize previous age name, no wedge will be set"
+            print("bhroBahroYeeshaCave.DoWedge():  ERROR.  Didn't recognize previous age name, no wedge will be set")
             return
 
         sdlVal = psnlSDL[sdlName][0]
         if not sdlVal:
-            print "bhroBahroYeeshaCave.DoWedge():  previous age was %s, turning wedge SDL of %s to On" % (self.ageFrom,sdlName)
+            print("bhroBahroYeeshaCave.DoWedge():  previous age was %s, turning wedge SDL of %s to On" % (self.ageFrom,sdlName))
             psnlSDL[sdlName] = (1,)
 
 
@@ -779,7 +779,7 @@ class bhroBahroYeeshaCave(ptModifier):
 
 
     def GetAutoStartLevel(self):
-        print "bhroBahroYeeshaCave.GetAutoStartLevel()"
+        print("bhroBahroYeeshaCave.GetAutoStartLevel()")
         vault = ptVault()
         bc = vault.findChronicleEntry("BahroCave")
         if bc is not None:
@@ -803,9 +803,9 @@ class bhroBahroYeeshaCave(ptModifier):
                 val = int(val)
             bc.chronicleSetValue(str(val + 1))
             bc.save()
-            print "bhroBahroYeeshaCave.IncrementAutoStartLevel(): setting BC chron = ",str(val + 1)
+            print("bhroBahroYeeshaCave.IncrementAutoStartLevel(): setting BC chron = ",str(val + 1))
         else:
-            print "bhroBahroYeeshaCave.IncrementAutoStartLevel(): no BC chron found"
+            print("bhroBahroYeeshaCave.IncrementAutoStartLevel(): no BC chron found")
 
 
     def OnBackdoorMsg(self, target, param):
@@ -839,14 +839,14 @@ class bhroBahroYeeshaCave(ptModifier):
             elif param == "Teledahn":
                 sdlName = "psnlBahroWedge04"
             else:
-                print "bhroBahroYeeshaCave.OnBackdoorMsg():  ERROR.  Incorrect age specified, no wedge will be set"
+                print("bhroBahroYeeshaCave.OnBackdoorMsg():  ERROR.  Incorrect age specified, no wedge will be set")
                 return
 
             sdlVal = psnlSDL[sdlName][0]
             if sdlVal:
-                print "bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to OFF" % (param,sdlName)
+                print("bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to OFF" % (param,sdlName))
                 psnlSDL[sdlName] = (0,)
             else:
-                print "bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to ON" % (param,sdlName)
+                print("bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to ON" % (param,sdlName))
                 psnlSDL[sdlName] = (1,)                
 

--- a/Python/bhroBahroYeeshaCave.py
+++ b/Python/bhroBahroYeeshaCave.py
@@ -243,7 +243,7 @@ class bhroBahroYeeshaCave(ptModifier):
         # check and see if the yeesha speech variable has been set yet
         self.UseYeeshaSpeech = self.GetAgeVariable(self.ageFrom, "YeeshaSpeech")
         if self.UseYeeshaSpeech != None:
-            print("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",self.UseYeeshaSpeech)
+            PtDebugPrint("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",self.UseYeeshaSpeech)
             if int(self.UseYeeshaSpeech) == 0:
                 serieslen = self.GetNumYSSet()
                 #self.SetAgeVariable(self.ageFrom, "YeeshaSpeech", serieslen + 1)
@@ -251,13 +251,13 @@ class bhroBahroYeeshaCave(ptModifier):
                 if self.GetAutoStartLevel() < self.UseYeeshaSpeech:
                     autostart = 1
                     self.IncrementAutoStartLevel()
-                print("GetAutoStartLevel = ",self.GetAutoStartLevel())
+                PtDebugPrint("GetAutoStartLevel = ",self.GetAutoStartLevel())
         else:
-            print("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = None")
+            PtDebugPrint("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = None")
 
         UseYS = self.UseYeeshaSpeech
-        print("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",UseYS)
-        print("bhroBahroYeeshaCave.OnServerInitComplete(): autostart = ",autostart)
+        PtDebugPrint("bhroBahroYeeshaCave.OnServerInitComplete(): useYeeshaSpeech = ",UseYS)
+        PtDebugPrint("bhroBahroYeeshaCave.OnServerInitComplete(): autostart = ",autostart)
 
         journeyComplete = 0
         #vault = ptVault()
@@ -410,7 +410,7 @@ class bhroBahroYeeshaCave(ptModifier):
             cam = ptCamera()
             cam.undoFirstPerson()
             cam.disableFirstPersonOverride()
-            print("undid first person and disabled override")
+            PtDebugPrint("undid first person and disabled override")
 
     
     def OnTimer(self, id):
@@ -547,9 +547,9 @@ class bhroBahroYeeshaCave(ptModifier):
                 ypageSDL = psnlSDL.findVar("YeeshaPage25")
                 if ypageSDL:
                     size, state = divmod(ypageSDL.getInt(), 10)
-                    print("YeeshaPage25 = ",state)
+                    PtDebugPrint("YeeshaPage25 = ",state)
                     if state == 1:
-                        print("bhroBahroYeeshaCave.DisablePole():  sending the pole and YeeshaPage25 is on!  will do the age's wedge...")
+                        PtDebugPrint("bhroBahroYeeshaCave.DisablePole():  sending the pole and YeeshaPage25 is on!  will do the age's wedge...")
                         self.DoWedge()
 
 
@@ -584,9 +584,9 @@ class bhroBahroYeeshaCave(ptModifier):
             ypageSDL = psnlSDL.findVar("YeeshaPage25")
             if ypageSDL:
                 size, state = divmod(ypageSDL.getInt(), 10)
-                print("YeeshaPage25 = ",state)
+                PtDebugPrint("YeeshaPage25 = ",state)
                 if state != 1:
-                    print("bhroBahroYeeshaCave.PostJCOneShot():  can't send pole to Relto, YeeshaPage25 is off!  Returning the pole...")
+                    PtDebugPrint("bhroBahroYeeshaCave.PostJCOneShot():  can't send pole to Relto, YeeshaPage25 is off!  Returning the pole...")
                     self.ageDict[age]['JCClickable'].disable()
                     self.ageDict[age]['PoleRemove'].run(self.key, state="Reject")
                     return
@@ -616,7 +616,7 @@ class bhroBahroYeeshaCave(ptModifier):
                 if self.ageDict[tage]['State'] == 9:
                     polesInPsnl += 1
             if polesInPsnl == 1:
-                print("Playing Bahro Cave bahro scream")
+                PtDebugPrint("Playing Bahro Cave bahro scream")
                 respBahroScream.run(self.key)
             self.DisablePole(age)
             self.SetState(age, 9)
@@ -674,15 +674,15 @@ class bhroBahroYeeshaCave(ptModifier):
             self.currentYS = "a"
 
         if self.currentYS == "age":
-            print("playing 'age' YeeshaSpeech for: ",age)
+            PtDebugPrint("playing 'age' YeeshaSpeech for: ",age)
             self.ageDict[age]["YeeshaSpeech"].run(self.key)
             self.SpeechRespReset = 0
         elif self.currentYS != "zz":
-            print("playing 'sequential' YeeshaSpeech...")
-            print("speech = ",speech)
-            print("self.currentYS = ",self.currentYS)
+            PtDebugPrint("playing 'sequential' YeeshaSpeech...")
+            PtDebugPrint("speech = ",speech)
+            PtDebugPrint("self.currentYS = ",self.currentYS)
             state = speech + self.currentYS
-            print("state = ",state)
+            PtDebugPrint("state = ",state)
             respSequentialYS.run(self.key, state)
             self.SpeechRespReset = 0
         else:
@@ -739,12 +739,12 @@ class bhroBahroYeeshaCave(ptModifier):
         elif self.ageFrom == "Teledahn":
             sdlName = "psnlBahroWedge04"
         else:
-            print("bhroBahroYeeshaCave.DoWedge():  ERROR.  Didn't recognize previous age name, no wedge will be set")
+            PtDebugPrint("bhroBahroYeeshaCave.DoWedge():  ERROR.  Didn't recognize previous age name, no wedge will be set")
             return
 
         sdlVal = psnlSDL[sdlName][0]
         if not sdlVal:
-            print("bhroBahroYeeshaCave.DoWedge():  previous age was %s, turning wedge SDL of %s to On" % (self.ageFrom,sdlName))
+            PtDebugPrint("bhroBahroYeeshaCave.DoWedge():  previous age was %s, turning wedge SDL of %s to On" % (self.ageFrom,sdlName))
             psnlSDL[sdlName] = (1,)
 
 
@@ -779,7 +779,7 @@ class bhroBahroYeeshaCave(ptModifier):
 
 
     def GetAutoStartLevel(self):
-        print("bhroBahroYeeshaCave.GetAutoStartLevel()")
+        PtDebugPrint("bhroBahroYeeshaCave.GetAutoStartLevel()")
         vault = ptVault()
         bc = vault.findChronicleEntry("BahroCave")
         if bc is not None:
@@ -803,9 +803,9 @@ class bhroBahroYeeshaCave(ptModifier):
                 val = int(val)
             bc.chronicleSetValue(str(val + 1))
             bc.save()
-            print("bhroBahroYeeshaCave.IncrementAutoStartLevel(): setting BC chron = ",str(val + 1))
+            PtDebugPrint("bhroBahroYeeshaCave.IncrementAutoStartLevel(): setting BC chron = ",str(val + 1))
         else:
-            print("bhroBahroYeeshaCave.IncrementAutoStartLevel(): no BC chron found")
+            PtDebugPrint("bhroBahroYeeshaCave.IncrementAutoStartLevel(): no BC chron found")
 
 
     def OnBackdoorMsg(self, target, param):
@@ -839,14 +839,14 @@ class bhroBahroYeeshaCave(ptModifier):
             elif param == "Teledahn":
                 sdlName = "psnlBahroWedge04"
             else:
-                print("bhroBahroYeeshaCave.OnBackdoorMsg():  ERROR.  Incorrect age specified, no wedge will be set")
+                PtDebugPrint("bhroBahroYeeshaCave.OnBackdoorMsg():  ERROR.  Incorrect age specified, no wedge will be set")
                 return
 
             sdlVal = psnlSDL[sdlName][0]
             if sdlVal:
-                print("bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to OFF" % (param,sdlName))
+                PtDebugPrint("bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to OFF" % (param,sdlName))
                 psnlSDL[sdlName] = (0,)
             else:
-                print("bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to ON" % (param,sdlName))
+                PtDebugPrint("bhroBahroYeeshaCave.OnBackdoorMsg():  previous age was %s, turning wedge SDL of %s to ON" % (param,sdlName))
                 psnlSDL[sdlName] = (1,)                
 

--- a/Python/city.py
+++ b/Python/city.py
@@ -85,9 +85,9 @@ class city(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            print "city.__init__(): city version = public"
+            print("city.__init__(): city version = public")
         else:
-            print "city.__init__(): city version = Yeesha"
+            print("city.__init__(): city version = Yeesha")
         
         if not IsPublic:
             pass
@@ -103,8 +103,8 @@ class city(ptResponder):
             spTitle = "title unknown"
             spName = "spawn point unknown"
 
-        print "city.__init__(): spTitle = ",spTitle
-        print "city.__init__(): spName = ",spName
+        print("city.__init__(): spTitle = ",spTitle)
+        print("city.__init__(): spName = ",spName)
 
         ## NOT USING THIS FOR NOW - MAY NEED TO LOAD IN SPECIFIC PAGE(S) FOR FUTURE CITY AREAS...
 #        if spTitle == "KadishGallery":
@@ -152,7 +152,7 @@ class city(ptResponder):
                     self.ILoadS1FinaleBahro(n,1)
                 n += 1
         except:
-            print "ERROR!  Couldn't find all Bahro sdl, leaving default = 0"
+            print("ERROR!  Couldn't find all Bahro sdl, leaving default = 0")
 
 #        ageSDL = PtGetAgeSDL()
 #        
@@ -188,7 +188,7 @@ class city(ptResponder):
 
 
     def ILoadS1FinaleBahro(self,bahro,state):
-        print "city.ILoadS1FinaleBahro(): bahro = %d, load = %d" % (bahro,state)
+        print("city.ILoadS1FinaleBahro(): bahro = %d, load = %d" % (bahro,state))
 #        if not self.sceneobject.isLocallyOwned():
 #            return
         if state:

--- a/Python/city.py
+++ b/Python/city.py
@@ -85,9 +85,9 @@ class city(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            print("city.__init__(): city version = public")
+            PtDebugPrint("city.__init__(): city version = public")
         else:
-            print("city.__init__(): city version = Yeesha")
+            PtDebugPrint("city.__init__(): city version = Yeesha")
         
         if not IsPublic:
             pass
@@ -103,15 +103,15 @@ class city(ptResponder):
             spTitle = "title unknown"
             spName = "spawn point unknown"
 
-        print("city.__init__(): spTitle = ",spTitle)
-        print("city.__init__(): spName = ",spName)
+        PtDebugPrint("city.__init__(): spTitle = ",spTitle)
+        PtDebugPrint("city.__init__(): spName = ",spName)
 
         ## NOT USING THIS FOR NOW - MAY NEED TO LOAD IN SPECIFIC PAGE(S) FOR FUTURE CITY AREAS...
 #        if spTitle == "KadishGallery":
-#            print "city.__init__(): we're linking into KadishGallery, only that page will be loaded"
+#            PtDebugPrint("city.__init__(): we're linking into KadishGallery, only that page will be loaded")
 #            IsKadishGallery = 1
 #        else:
-#            print "city.__init__(): we're NOT linking into KadishGallery, will load the entire city"
+#            PtDebugPrint("city.__init__(): we're NOT linking into KadishGallery, will load the entire city")
         
         pages = []
 
@@ -152,7 +152,7 @@ class city(ptResponder):
                     self.ILoadS1FinaleBahro(n,1)
                 n += 1
         except:
-            print("ERROR!  Couldn't find all Bahro sdl, leaving default = 0")
+            PtDebugPrint("ERROR!  Couldn't find all Bahro sdl, leaving default = 0")
 
 #        ageSDL = PtGetAgeSDL()
 #        
@@ -188,7 +188,7 @@ class city(ptResponder):
 
 
     def ILoadS1FinaleBahro(self,bahro,state):
-        print("city.ILoadS1FinaleBahro(): bahro = %d, load = %d" % (bahro,state))
+        PtDebugPrint("city.ILoadS1FinaleBahro(): bahro = %d, load = %d" % (bahro,state))
 #        if not self.sceneobject.isLocallyOwned():
 #            return
         if state:

--- a/Python/clftEndingCredits.py
+++ b/Python/clftEndingCredits.py
@@ -94,7 +94,7 @@ class clftEndingCredits(ptResponder):
         self.id = 8802
         version = 5
         self.version = version
-        print "__init__ clftEndingCredits v. ",version,".1"
+        print("__init__ clftEndingCredits v. ",version,".1")
         
 
     def OnServerInitComplete(self):
@@ -110,10 +110,10 @@ class clftEndingCredits(ptResponder):
         
         SDLVarSceneBahro = "clftSceneBahroUnseen"
         if VARname == SDLVarSceneBahro:
-            print "OnSDL launched the credits."
+            print("OnSDL launched the credits.")
             boolSceneBahro = ageSDL[SDLVarSceneBahro][0]
             if boolSceneBahro == 0:
-                print "clftEndingCredits.OnSDLNotify(): we're no longer showing the credits here"
+                print("clftEndingCredits.OnSDLNotify(): we're no longer showing the credits here")
                 cam = ptCamera()
                 cam.enableFirstPersonOverride()
                 PtEnableMovementKeys()
@@ -133,7 +133,7 @@ class clftEndingCredits(ptResponder):
 #                PtDisableMovementKeys()
 #                PtAtTimeCallback(self.key,kDelayFadeSeconds,kFadeOutToCreditsID)
             else:
-                print "No credits."
+                print("No credits.")
         
         pass
 
@@ -144,10 +144,10 @@ class clftEndingCredits(ptResponder):
         if (id == RgnSnsrSndLogTracks.id and state):
             import xSndLogTracks
             if xSndLogTracks.IsLogMode():
-                print "Start of Egg!!! Enable Riven scope clickable"
+                print("Start of Egg!!! Enable Riven scope clickable")
                 ClkSndLogTracks.enable()
             else:
-                print "not this time"
+                print("not this time")
                 ClkSndLogTracks.disable()
                 
         if (id == ClkSndLogTracks.id and state):
@@ -156,7 +156,7 @@ class clftEndingCredits(ptResponder):
 
 
         if AlreadyClosed:
-            print "failed AlreadyClosed check"
+            print("failed AlreadyClosed check")
             return
     
         for event in events:
@@ -164,7 +164,7 @@ class clftEndingCredits(ptResponder):
                 if event[1] == PtBookEventTypes.kNotifyHide:
                     AlreadyClosed = True
                     PtFadeOut(kFadeOutToGameSeconds,1)
-                    print "clftEndingCredits.OnNotify(): Book hidden. FadeOut over", kFadeOutToGameSeconds," seconds"  
+                    print("clftEndingCredits.OnNotify(): Book hidden. FadeOut over", kFadeOutToGameSeconds," seconds")  
                     
                     #The book is already hidden, so just go ahead and fade back in on the game
                     PtAtTimeCallback(self.key,kFadeOutToGameSeconds,kFadeOutToGameID)
@@ -172,7 +172,7 @@ class clftEndingCredits(ptResponder):
                 elif event[1] == PtBookEventTypes.kNotifyClose:
                     AlreadyClosed = True
                     PtFadeOut(kFadeOutToGameSeconds,1)
-                    print "clftEndingCredits.OnNotify(): Book closed. FadeOut over", kFadeOutToGameSeconds," seconds"                    
+                    print("clftEndingCredits.OnNotify(): Book closed. FadeOut over", kFadeOutToGameSeconds," seconds")                    
                     
                     #We have to hide the book first before we fade back in on the game
                     PtAtTimeCallback(self.key,kFadeOutToGameSeconds+1,kHideBookID)
@@ -181,7 +181,7 @@ class clftEndingCredits(ptResponder):
     def OnTimer(self,id):
         
         global gJournalBook        
-        print "clftEndingCredits.OnTimer(): Callback from id:",id
+        print("clftEndingCredits.OnTimer(): Callback from id:",id)
         if id == kFadeOutToCreditsID: # 1
             self.IFadeOutToCredits()
         elif id == kShowCreditsID: # 2 
@@ -191,13 +191,13 @@ class clftEndingCredits(ptResponder):
         elif id == kFadeOutToGameID: # 4
             self.IFadeOutToGame()
         elif id == kHideBookID: # 5
-            print "clftEndingCredits.OnTimer(): The credits book is now hidden"
+            print("clftEndingCredits.OnTimer(): The credits book is now hidden")
             gJournalBook.hide()            
             PtAtTimeCallback(self.key,kFadeOutToGameSeconds,kFadeOutToGameID)
 
         elif id == kFadeInToGameID: # 6
             PtFadeIn(kFadeInToGameSeconds,1)
-            print "clftEndingCredits.OnTimer(): FadeIn over", kFadeInToGameSeconds," seconds"
+            print("clftEndingCredits.OnTimer(): FadeIn over", kFadeInToGameSeconds," seconds")
             cam = ptCamera()
             cam.enableFirstPersonOverride()
             PtEnableMovementKeys()
@@ -206,7 +206,7 @@ class clftEndingCredits(ptResponder):
 
     def IFadeOutToCredits(self):
         PtFadeOut(kFadeOutToCreditsSeconds,1)
-        print "clftEndingCredits.IFadeOutToCredits(): FadeOut over", kFadeOutToCreditsSeconds," seconds."
+        print("clftEndingCredits.IFadeOutToCredits(): FadeOut over", kFadeOutToCreditsSeconds," seconds.")
         PtAtTimeCallback(self.key,4,kShowCreditsID)
 
 
@@ -214,7 +214,7 @@ class clftEndingCredits(ptResponder):
         global gJournalBook
         global AlreadyClosed
         
-        print "clftEndingCredits.IShowCredits(): Showing Journal now."
+        print("clftEndingCredits.IShowCredits(): Showing Journal now.")
         gJournalBook.show(0)
         AlreadyClosed = False
         PtAtTimeCallback(self.key,1,kFadeInToCreditsID)        
@@ -235,7 +235,7 @@ class clftEndingCredits(ptResponder):
         respStartCreditsMusic.run(self.key)
         
         PtFadeIn(kFadeInToCreditsSeconds,1)
-        print "clftEndingCredits.IFadeInToCredits(): FadeIn over", kFadeInToCreditsSeconds," seconds"
+        print("clftEndingCredits.IFadeInToCredits(): FadeIn over", kFadeInToCreditsSeconds," seconds")
 
 
     def IFadeOutToGame(self):

--- a/Python/clftEndingCredits.py
+++ b/Python/clftEndingCredits.py
@@ -94,7 +94,7 @@ class clftEndingCredits(ptResponder):
         self.id = 8802
         version = 5
         self.version = version
-        print("__init__ clftEndingCredits v. ",version,".1")
+        PtDebugPrint("__init__ clftEndingCredits v. ",version,".1")
         
 
     def OnServerInitComplete(self):
@@ -110,15 +110,15 @@ class clftEndingCredits(ptResponder):
         
         SDLVarSceneBahro = "clftSceneBahroUnseen"
         if VARname == SDLVarSceneBahro:
-            print("OnSDL launched the credits.")
+            PtDebugPrint("OnSDL launched the credits.")
             boolSceneBahro = ageSDL[SDLVarSceneBahro][0]
             if boolSceneBahro == 0:
-                print("clftEndingCredits.OnSDLNotify(): we're no longer showing the credits here")
+                PtDebugPrint("clftEndingCredits.OnSDLNotify(): we're no longer showing the credits here")
                 cam = ptCamera()
                 cam.enableFirstPersonOverride()
                 PtEnableMovementKeys()
                 PtSendKIMessage(kEnableKIandBB,0)
-#                print "\tclftEndingCredits.OnSDLNotify: loading journal"
+#                PtDebugPrint("\tclftEndingCredits.OnSDLNotify: loading journal")
 #                params = xJournalBookDefs.xJournalBooks["UruCredits"]
 #                if len(params) == 4:
 #                    width,height,locPath,gui = params
@@ -133,7 +133,7 @@ class clftEndingCredits(ptResponder):
 #                PtDisableMovementKeys()
 #                PtAtTimeCallback(self.key,kDelayFadeSeconds,kFadeOutToCreditsID)
             else:
-                print("No credits.")
+                PtDebugPrint("No credits.")
         
         pass
 
@@ -144,10 +144,10 @@ class clftEndingCredits(ptResponder):
         if (id == RgnSnsrSndLogTracks.id and state):
             import xSndLogTracks
             if xSndLogTracks.IsLogMode():
-                print("Start of Egg!!! Enable Riven scope clickable")
+                PtDebugPrint("Start of Egg!!! Enable Riven scope clickable")
                 ClkSndLogTracks.enable()
             else:
-                print("not this time")
+                PtDebugPrint("not this time")
                 ClkSndLogTracks.disable()
                 
         if (id == ClkSndLogTracks.id and state):
@@ -156,7 +156,7 @@ class clftEndingCredits(ptResponder):
 
 
         if AlreadyClosed:
-            print("failed AlreadyClosed check")
+            PtDebugPrint("failed AlreadyClosed check")
             return
     
         for event in events:
@@ -164,7 +164,7 @@ class clftEndingCredits(ptResponder):
                 if event[1] == PtBookEventTypes.kNotifyHide:
                     AlreadyClosed = True
                     PtFadeOut(kFadeOutToGameSeconds,1)
-                    print("clftEndingCredits.OnNotify(): Book hidden. FadeOut over", kFadeOutToGameSeconds," seconds")  
+                    PtDebugPrint("clftEndingCredits.OnNotify(): Book hidden. FadeOut over", kFadeOutToGameSeconds," seconds")  
                     
                     #The book is already hidden, so just go ahead and fade back in on the game
                     PtAtTimeCallback(self.key,kFadeOutToGameSeconds,kFadeOutToGameID)
@@ -172,7 +172,7 @@ class clftEndingCredits(ptResponder):
                 elif event[1] == PtBookEventTypes.kNotifyClose:
                     AlreadyClosed = True
                     PtFadeOut(kFadeOutToGameSeconds,1)
-                    print("clftEndingCredits.OnNotify(): Book closed. FadeOut over", kFadeOutToGameSeconds," seconds")                    
+                    PtDebugPrint("clftEndingCredits.OnNotify(): Book closed. FadeOut over", kFadeOutToGameSeconds," seconds")                    
                     
                     #We have to hide the book first before we fade back in on the game
                     PtAtTimeCallback(self.key,kFadeOutToGameSeconds+1,kHideBookID)
@@ -181,7 +181,7 @@ class clftEndingCredits(ptResponder):
     def OnTimer(self,id):
         
         global gJournalBook        
-        print("clftEndingCredits.OnTimer(): Callback from id:",id)
+        PtDebugPrint("clftEndingCredits.OnTimer(): Callback from id:",id)
         if id == kFadeOutToCreditsID: # 1
             self.IFadeOutToCredits()
         elif id == kShowCreditsID: # 2 
@@ -191,13 +191,13 @@ class clftEndingCredits(ptResponder):
         elif id == kFadeOutToGameID: # 4
             self.IFadeOutToGame()
         elif id == kHideBookID: # 5
-            print("clftEndingCredits.OnTimer(): The credits book is now hidden")
+            PtDebugPrint("clftEndingCredits.OnTimer(): The credits book is now hidden")
             gJournalBook.hide()            
             PtAtTimeCallback(self.key,kFadeOutToGameSeconds,kFadeOutToGameID)
 
         elif id == kFadeInToGameID: # 6
             PtFadeIn(kFadeInToGameSeconds,1)
-            print("clftEndingCredits.OnTimer(): FadeIn over", kFadeInToGameSeconds," seconds")
+            PtDebugPrint("clftEndingCredits.OnTimer(): FadeIn over", kFadeInToGameSeconds," seconds")
             cam = ptCamera()
             cam.enableFirstPersonOverride()
             PtEnableMovementKeys()
@@ -206,7 +206,7 @@ class clftEndingCredits(ptResponder):
 
     def IFadeOutToCredits(self):
         PtFadeOut(kFadeOutToCreditsSeconds,1)
-        print("clftEndingCredits.IFadeOutToCredits(): FadeOut over", kFadeOutToCreditsSeconds," seconds.")
+        PtDebugPrint("clftEndingCredits.IFadeOutToCredits(): FadeOut over", kFadeOutToCreditsSeconds," seconds.")
         PtAtTimeCallback(self.key,4,kShowCreditsID)
 
 
@@ -214,7 +214,7 @@ class clftEndingCredits(ptResponder):
         global gJournalBook
         global AlreadyClosed
         
-        print("clftEndingCredits.IShowCredits(): Showing Journal now.")
+        PtDebugPrint("clftEndingCredits.IShowCredits(): Showing Journal now.")
         gJournalBook.show(0)
         AlreadyClosed = False
         PtAtTimeCallback(self.key,1,kFadeInToCreditsID)        
@@ -235,7 +235,7 @@ class clftEndingCredits(ptResponder):
         respStartCreditsMusic.run(self.key)
         
         PtFadeIn(kFadeInToCreditsSeconds,1)
-        print("clftEndingCredits.IFadeInToCredits(): FadeIn over", kFadeInToCreditsSeconds," seconds")
+        PtDebugPrint("clftEndingCredits.IFadeInToCredits(): FadeIn over", kFadeInToCreditsSeconds," seconds")
 
 
     def IFadeOutToGame(self):

--- a/Python/clftGetPersonalBook.py
+++ b/Python/clftGetPersonalBook.py
@@ -222,7 +222,7 @@ class clftGetPersonalBook(ptResponder):
                 # just continue processing
             except:
                 PtDebugPrint("xLiveTrailer - no intro movie!!!",level=kDebugDumpLevel)
-                print "Quitting demo now..."
+                print("Quitting demo now...")
                 PtConsole("App.Quit")
             PtDebugPrint("xLiveTrailer - start showing movie",level=kDebugDumpLevel)
             PtShowDialog("IntroBahroBgGUI")
@@ -248,7 +248,7 @@ class clftGetPersonalBook(ptResponder):
             if gDemoMovie is not None:
                 gDemoMovie.resume()
         elif id == kTrailerDoneID:
-            print "Quitting demo now..."
+            print("Quitting demo now...")
             PtConsole("App.Quit")
 
     def OnMovieEvent(self,movieName,reason):

--- a/Python/clftGetPersonalBook.py
+++ b/Python/clftGetPersonalBook.py
@@ -180,10 +180,10 @@ class clftGetPersonalBook(ptResponder):
                         cam.disableFirstPersonOverride()
                         cam.undoFirstPerson()
                         if currentgender == 1:
-                            #~ print "Playing female book animation"
+                            #~ PtDebugPrint("Playing female book animation")
                             BookAnimFemale.animation.play()
                         elif currentgender == 0:
-                            #~ print "Playing male book animation"
+                            #~ PtDebugPrint("Playing male book animation")
                             BookAnimMale.animation.play()
                         else:
                             PtDebugPrint("clftGetPersonalBook: unreadable gender or special character.",level=kErrorLevel)
@@ -193,7 +193,7 @@ class clftGetPersonalBook(ptResponder):
         global LocalAvatar
         # start the alert of the personal book blinking
         PtSendKIMessage(kStartBookAlert,0)
-        #~ print "trying to get book."
+        #~ PtDebugPrint("trying to get book.")
         MultiBeh.run(LocalAvatar)
         self.SolveCleft()
         PtAtTimeCallback(self.key, 8, kLinkRespID) 
@@ -222,7 +222,7 @@ class clftGetPersonalBook(ptResponder):
                 # just continue processing
             except:
                 PtDebugPrint("xLiveTrailer - no intro movie!!!",level=kDebugDumpLevel)
-                print("Quitting demo now...")
+                PtDebugPrint("Quitting demo now...")
                 PtConsole("App.Quit")
             PtDebugPrint("xLiveTrailer - start showing movie",level=kDebugDumpLevel)
             PtShowDialog("IntroBahroBgGUI")
@@ -248,7 +248,7 @@ class clftGetPersonalBook(ptResponder):
             if gDemoMovie is not None:
                 gDemoMovie.resume()
         elif id == kTrailerDoneID:
-            print("Quitting demo now...")
+            PtDebugPrint("Quitting demo now...")
             PtConsole("App.Quit")
 
     def OnMovieEvent(self,movieName,reason):

--- a/Python/clftImager.py
+++ b/Python/clftImager.py
@@ -228,7 +228,7 @@ class clftImager(ptResponder):
             try:
                 avatar = PtGetLocalAvatar()
             except:
-                print"failed to get local avatar"
+                print("failed to get local avatar")
                 return
             avatar.avatar.registerForBehaviorNotify(self.key)
             cam = ptCamera()
@@ -319,7 +319,7 @@ class clftImager(ptResponder):
 
     def IQuitImager(self):
         global PuzzleView
-        print "disengage and exit the imager puzzle"
+        print("disengage and exit the imager puzzle")
         avatar = PtGetLocalAvatar()
         imagerCam.value.popCutsceneCamera(avatar.getKey())
         #imagerBtn.enableActivator()
@@ -365,7 +365,7 @@ class clftImager(ptResponder):
                 return
             avatar=PtFindAvatar(events)
             avatar.draw.enable()
-            print"force avatar visible"
+            print("force avatar visible")
             return
             
         # Causes Yeesha to be spawned out of sight before imager is activated
@@ -379,7 +379,7 @@ class clftImager(ptResponder):
         # switch to imager close-up camera
 
         if (id == imagerBtn.id and state):
-            print"switch to imager close up"
+            print("switch to imager close up")
             imagerBtn.disableActivator()
             ImagerBtnInvisible.run(self.key)
             #~ if visionplaying:
@@ -411,7 +411,7 @@ class clftImager(ptResponder):
 
         # trigger the imager to run, reset clickables
         if (id == imagerBrokenBtn.id and state):
-            print "trigger imager"
+            print("trigger imager")
             imagerBrokenBtn.disableActivator()
             imagerLockN.disableActivator()
             imagerLockS.disableActivator()
@@ -435,20 +435,20 @@ class clftImager(ptResponder):
             if (self.EndgameSolved()):
                 PlayFull = 0
                 PlayFinal = 1
-                print "play final speech"
+                print("play final speech")
             elif (self.OpeningSolved()):
                 PlayFull = 1
                 PlayFinal = 0
-                print "play full opening speech"
+                print("play full opening speech")
             elif (self.TPOTSolved()):
                 PlayFull = 0
                 PlayFinal = 0
                 PlayTPOT = 1
-                print "play TPOT speech"
+                print("play TPOT speech")
             else:
                 PlayFull = 0
                 PlayFinal = 0
-                print "play partial opening speech"
+                print("play partial opening speech")
 
             #PtAtTimeCallback(self.key,2,imagerBtn.id)
                 
@@ -458,7 +458,7 @@ class clftImager(ptResponder):
                     return
 
         if (id == ImagerOneshot.id):
-            print"avatar oneshot callback"
+            print("avatar oneshot callback")
             PuzzleView = 0
             PtEnableForwardMovement()
             PtSendKIMessage(kEnableEntireYeeshaBook,0)
@@ -473,21 +473,21 @@ class clftImager(ptResponder):
                             #~ imagerLockS.disableActivator()
                             #~ imagerLockW.disableActivator()
                             #~ imagerLockE.disableActivator()
-                            print "Now, killing vision"
+                            print("Now, killing vision")
                             speechKilled = 1
                             self.StopVision()
                         elif visionplaying == 0:
                             self.StartVision()
                             if PlayFinal == 1:
-                                print "nothing"
+                                print("nothing")
                                 # this timer value is approximate right now
                                 #PtAtTimeCallback(self.key, 204.2, kFinished)
                             elif PlayFinal == 0 and PlayFull == 0 and PlayTPOT == 0:
                                 stopvision = random.randint(minstoptime, maxstoptime)
-                                print "\tImager will autoshut off in %d seconds" % (stopvision)
+                                print("\tImager will autoshut off in %d seconds" % (stopvision))
                                 PtAtTimeCallback(self.key, stopvision, kVision)
                             elif PlayFull == 1:
-                                print "nothing"
+                                print("nothing")
                                 # The full audio of the Yeesha Vision plays for 137 seconds. This ensures turning it off after completion.
                                 #PtAtTimeCallback(self.key, 141.6, kVision)
             else:
@@ -503,10 +503,10 @@ class clftImager(ptResponder):
                 clothingName = "02_MTorso09_01"
             clothingList = avatar.avatar.getWardrobeClothingList()
             if clothingName not in clothingList:
-                print "adding Yeesha reward clothing %s to wardrobe" % (clothingName)
+                print("adding Yeesha reward clothing %s to wardrobe" % (clothingName))
                 avatar.avatar.addWardrobeClothingItem(clothingName,ptColor().white(),ptColor().black())
             else:
-                print "player already has Yeesha reward clothing, doing nothing"
+                print("player already has Yeesha reward clothing, doing nothing")
 
         if (id == StopIntroVisEvent.id and state):
             speechKilled = 0
@@ -530,10 +530,10 @@ class clftImager(ptResponder):
                 self.ageSDL.setTagString(SDLVarOfficeDoor,xtraInfo)
                 self.ageSDL[SDLVarOfficeDoor] = (1,)
             else:
-                print "what's wrong with the door?"
+                print("what's wrong with the door?")
 
         if (id == YeeshaSceneTimerDone.id and state and PlayScene == 1):
-            print "clftImager.OnNotify(): Yeesha timer is done.  Getting rid of Yeesha and setting SDL."
+            print("clftImager.OnNotify(): Yeesha timer is done.  Getting rid of Yeesha and setting SDL.")
             self.ageSDL = PtGetAgeSDL()
             YeeshaName.draw.disable()
             YeeshaName.physics.warpObj(YeeshaWarpHid.value.getKey())
@@ -561,13 +561,13 @@ class clftImager(ptResponder):
         PtDebugPrint("clftImager.SceneYeesha(): PlayScene = %d" % (PlayScene))
 
         if PlayScene == 1:
-            print "clftImager: Playing scene now..."
+            print("clftImager: Playing scene now...")
             YeeshaName.draw.enable()
             YeeshaName.physics.warpObj(YeeshaWarpVis3.value.getKey())
             YeeshaMultiStage.gotoStage(YeeshaName, 3,dirFlag=1,isForward=1)
             YeeshaSpeech3.run(self.key,avatar=PtGetLocalAvatar())
         else:
-            print "clftImager: Nope, not playing scene."
+            print("clftImager: Nope, not playing scene.")
 
 
     def OpeningSolved(self):
@@ -579,8 +579,8 @@ class clftImager(ptResponder):
         imagerList.append(imagerRespS.state_list.index(imagerRespS.getState()))
         imagerList.append(imagerRespW.state_list.index(imagerRespW.getState()))
 
-        print "clftImager.OpenSolved(): solution list:", solutionList
-        print "clftImager.OpenSolved(): imager list  :", imagerList
+        print("clftImager.OpenSolved(): solution list:", solutionList)
+        print("clftImager.OpenSolved(): imager list  :", imagerList)
         
         if self.AreListsEquiv(solutionList, imagerList):
             return True
@@ -661,8 +661,8 @@ class clftImager(ptResponder):
         for x in range(4):
             currentStateList[x] = (currentStateList[x]+6)%7
 
-        print "clftImager.EndgameSolved(): solution list: " + str(solutionList)
-        print "clftImager.EndgameSolved(): currentState list: " + str(currentStateList)
+        print("clftImager.EndgameSolved(): solution list: " + str(solutionList))
+        print("clftImager.EndgameSolved(): currentState list: " + str(currentStateList))
 
         if self.AreListsEquiv(solutionList, currentStateList):
             return True
@@ -682,8 +682,8 @@ class clftImager(ptResponder):
         for x in range(4):
             currentStateList[x] = (currentStateList[x]+6)%7
 
-        print "clftImager.TPOTSolved(): solution list:", solutionList
-        print "clftImager.TPOTSolved(): currentState list  :", currentStateList
+        print("clftImager.TPOTSolved(): solution list:", solutionList)
+        print("clftImager.TPOTSolved(): currentState list  :", currentStateList)
         
         if self.AreListsEquiv(solutionList, currentStateList):
             return True
@@ -717,7 +717,7 @@ class clftImager(ptResponder):
                             chronSolutions = []
                             for sol in chronString:
                                 chronSolutions.append(string.atoi(sol))
-                            print "found pellet cave solution: ",chronSolutions
+                            print("found pellet cave solution: ",chronSolutions)
                             return chronSolutions
 
 
@@ -729,7 +729,7 @@ class clftImager(ptResponder):
         global speechKilled
         
         if visionplaying == 1 and id == kVision: 
-            print "\nclftImager.Ontimer:Got kVision timer callback. Automatically stopping vision."
+            print("\nclftImager.Ontimer:Got kVision timer callback. Automatically stopping vision.")
             self.StopVision()
             imagerBrokenBtn.disableActivator()
             imagerLockN.disableActivator()
@@ -746,7 +746,7 @@ class clftImager(ptResponder):
             #~ imagerLockW.disableActivator()
             #~ imagerLockE.disableActivator()
         elif id == imagerBrokenBtn.id:
-            print "\nclftImager.Ontimer:Got timer callback. Setting up Imager button...."
+            print("\nclftImager.Ontimer:Got timer callback. Setting up Imager button....")
             imagerBtn.disableActivator()
             ImagerBtnInvisible.run(self.key)
             imagerBrokenBtn.enableActivator()
@@ -757,7 +757,7 @@ class clftImager(ptResponder):
             PtSendKIMessage(kDisableEntireYeeshaBook,0)
             PtDisableForwardMovement()
         elif id == imagerBtn.id:
-            print "\nclftImager.Ontimer:Got timer callback. Setting up Imager dummy...."
+            print("\nclftImager.Ontimer:Got timer callback. Setting up Imager dummy....")
             imagerBrokenBtn.disableActivator()
             imagerLockN.disableActivator()
             imagerLockS.disableActivator()
@@ -784,7 +784,7 @@ class clftImager(ptResponder):
         global YeeshaName
         global VisionID
         
-        print "clftImager.StartVision: Playing Yeesha vision."
+        print("clftImager.StartVision: Playing Yeesha vision.")
         
         YeeshaName.draw.enable()
         
@@ -837,7 +837,7 @@ class clftImager(ptResponder):
         global PuzzleView
         global VisionID
         
-        print "clftImager.StopVision: Stopping Yeesha vision."
+        print("clftImager.StopVision: Stopping Yeesha vision.")
         
         YeeshaName.draw.disable()
         YeeshaName.physics.warpObj(YeeshaWarpHid.value.getKey())
@@ -847,7 +847,7 @@ class clftImager(ptResponder):
             YeeshaMultiStage.gotoStage(YeeshaName, 0,dirFlag=1,isForward=1)
             #respBookAnim.run(self.key,state="off")
             visionplaying = 0
-            print "TRYING TO KILL FINAL VISION"
+            print("TRYING TO KILL FINAL VISION")
             if speechKilled == 1:
                 YeeshaSpeech2.run(self.key,state="on",fastforward=1)
                 KillFinalVisMusic.run(self.key)
@@ -877,9 +877,9 @@ class clftImager(ptResponder):
                 speechKilled = 0
             respPlayTPOTSpeech.run(self.key,state="off")
         else:
-            print "clftImager.StopVision: Don't know which vision to kill!"
+            print("clftImager.StopVision: Don't know which vision to kill!")
 
-        print "PuzzleView = %s" % (PuzzleView)
+        print("PuzzleView = %s" % (PuzzleView))
         
         avatar = PtGetLocalAvatar()
         if PuzzleView:
@@ -896,28 +896,28 @@ class clftImager(ptResponder):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print "valCityLinks = ",valCityLinks
+            print("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print "CityLinks = ",CityLinks
+            print("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
                 entryCityLinks.chronicleSetValue(NewLinks)
                 entryCityLinks.save()
-                print "xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel
+                print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
                 valCityLinks = entryCityLinks.chronicleGetValue()
                 CityLinks = valCityLinks.split(",")
-                print "xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks
+                print("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
-                print "xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel
+                print("xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
         else:
             vault.addChronicleEntry("CityBookLinks",0,agePanel)
-            print "xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel
+            print("xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
         
         psnlSDL = xPsnlVaultSDL()
         GotBook = psnlSDL["psnlGotCityBook"][0]
         if not GotBook:
             psnlSDL["psnlGotCityBook"] = (1,)
-            print "xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1"
+            print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1")
 
 
     def OnBackdoorMsg(self, target, param):

--- a/Python/clftImager.py
+++ b/Python/clftImager.py
@@ -228,7 +228,7 @@ class clftImager(ptResponder):
             try:
                 avatar = PtGetLocalAvatar()
             except:
-                print("failed to get local avatar")
+                PtDebugPrint("failed to get local avatar")
                 return
             avatar.avatar.registerForBehaviorNotify(self.key)
             cam = ptCamera()
@@ -319,7 +319,7 @@ class clftImager(ptResponder):
 
     def IQuitImager(self):
         global PuzzleView
-        print("disengage and exit the imager puzzle")
+        PtDebugPrint("disengage and exit the imager puzzle")
         avatar = PtGetLocalAvatar()
         imagerCam.value.popCutsceneCamera(avatar.getKey())
         #imagerBtn.enableActivator()
@@ -365,7 +365,7 @@ class clftImager(ptResponder):
                 return
             avatar=PtFindAvatar(events)
             avatar.draw.enable()
-            print("force avatar visible")
+            PtDebugPrint("force avatar visible")
             return
             
         # Causes Yeesha to be spawned out of sight before imager is activated
@@ -379,7 +379,7 @@ class clftImager(ptResponder):
         # switch to imager close-up camera
 
         if (id == imagerBtn.id and state):
-            print("switch to imager close up")
+            PtDebugPrint("switch to imager close up")
             imagerBtn.disableActivator()
             ImagerBtnInvisible.run(self.key)
             #~ if visionplaying:
@@ -411,7 +411,7 @@ class clftImager(ptResponder):
 
         # trigger the imager to run, reset clickables
         if (id == imagerBrokenBtn.id and state):
-            print("trigger imager")
+            PtDebugPrint("trigger imager")
             imagerBrokenBtn.disableActivator()
             imagerLockN.disableActivator()
             imagerLockS.disableActivator()
@@ -435,20 +435,20 @@ class clftImager(ptResponder):
             if (self.EndgameSolved()):
                 PlayFull = 0
                 PlayFinal = 1
-                print("play final speech")
+                PtDebugPrint("play final speech")
             elif (self.OpeningSolved()):
                 PlayFull = 1
                 PlayFinal = 0
-                print("play full opening speech")
+                PtDebugPrint("play full opening speech")
             elif (self.TPOTSolved()):
                 PlayFull = 0
                 PlayFinal = 0
                 PlayTPOT = 1
-                print("play TPOT speech")
+                PtDebugPrint("play TPOT speech")
             else:
                 PlayFull = 0
                 PlayFinal = 0
-                print("play partial opening speech")
+                PtDebugPrint("play partial opening speech")
 
             #PtAtTimeCallback(self.key,2,imagerBtn.id)
                 
@@ -458,7 +458,7 @@ class clftImager(ptResponder):
                     return
 
         if (id == ImagerOneshot.id):
-            print("avatar oneshot callback")
+            PtDebugPrint("avatar oneshot callback")
             PuzzleView = 0
             PtEnableForwardMovement()
             PtSendKIMessage(kEnableEntireYeeshaBook,0)
@@ -473,21 +473,21 @@ class clftImager(ptResponder):
                             #~ imagerLockS.disableActivator()
                             #~ imagerLockW.disableActivator()
                             #~ imagerLockE.disableActivator()
-                            print("Now, killing vision")
+                            PtDebugPrint("Now, killing vision")
                             speechKilled = 1
                             self.StopVision()
                         elif visionplaying == 0:
                             self.StartVision()
                             if PlayFinal == 1:
-                                print("nothing")
+                                PtDebugPrint("nothing")
                                 # this timer value is approximate right now
                                 #PtAtTimeCallback(self.key, 204.2, kFinished)
                             elif PlayFinal == 0 and PlayFull == 0 and PlayTPOT == 0:
                                 stopvision = random.randint(minstoptime, maxstoptime)
-                                print("\tImager will autoshut off in %d seconds" % (stopvision))
+                                PtDebugPrint("\tImager will autoshut off in %d seconds" % (stopvision))
                                 PtAtTimeCallback(self.key, stopvision, kVision)
                             elif PlayFull == 1:
-                                print("nothing")
+                                PtDebugPrint("nothing")
                                 # The full audio of the Yeesha Vision plays for 137 seconds. This ensures turning it off after completion.
                                 #PtAtTimeCallback(self.key, 141.6, kVision)
             else:
@@ -503,10 +503,10 @@ class clftImager(ptResponder):
                 clothingName = "02_MTorso09_01"
             clothingList = avatar.avatar.getWardrobeClothingList()
             if clothingName not in clothingList:
-                print("adding Yeesha reward clothing %s to wardrobe" % (clothingName))
+                PtDebugPrint("adding Yeesha reward clothing %s to wardrobe" % (clothingName))
                 avatar.avatar.addWardrobeClothingItem(clothingName,ptColor().white(),ptColor().black())
             else:
-                print("player already has Yeesha reward clothing, doing nothing")
+                PtDebugPrint("player already has Yeesha reward clothing, doing nothing")
 
         if (id == StopIntroVisEvent.id and state):
             speechKilled = 0
@@ -530,10 +530,10 @@ class clftImager(ptResponder):
                 self.ageSDL.setTagString(SDLVarOfficeDoor,xtraInfo)
                 self.ageSDL[SDLVarOfficeDoor] = (1,)
             else:
-                print("what's wrong with the door?")
+                PtDebugPrint("what's wrong with the door?")
 
         if (id == YeeshaSceneTimerDone.id and state and PlayScene == 1):
-            print("clftImager.OnNotify(): Yeesha timer is done.  Getting rid of Yeesha and setting SDL.")
+            PtDebugPrint("clftImager.OnNotify(): Yeesha timer is done.  Getting rid of Yeesha and setting SDL.")
             self.ageSDL = PtGetAgeSDL()
             YeeshaName.draw.disable()
             YeeshaName.physics.warpObj(YeeshaWarpHid.value.getKey())
@@ -561,13 +561,13 @@ class clftImager(ptResponder):
         PtDebugPrint("clftImager.SceneYeesha(): PlayScene = %d" % (PlayScene))
 
         if PlayScene == 1:
-            print("clftImager: Playing scene now...")
+            PtDebugPrint("clftImager: Playing scene now...")
             YeeshaName.draw.enable()
             YeeshaName.physics.warpObj(YeeshaWarpVis3.value.getKey())
             YeeshaMultiStage.gotoStage(YeeshaName, 3,dirFlag=1,isForward=1)
             YeeshaSpeech3.run(self.key,avatar=PtGetLocalAvatar())
         else:
-            print("clftImager: Nope, not playing scene.")
+            PtDebugPrint("clftImager: Nope, not playing scene.")
 
 
     def OpeningSolved(self):
@@ -579,8 +579,8 @@ class clftImager(ptResponder):
         imagerList.append(imagerRespS.state_list.index(imagerRespS.getState()))
         imagerList.append(imagerRespW.state_list.index(imagerRespW.getState()))
 
-        print("clftImager.OpenSolved(): solution list:", solutionList)
-        print("clftImager.OpenSolved(): imager list  :", imagerList)
+        PtDebugPrint("clftImager.OpenSolved(): solution list:", solutionList)
+        PtDebugPrint("clftImager.OpenSolved(): imager list  :", imagerList)
         
         if self.AreListsEquiv(solutionList, imagerList):
             return True
@@ -661,8 +661,8 @@ class clftImager(ptResponder):
         for x in range(4):
             currentStateList[x] = (currentStateList[x]+6)%7
 
-        print("clftImager.EndgameSolved(): solution list: " + str(solutionList))
-        print("clftImager.EndgameSolved(): currentState list: " + str(currentStateList))
+        PtDebugPrint("clftImager.EndgameSolved(): solution list: " + str(solutionList))
+        PtDebugPrint("clftImager.EndgameSolved(): currentState list: " + str(currentStateList))
 
         if self.AreListsEquiv(solutionList, currentStateList):
             return True
@@ -682,8 +682,8 @@ class clftImager(ptResponder):
         for x in range(4):
             currentStateList[x] = (currentStateList[x]+6)%7
 
-        print("clftImager.TPOTSolved(): solution list:", solutionList)
-        print("clftImager.TPOTSolved(): currentState list  :", currentStateList)
+        PtDebugPrint("clftImager.TPOTSolved(): solution list:", solutionList)
+        PtDebugPrint("clftImager.TPOTSolved(): currentState list  :", currentStateList)
         
         if self.AreListsEquiv(solutionList, currentStateList):
             return True
@@ -717,7 +717,7 @@ class clftImager(ptResponder):
                             chronSolutions = []
                             for sol in chronString:
                                 chronSolutions.append(string.atoi(sol))
-                            print("found pellet cave solution: ",chronSolutions)
+                            PtDebugPrint("found pellet cave solution: ",chronSolutions)
                             return chronSolutions
 
 
@@ -729,7 +729,7 @@ class clftImager(ptResponder):
         global speechKilled
         
         if visionplaying == 1 and id == kVision: 
-            print("\nclftImager.Ontimer:Got kVision timer callback. Automatically stopping vision.")
+            PtDebugPrint("\nclftImager.Ontimer:Got kVision timer callback. Automatically stopping vision.")
             self.StopVision()
             imagerBrokenBtn.disableActivator()
             imagerLockN.disableActivator()
@@ -737,7 +737,7 @@ class clftImager(ptResponder):
             imagerLockW.disableActivator()
             imagerLockE.disableActivator()
         #~ elif visionplaying == 1 and id == kFinished: 
-            #~ print "\nclftImager.Ontimer:Got kFinished timer callback. Automatically stopping vision."
+            #~ PtDebugPrint("\nclftImager.Ontimer:Got kFinished timer callback. Automatically stopping vision.")
             #~ finalDone = 1
             #~ self.StopVision()
             #~ imagerBrokenBtn.disableActivator()
@@ -746,7 +746,7 @@ class clftImager(ptResponder):
             #~ imagerLockW.disableActivator()
             #~ imagerLockE.disableActivator()
         elif id == imagerBrokenBtn.id:
-            print("\nclftImager.Ontimer:Got timer callback. Setting up Imager button....")
+            PtDebugPrint("\nclftImager.Ontimer:Got timer callback. Setting up Imager button....")
             imagerBtn.disableActivator()
             ImagerBtnInvisible.run(self.key)
             imagerBrokenBtn.enableActivator()
@@ -757,7 +757,7 @@ class clftImager(ptResponder):
             PtSendKIMessage(kDisableEntireYeeshaBook,0)
             PtDisableForwardMovement()
         elif id == imagerBtn.id:
-            print("\nclftImager.Ontimer:Got timer callback. Setting up Imager dummy....")
+            PtDebugPrint("\nclftImager.Ontimer:Got timer callback. Setting up Imager dummy....")
             imagerBrokenBtn.disableActivator()
             imagerLockN.disableActivator()
             imagerLockS.disableActivator()
@@ -784,7 +784,7 @@ class clftImager(ptResponder):
         global YeeshaName
         global VisionID
         
-        print("clftImager.StartVision: Playing Yeesha vision.")
+        PtDebugPrint("clftImager.StartVision: Playing Yeesha vision.")
         
         YeeshaName.draw.enable()
         
@@ -837,7 +837,7 @@ class clftImager(ptResponder):
         global PuzzleView
         global VisionID
         
-        print("clftImager.StopVision: Stopping Yeesha vision.")
+        PtDebugPrint("clftImager.StopVision: Stopping Yeesha vision.")
         
         YeeshaName.draw.disable()
         YeeshaName.physics.warpObj(YeeshaWarpHid.value.getKey())
@@ -847,7 +847,7 @@ class clftImager(ptResponder):
             YeeshaMultiStage.gotoStage(YeeshaName, 0,dirFlag=1,isForward=1)
             #respBookAnim.run(self.key,state="off")
             visionplaying = 0
-            print("TRYING TO KILL FINAL VISION")
+            PtDebugPrint("TRYING TO KILL FINAL VISION")
             if speechKilled == 1:
                 YeeshaSpeech2.run(self.key,state="on",fastforward=1)
                 KillFinalVisMusic.run(self.key)
@@ -877,9 +877,9 @@ class clftImager(ptResponder):
                 speechKilled = 0
             respPlayTPOTSpeech.run(self.key,state="off")
         else:
-            print("clftImager.StopVision: Don't know which vision to kill!")
+            PtDebugPrint("clftImager.StopVision: Don't know which vision to kill!")
 
-        print("PuzzleView = %s" % (PuzzleView))
+        PtDebugPrint("PuzzleView = %s" % (PuzzleView))
         
         avatar = PtGetLocalAvatar()
         if PuzzleView:
@@ -896,28 +896,28 @@ class clftImager(ptResponder):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print("valCityLinks = ",valCityLinks)
+            PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print("CityLinks = ",CityLinks)
+            PtDebugPrint("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
                 entryCityLinks.chronicleSetValue(NewLinks)
                 entryCityLinks.save()
-                print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
+                PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
                 valCityLinks = entryCityLinks.chronicleGetValue()
                 CityLinks = valCityLinks.split(",")
-                print("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
+                PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
-                print("xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
+                PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
         else:
             vault.addChronicleEntry("CityBookLinks",0,agePanel)
-            print("xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
+            PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
         
         psnlSDL = xPsnlVaultSDL()
         GotBook = psnlSDL["psnlGotCityBook"][0]
         if not GotBook:
             psnlSDL["psnlGotCityBook"] = (1,)
-            print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1")
+            PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1")
 
 
     def OnBackdoorMsg(self, target, param):

--- a/Python/clftIntroMusic.py
+++ b/Python/clftIntroMusic.py
@@ -97,17 +97,17 @@ class clftIntroMusic(ptResponder):
         startMusicActIDs = (actStartMusic01.id, actStartMusic02.id, actStartMusic03.id)
         if id in startMusicActIDs:
             if musicState == kOff:
-                print "clftIntroMusic: ---Starting Music---"
+                print("clftIntroMusic: ---Starting Music---")
                 musicState = kInitialPlay
                 respStartMusic.run(self.key)
             return
         
         elif id == actStopMusic.id:
             if musicState == kInitialPlay:
-                print "clftIntroMusic: ###Stopping Music###"
+                print("clftIntroMusic: ###Stopping Music###")
                 respStopInitialMusic.run(self.key)
             elif musicState == kRandomPlay:
-                print "clftIntroMusic: ###Stopping Music###"
+                print("clftIntroMusic: ###Stopping Music###")
                 respStopRandomMusic.run(self.key)
             musicState = kOff
             return
@@ -115,7 +115,7 @@ class clftIntroMusic(ptResponder):
         #-----Responders-----
         elif id == respStartMusic.id:
             if musicState == kInitialPlay:
-                print "clftIntroMusic: ___Randomly Starting Music___"
+                print("clftIntroMusic: ___Randomly Starting Music___")
                 musicState = kRandomPlay
                 respStartRandomMusic.run(self.key)
             return

--- a/Python/clftIntroMusic.py
+++ b/Python/clftIntroMusic.py
@@ -91,23 +91,23 @@ class clftIntroMusic(ptResponder):
             return
 
 
-        #print "clftIntroMusic: We've got notification from ID #:%s" %id 
+        #PtDebugPrint("clftIntroMusic: We've got notification from ID #:%s" %id)
 
         #-----Activators-----
         startMusicActIDs = (actStartMusic01.id, actStartMusic02.id, actStartMusic03.id)
         if id in startMusicActIDs:
             if musicState == kOff:
-                print("clftIntroMusic: ---Starting Music---")
+                PtDebugPrint("clftIntroMusic: ---Starting Music---")
                 musicState = kInitialPlay
                 respStartMusic.run(self.key)
             return
         
         elif id == actStopMusic.id:
             if musicState == kInitialPlay:
-                print("clftIntroMusic: ###Stopping Music###")
+                PtDebugPrint("clftIntroMusic: ###Stopping Music###")
                 respStopInitialMusic.run(self.key)
             elif musicState == kRandomPlay:
-                print("clftIntroMusic: ###Stopping Music###")
+                PtDebugPrint("clftIntroMusic: ###Stopping Music###")
                 respStopRandomMusic.run(self.key)
             musicState = kOff
             return
@@ -115,7 +115,7 @@ class clftIntroMusic(ptResponder):
         #-----Responders-----
         elif id == respStartMusic.id:
             if musicState == kInitialPlay:
-                print("clftIntroMusic: ___Randomly Starting Music___")
+                PtDebugPrint("clftIntroMusic: ___Randomly Starting Music___")
                 musicState = kRandomPlay
                 respStartRandomMusic.run(self.key)
             return

--- a/Python/clftNpcZandi.py
+++ b/Python/clftNpcZandi.py
@@ -98,7 +98,7 @@ class clftNpcZandi(ptModifier):
         self.id = 5217
         
         self.version = 7
-        print "__init__clftNpcZandi v.", self.version
+        print("__init__clftNpcZandi v.", self.version)
         self.NpcName = None
         self.ZandiFace = None
         random.seed()
@@ -128,18 +128,18 @@ class clftNpcZandi(ptModifier):
         PtAtTimeCallback(self.key, PageTurnInterval, TimerID.TurnPage)
 
     def OnNotify(self,state,id,events):
-        print "OnNotify id =", id
+        print("OnNotify id =", id)
         if id==NpcSpawner.id: # Causes Zandi to Ilde even before avatar visits
             self.NpcName = PtFindAvatar(events)
             MultiStage01.run(self.NpcName)
 
         elif id == actZandiClick.id:
-            print "Zandi was clicked"
+            print("Zandi was clicked")
             if not self.IsTalking:
-                print "Zandi will talk"
+                print("Zandi will talk")
                 self.ZandiSpeaks(1)
             else:
-                print "Zandi is already talking"
+                print("Zandi is already talking")
 
         elif id == Activate.id:
             # Zandi himself will activate the region when he spawns...
@@ -159,54 +159,54 @@ class clftNpcZandi(ptModifier):
                     self.PlayWelcome2 = 0
                 
         elif id == MultiStage01.id:
-            print "notified by behavior"
+            print("notified by behavior")
             for event in events:
                 if event[0]==10 and event[2]==3: # A Zandi behavior just finished. Returning to idle animation.
-                    print "zandi is done doing a behavior"
+                    print("zandi is done doing a behavior")
                     self.DoingBehavior = 0
                     break
 
         elif id in (respBrakeNotReleased.id, respWindmillNotTurning.id, respVisionNotSeen.id, respNoTrailerJC.id, respNoImagerJC.id, respNoBedroomJC.id, respNoWahrkJC.id, respNoSignJC.id, respNoBucketJC.id, respNoDoorJC.id, respDoorNotOpen.id, respZandiSayings.id ):
-            print "zandi finished talking"
+            print("zandi finished talking")
             if self.PlayOnFinish:
-                print "zandi has more to say"
+                print("zandi has more to say")
                 self.PlayOnFinish = 0
                 self.ZandiSpeaks()
             else:
-                print "zandi really is done and is ready to say more"
+                print("zandi really is done and is ready to say more")
                 self.IsTalking = 0
 
     def OnTimer(self,id):
         #~ global firstpauserange
         if id < 10:
-            print "attempt behavior ", id
+            print("attempt behavior ", id)
             if not self.DoingBehavior:
-                print "doing behavior ", id
+                print("doing behavior ", id)
                 self.DoingBehavior = 1
                 MultiStage01.gotoStage(self.NpcName, id,dirFlag=1,isForward=1)
             if isinstance(self.ZandiFace, str):
-                print "using zandi face anim:", self.ZandiFace
+                print("using zandi face anim:", self.ZandiFace)
                 self.NpcName.avatar.playSimpleAnimation(self.ZandiFace)
 
         elif id == TimerID.TurnPage:
-            print "attempt turn page"
+            print("attempt turn page")
             if not self.DoingBehavior:
-                print "do turn page"
+                print("do turn page")
                 self.DoingBehavior = 1
                 MultiStage01.gotoStage(self.NpcName, 2,dirFlag=1,isForward=1) #turn page
                 PtAtTimeCallback(self.key, PageTurnInterval, TimerID.TurnPage)
 
         elif id == TimerID.IgnoreFinished:
-            print "timer ignorefinished"
+            print("timer ignorefinished")
             if self.NearZandi:
                 if self.IsTalking:
-                    print "zandi's talking, play on finish"
+                    print("zandi's talking, play on finish")
                     self.PlayOnFinish = 1
                 else:
                     "speak zandi speak!"
                     self.ZandiSpeaks()
             else:
-                print "zandi's done ignoring"
+                print("zandi's done ignoring")
                 self.IsIgnoring = 0
             
 
@@ -227,35 +227,35 @@ class clftNpcZandi(ptModifier):
         return ""
 
     def CheckForJC(self, progress, jc):
-        print "check for jc"
+        print("check for jc")
         if jcDict[jc] in progress:
             return 1
         else:
             return 0
 
     def BahroDoorStillClosed(self, sdl):
-        print "in bahro door still closed"
+        print("in bahro door still closed")
         if sdl["clftBahroDoorClosed"][0]:
             return 1
         else:
             return 0
 
     def BrakeNotReleased(self, sdl):
-        print "in brake not released"
+        print("in brake not released")
         if sdl["clftAgeSDLWindmillLocked"][0]:
             return 1
         else:
             return 0
 
     def WindmillNotTurning(self, sdl):
-        print "in windmill not turning"
+        print("in windmill not turning")
         if sdl["clftAgeSDLWindmillRunning"][0]:
             return 0
         else:
             return 1
 
     def HaventSeenImagerMessage(self):
-        print "in haven't seen imager message"
+        print("in haven't seen imager message")
         vault = ptVault()
         entry = vault.findChronicleEntry("YeeshaVisionViewed")
         if entry is None:
@@ -268,9 +268,9 @@ class clftNpcZandi(ptModifier):
             return 1
 
     def NeedsWelcome(self, clicked = 0):
-        print "in needs welcome"
+        print("in needs welcome")
         if self.LastSpeech < 0 and clicked:
-            print "last speech less than 0 and clicked"
+            print("last speech less than 0 and clicked")
             return 1
         
         vault = ptVault()
@@ -305,7 +305,7 @@ class clftNpcZandi(ptModifier):
         
         useSpeech = "2"
 
-        print "last speech:", self.LastSpeech
+        print("last speech:", self.LastSpeech)
 
         self.IsTalking = 1
         stage = random.randint(1,5)
@@ -313,15 +313,15 @@ class clftNpcZandi(ptModifier):
 
         if self.PlayWelcome2 and clicked:
             if self.LastSpeech >= 0:
-                print "we've moved past the welcome, so don't play welcome 2"
+                print("we've moved past the welcome, so don't play welcome 2")
                 self.PlayWelcome2 = 0
             else:
-                print "let's play welcome2"
+                print("let's play welcome2")
                 self.PlaySecondWelcome()
                 stage = 4
 
         if self.NeedsWelcome(clicked):
-            print "zandi playes the welcome"
+            print("zandi playes the welcome")
             respZandiSayings.run(self.key, state = "welcome")
             self.ZandiFace = "ZandiOpen01Face"
             self.PlayWelcome2 = 1
@@ -341,7 +341,7 @@ class clftNpcZandi(ptModifier):
                     else:
                         useSpeech = "1"
                 
-            print "playing brake not released, speech = ", useSpeech
+            print("playing brake not released, speech = ", useSpeech)
             respBrakeNotReleased.run(self.key, useSpeech)
             if useSpeech == "1":
                 self.ZandiFace = "ZandiRes01aFace"
@@ -361,7 +361,7 @@ class clftNpcZandi(ptModifier):
                         useSpeech = "2"
                     else:
                         useSpeech = "1"
-            print "playing no windmill, speech = ", useSpeech
+            print("playing no windmill, speech = ", useSpeech)
             respWindmillNotTurning.run(self.key, useSpeech)
             if useSpeech == "1":
                 self.ZandiFace = "ZandiRes02aFace"
@@ -381,7 +381,7 @@ class clftNpcZandi(ptModifier):
                         useSpeech = "2"
                     else:
                         useSpeech = "1"
-            print "playing no imager message, speech = ", useSpeech
+            print("playing no imager message, speech = ", useSpeech)
             respVisionNotSeen.run(self.key, useSpeech)
             if useSpeech == "1":
                 self.ZandiFace = "ZandiRes03aFace"
@@ -403,7 +403,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no trailer jc, speech = ", useSpeech
+                print("playing no trailer jc, speech = ", useSpeech)
                 respNoTrailerJC.run(self.key, useSpeech)
                 
                 if useSpeech == "1":
@@ -424,7 +424,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no imager jc, speech = ", useSpeech
+                print("playing no imager jc, speech = ", useSpeech)
                 respNoImagerJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC02aFace"
@@ -444,7 +444,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no bedroom jc, speech = ", useSpeech
+                print("playing no bedroom jc, speech = ", useSpeech)
                 respNoBedroomJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC03aFace"
@@ -464,7 +464,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no whark jc, speech = ", useSpeech
+                print("playing no whark jc, speech = ", useSpeech)
                 respNoWahrkJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC04aFace"
@@ -484,7 +484,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no sign jc, speech = ", useSpeech
+                print("playing no sign jc, speech = ", useSpeech)
                 respNoSignJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC05aFace"
@@ -504,7 +504,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no bucket jc, speech = ", useSpeech
+                print("playing no bucket jc, speech = ", useSpeech)
                 respNoBucketJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC06aFace"
@@ -524,7 +524,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing no door jc, speech = ", useSpeech
+                print("playing no door jc, speech = ", useSpeech)
                 respNoDoorJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC07aFace"
@@ -544,7 +544,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print "playing door not open speech"
+                print("playing door not open speech")
                 respDoorNotOpen.run(self.key)
                 self.ZandiFace = "ZandiAllFace"
             else:
@@ -556,7 +556,7 @@ class clftNpcZandi(ptModifier):
                 self.ZandiFace = "ZandiRand0" + str( usesaying - 1) + "Face"
 
                 if useSpeech != "":
-                    print "playing misc, speech = ", useSpeech
+                    print("playing misc, speech = ", useSpeech)
                     respZandiSayings.run(self.key, state = useSpeech)
 
         PtAtTimeCallback(self.key, 2, stage)

--- a/Python/clftNpcZandi.py
+++ b/Python/clftNpcZandi.py
@@ -98,7 +98,7 @@ class clftNpcZandi(ptModifier):
         self.id = 5217
         
         self.version = 7
-        print("__init__clftNpcZandi v.", self.version)
+        PtDebugPrint("__init__clftNpcZandi v.", self.version)
         self.NpcName = None
         self.ZandiFace = None
         random.seed()
@@ -119,7 +119,7 @@ class clftNpcZandi(ptModifier):
             #~ FoundJCs = entry.chronicleGetValue()
             #~ if "Z" in FoundJCs:
                 #~ PtPageOutNode("clftZandiVis")
-                #~ print "Zandi seems to have stepped away from the Airstream. Hmmm..."
+                #~ PtDebugPrint("Zandi seems to have stepped away from the Airstream. Hmmm...")
 
         entry = vault.findChronicleEntry("YeeshaVisionViewed")
         if entry is None:
@@ -128,18 +128,18 @@ class clftNpcZandi(ptModifier):
         PtAtTimeCallback(self.key, PageTurnInterval, TimerID.TurnPage)
 
     def OnNotify(self,state,id,events):
-        print("OnNotify id =", id)
+        PtDebugPrint("OnNotify id =", id)
         if id==NpcSpawner.id: # Causes Zandi to Ilde even before avatar visits
             self.NpcName = PtFindAvatar(events)
             MultiStage01.run(self.NpcName)
 
         elif id == actZandiClick.id:
-            print("Zandi was clicked")
+            PtDebugPrint("Zandi was clicked")
             if not self.IsTalking:
-                print("Zandi will talk")
+                PtDebugPrint("Zandi will talk")
                 self.ZandiSpeaks(1)
             else:
-                print("Zandi is already talking")
+                PtDebugPrint("Zandi is already talking")
 
         elif id == Activate.id:
             # Zandi himself will activate the region when he spawns...
@@ -154,59 +154,59 @@ class clftNpcZandi(ptModifier):
                         self.ZandiSpeaks()
                 
                 elif event[0]==1 and event[1]==0: # avatar physically stepped away from Zandi
-                    #~ print "Stepped away"
+                    #~ PtDebugPrint("Stepped away")
                     self.NearZandi = 0
                     self.PlayWelcome2 = 0
                 
         elif id == MultiStage01.id:
-            print("notified by behavior")
+            PtDebugPrint("notified by behavior")
             for event in events:
                 if event[0]==10 and event[2]==3: # A Zandi behavior just finished. Returning to idle animation.
-                    print("zandi is done doing a behavior")
+                    PtDebugPrint("zandi is done doing a behavior")
                     self.DoingBehavior = 0
                     break
 
         elif id in (respBrakeNotReleased.id, respWindmillNotTurning.id, respVisionNotSeen.id, respNoTrailerJC.id, respNoImagerJC.id, respNoBedroomJC.id, respNoWahrkJC.id, respNoSignJC.id, respNoBucketJC.id, respNoDoorJC.id, respDoorNotOpen.id, respZandiSayings.id ):
-            print("zandi finished talking")
+            PtDebugPrint("zandi finished talking")
             if self.PlayOnFinish:
-                print("zandi has more to say")
+                PtDebugPrint("zandi has more to say")
                 self.PlayOnFinish = 0
                 self.ZandiSpeaks()
             else:
-                print("zandi really is done and is ready to say more")
+                PtDebugPrint("zandi really is done and is ready to say more")
                 self.IsTalking = 0
 
     def OnTimer(self,id):
         #~ global firstpauserange
         if id < 10:
-            print("attempt behavior ", id)
+            PtDebugPrint("attempt behavior ", id)
             if not self.DoingBehavior:
-                print("doing behavior ", id)
+                PtDebugPrint("doing behavior ", id)
                 self.DoingBehavior = 1
                 MultiStage01.gotoStage(self.NpcName, id,dirFlag=1,isForward=1)
             if isinstance(self.ZandiFace, str):
-                print("using zandi face anim:", self.ZandiFace)
+                PtDebugPrint("using zandi face anim:", self.ZandiFace)
                 self.NpcName.avatar.playSimpleAnimation(self.ZandiFace)
 
         elif id == TimerID.TurnPage:
-            print("attempt turn page")
+            PtDebugPrint("attempt turn page")
             if not self.DoingBehavior:
-                print("do turn page")
+                PtDebugPrint("do turn page")
                 self.DoingBehavior = 1
                 MultiStage01.gotoStage(self.NpcName, 2,dirFlag=1,isForward=1) #turn page
                 PtAtTimeCallback(self.key, PageTurnInterval, TimerID.TurnPage)
 
         elif id == TimerID.IgnoreFinished:
-            print("timer ignorefinished")
+            PtDebugPrint("timer ignorefinished")
             if self.NearZandi:
                 if self.IsTalking:
-                    print("zandi's talking, play on finish")
+                    PtDebugPrint("zandi's talking, play on finish")
                     self.PlayOnFinish = 1
                 else:
                     "speak zandi speak!"
                     self.ZandiSpeaks()
             else:
-                print("zandi's done ignoring")
+                PtDebugPrint("zandi's done ignoring")
                 self.IsIgnoring = 0
             
 
@@ -227,35 +227,35 @@ class clftNpcZandi(ptModifier):
         return ""
 
     def CheckForJC(self, progress, jc):
-        print("check for jc")
+        PtDebugPrint("check for jc")
         if jcDict[jc] in progress:
             return 1
         else:
             return 0
 
     def BahroDoorStillClosed(self, sdl):
-        print("in bahro door still closed")
+        PtDebugPrint("in bahro door still closed")
         if sdl["clftBahroDoorClosed"][0]:
             return 1
         else:
             return 0
 
     def BrakeNotReleased(self, sdl):
-        print("in brake not released")
+        PtDebugPrint("in brake not released")
         if sdl["clftAgeSDLWindmillLocked"][0]:
             return 1
         else:
             return 0
 
     def WindmillNotTurning(self, sdl):
-        print("in windmill not turning")
+        PtDebugPrint("in windmill not turning")
         if sdl["clftAgeSDLWindmillRunning"][0]:
             return 0
         else:
             return 1
 
     def HaventSeenImagerMessage(self):
-        print("in haven't seen imager message")
+        PtDebugPrint("in haven't seen imager message")
         vault = ptVault()
         entry = vault.findChronicleEntry("YeeshaVisionViewed")
         if entry is None:
@@ -268,9 +268,9 @@ class clftNpcZandi(ptModifier):
             return 1
 
     def NeedsWelcome(self, clicked = 0):
-        print("in needs welcome")
+        PtDebugPrint("in needs welcome")
         if self.LastSpeech < 0 and clicked:
-            print("last speech less than 0 and clicked")
+            PtDebugPrint("last speech less than 0 and clicked")
             return 1
         
         vault = ptVault()
@@ -305,7 +305,7 @@ class clftNpcZandi(ptModifier):
         
         useSpeech = "2"
 
-        print("last speech:", self.LastSpeech)
+        PtDebugPrint("last speech:", self.LastSpeech)
 
         self.IsTalking = 1
         stage = random.randint(1,5)
@@ -313,15 +313,15 @@ class clftNpcZandi(ptModifier):
 
         if self.PlayWelcome2 and clicked:
             if self.LastSpeech >= 0:
-                print("we've moved past the welcome, so don't play welcome 2")
+                PtDebugPrint("we've moved past the welcome, so don't play welcome 2")
                 self.PlayWelcome2 = 0
             else:
-                print("let's play welcome2")
+                PtDebugPrint("let's play welcome2")
                 self.PlaySecondWelcome()
                 stage = 4
 
         if self.NeedsWelcome(clicked):
-            print("zandi playes the welcome")
+            PtDebugPrint("zandi playes the welcome")
             respZandiSayings.run(self.key, state = "welcome")
             self.ZandiFace = "ZandiOpen01Face"
             self.PlayWelcome2 = 1
@@ -341,7 +341,7 @@ class clftNpcZandi(ptModifier):
                     else:
                         useSpeech = "1"
                 
-            print("playing brake not released, speech = ", useSpeech)
+            PtDebugPrint("playing brake not released, speech = ", useSpeech)
             respBrakeNotReleased.run(self.key, useSpeech)
             if useSpeech == "1":
                 self.ZandiFace = "ZandiRes01aFace"
@@ -361,7 +361,7 @@ class clftNpcZandi(ptModifier):
                         useSpeech = "2"
                     else:
                         useSpeech = "1"
-            print("playing no windmill, speech = ", useSpeech)
+            PtDebugPrint("playing no windmill, speech = ", useSpeech)
             respWindmillNotTurning.run(self.key, useSpeech)
             if useSpeech == "1":
                 self.ZandiFace = "ZandiRes02aFace"
@@ -381,7 +381,7 @@ class clftNpcZandi(ptModifier):
                         useSpeech = "2"
                     else:
                         useSpeech = "1"
-            print("playing no imager message, speech = ", useSpeech)
+            PtDebugPrint("playing no imager message, speech = ", useSpeech)
             respVisionNotSeen.run(self.key, useSpeech)
             if useSpeech == "1":
                 self.ZandiFace = "ZandiRes03aFace"
@@ -403,7 +403,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no trailer jc, speech = ", useSpeech)
+                PtDebugPrint("playing no trailer jc, speech = ", useSpeech)
                 respNoTrailerJC.run(self.key, useSpeech)
                 
                 if useSpeech == "1":
@@ -424,7 +424,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no imager jc, speech = ", useSpeech)
+                PtDebugPrint("playing no imager jc, speech = ", useSpeech)
                 respNoImagerJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC02aFace"
@@ -444,7 +444,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no bedroom jc, speech = ", useSpeech)
+                PtDebugPrint("playing no bedroom jc, speech = ", useSpeech)
                 respNoBedroomJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC03aFace"
@@ -464,7 +464,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no whark jc, speech = ", useSpeech)
+                PtDebugPrint("playing no whark jc, speech = ", useSpeech)
                 respNoWahrkJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC04aFace"
@@ -484,7 +484,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no sign jc, speech = ", useSpeech)
+                PtDebugPrint("playing no sign jc, speech = ", useSpeech)
                 respNoSignJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC05aFace"
@@ -504,7 +504,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no bucket jc, speech = ", useSpeech)
+                PtDebugPrint("playing no bucket jc, speech = ", useSpeech)
                 respNoBucketJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC06aFace"
@@ -524,7 +524,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing no door jc, speech = ", useSpeech)
+                PtDebugPrint("playing no door jc, speech = ", useSpeech)
                 respNoDoorJC.run(self.key, useSpeech)
                 if useSpeech == "1":
                     self.ZandiFace = "ZandiJC07aFace"
@@ -544,7 +544,7 @@ class clftNpcZandi(ptModifier):
                             useSpeech = "2"
                         else:
                             useSpeech = "1"
-                print("playing door not open speech")
+                PtDebugPrint("playing door not open speech")
                 respDoorNotOpen.run(self.key)
                 self.ZandiFace = "ZandiAllFace"
             else:
@@ -556,7 +556,7 @@ class clftNpcZandi(ptModifier):
                 self.ZandiFace = "ZandiRand0" + str( usesaying - 1) + "Face"
 
                 if useSpeech != "":
-                    print("playing misc, speech = ", useSpeech)
+                    PtDebugPrint("playing misc, speech = ", useSpeech)
                     respZandiSayings.run(self.key, state = useSpeech)
 
         PtAtTimeCallback(self.key, 2, stage)

--- a/Python/clftTreeLadder.py
+++ b/Python/clftTreeLadder.py
@@ -70,7 +70,7 @@ class clftTreeLadder(ptModifier):
         
         version = 4
         self.version = version
-        print "__init__clftTreeLadder v.", version
+        print("__init__clftTreeLadder v.", version)
 
     def OnFirstUpdate(self):
         pass
@@ -86,10 +86,10 @@ class clftTreeLadder(ptModifier):
             
             elif event[0] == 10 and event[1] == 1 and (direction.value) == "up": # going up
                 audioresponder.run(self.key)
-                print "Playing sfx for climbing out of the tree"
+                print("Playing sfx for climbing out of the tree")
 
             elif event[0] == 10 and event[1] == 0 and (direction.value) == "down": # going down
                 audioresponder.run(self.key)
-                print "Playing sfx for climbing into the tree"
+                print("Playing sfx for climbing into the tree")
 
 

--- a/Python/clftTreeLadder.py
+++ b/Python/clftTreeLadder.py
@@ -70,7 +70,7 @@ class clftTreeLadder(ptModifier):
         
         version = 4
         self.version = version
-        print("__init__clftTreeLadder v.", version)
+        PtDebugPrint("__init__clftTreeLadder v.", version)
 
     def OnFirstUpdate(self):
         pass
@@ -86,10 +86,10 @@ class clftTreeLadder(ptModifier):
             
             elif event[0] == 10 and event[1] == 1 and (direction.value) == "up": # going up
                 audioresponder.run(self.key)
-                print("Playing sfx for climbing out of the tree")
+                PtDebugPrint("Playing sfx for climbing out of the tree")
 
             elif event[0] == 10 and event[1] == 0 and (direction.value) == "down": # going down
                 audioresponder.run(self.key)
-                print("Playing sfx for climbing into the tree")
+                PtDebugPrint("Playing sfx for climbing into the tree")
 
 

--- a/Python/clftYeeshaPage08.py
+++ b/Python/clftYeeshaPage08.py
@@ -103,7 +103,7 @@ class clftYeeshaPage08(ptModifier):
         ptModifier.__init__(self)
         self.id = 5312
         self.version = 1
-        print "__init__clftYeeshaPage08 v.", self.version
+        print("__init__clftYeeshaPage08 v.", self.version)
 
 
     def OnFirstUpdate(self):

--- a/Python/clftYeeshaPage08.py
+++ b/Python/clftYeeshaPage08.py
@@ -103,7 +103,7 @@ class clftYeeshaPage08(ptModifier):
         ptModifier.__init__(self)
         self.id = 5312
         self.version = 1
-        print("__init__clftYeeshaPage08 v.", self.version)
+        PtDebugPrint("__init__clftYeeshaPage08 v.", self.version)
 
 
     def OnFirstUpdate(self):

--- a/Python/clftYeeshaPageImager.py
+++ b/Python/clftYeeshaPageImager.py
@@ -78,7 +78,7 @@ class clftYeeshaPageImager(ptModifier):
         
         version = 5
         self.version = version
-        print "__init__clftYeeshaPageImager v.", version
+        print("__init__clftYeeshaPageImager v.", version)
         self.ImagerUsable = 1
         random.seed()
 
@@ -103,7 +103,7 @@ class clftYeeshaPageImager(ptModifier):
             ageSDL = PtGetAgeSDL()
             ageSDL.setNotify(self.key,"clftYeeshaPage08Vis",0.0)
             self.ImagerUsable = ageSDL["clftYeeshaPage08Vis"][0]
-            print "ServerInitComplete: ImagerUsable: %d" % self.ImagerUsable
+            print("ServerInitComplete: ImagerUsable: %d" % self.ImagerUsable)
 
             ageSDL.setNotify(self.key, "clftAgeSDLWindmillRunning", 0.0)
 
@@ -130,7 +130,7 @@ class clftYeeshaPageImager(ptModifier):
 
 
     def OnSDLNotify(self,VARname,SDLname,PlayerID,tag):
-        print "clftYeeshaPageImager.OnSDLNotify():  var = ",VARname
+        print("clftYeeshaPageImager.OnSDLNotify():  var = ",VARname)
         global inTomahna
         
         if AgeStartedIn == PtGetAgeName():
@@ -159,13 +159,13 @@ class clftYeeshaPageImager(ptModifier):
         if not state:
             return
 
-        print "clftYeeshaPageImager.OnNotify()"
-        print "ImagerUsable: %d" % self.ImagerUsable
+        print("clftYeeshaPageImager.OnNotify()")
+        print("ImagerUsable: %d" % self.ImagerUsable)
         
         for event in events:
             #~ print "YP events: ", event
             if event[0]==2 and event[1]==1 and id == ActImager.id: # play avatar oneshot, regardless of whether button is going on or off
-                print "clftYeeshaPageImager.OnNotify():Imager Button pressed. Playfull = ", PlayFull
+                print("clftYeeshaPageImager.OnNotify():Imager Button pressed. Playfull = ", PlayFull)
                 if PtWasLocallyNotified(self.key):
                     #AvatarOneshot.run(self.key,events=events)
                     AvatarOneshot.run(self.key,avatar=PtGetLocalAvatar())
@@ -173,7 +173,7 @@ class clftYeeshaPageImager(ptModifier):
             elif event[0]==8 and event[1]==1: # A "Notify triggerer" command was received from one of several responders. The id distinguishes which it is
                 if not self.ImagerUsable:
                     # imager not usable and event is something other than the oneshot
-                    print "clftYeeshaPageImager.OnNotify(): imager should be not working right now"
+                    print("clftYeeshaPageImager.OnNotify(): imager should be not working right now")
                     ActImager.enable()
                     return
 
@@ -202,7 +202,7 @@ class clftYeeshaPageImager(ptModifier):
         global visionplaying
         global PlayFull
         
-        print "clftYeeshaPageImager: Turning on YP Imager"
+        print("clftYeeshaPageImager: Turning on YP Imager")
 
         # disable imager clickable so it can't be turned off while opening
         ActImager.disable()
@@ -216,7 +216,7 @@ class clftYeeshaPageImager(ptModifier):
         
     def CloseImager(self,ff=0):
         global visionplaying
-        print "clftYeeshaPageImager: Turning off YP Imager"
+        print("clftYeeshaPageImager: Turning off YP Imager")
 
         # disable imager clickable so it can't be turned off while closing
         ActImager.disable()

--- a/Python/clftYeeshaPageImager.py
+++ b/Python/clftYeeshaPageImager.py
@@ -78,7 +78,7 @@ class clftYeeshaPageImager(ptModifier):
         
         version = 5
         self.version = version
-        print("__init__clftYeeshaPageImager v.", version)
+        PtDebugPrint("__init__clftYeeshaPageImager v.", version)
         self.ImagerUsable = 1
         random.seed()
 
@@ -103,7 +103,7 @@ class clftYeeshaPageImager(ptModifier):
             ageSDL = PtGetAgeSDL()
             ageSDL.setNotify(self.key,"clftYeeshaPage08Vis",0.0)
             self.ImagerUsable = ageSDL["clftYeeshaPage08Vis"][0]
-            print("ServerInitComplete: ImagerUsable: %d" % self.ImagerUsable)
+            PtDebugPrint("ServerInitComplete: ImagerUsable: %d" % self.ImagerUsable)
 
             ageSDL.setNotify(self.key, "clftAgeSDLWindmillRunning", 0.0)
 
@@ -117,20 +117,20 @@ class clftYeeshaPageImager(ptModifier):
             if powerOn:
                 if inTomahna:
                     GreenLightResp.run(self.key, state = "Blinking")
-                    #print "starting blinking green light"
+                    #PtDebugPrint("starting blinking green light")
                 else:
                     GreenLightResp.run(self.key, state = "Solid")
-                    #print "starting solid green light"
+                    #PtDebugPrint("starting solid green light")
             else:
                 GreenLightResp.run(self.key, state = "Off")
-                #print "green light is off"
+                #PtDebugPrint("green light is off")
         
         if inTomahna:
             PtLoadDialog("YeeshaPageGUI")
 
 
     def OnSDLNotify(self,VARname,SDLname,PlayerID,tag):
-        print("clftYeeshaPageImager.OnSDLNotify():  var = ",VARname)
+        PtDebugPrint("clftYeeshaPageImager.OnSDLNotify():  var = ",VARname)
         global inTomahna
         
         if AgeStartedIn == PtGetAgeName():
@@ -142,13 +142,13 @@ class clftYeeshaPageImager(ptModifier):
                 if powerOn:
                     if inTomahna:
                         GreenLightResp.run(self.key, state = "Blinking")
-                        #print "starting blinking green light"
+                        #PtDebugPrint("starting blinking green light")
                     else:
                         GreenLightResp.run(self.key, state = "Solid")
-                        #print "starting solid green light"
+                        #PtDebugPrint("starting solid green light")
                 else:
                     GreenLightResp.run(self.key, state = "Off")
-                    #print "green light is off"
+                    #PtDebugPrint("green light is off")
                     self.CloseImager()
 
 
@@ -159,13 +159,13 @@ class clftYeeshaPageImager(ptModifier):
         if not state:
             return
 
-        print("clftYeeshaPageImager.OnNotify()")
-        print("ImagerUsable: %d" % self.ImagerUsable)
+        PtDebugPrint("clftYeeshaPageImager.OnNotify()")
+        PtDebugPrint("ImagerUsable: %d" % self.ImagerUsable)
         
         for event in events:
-            #~ print "YP events: ", event
+            #~ PtDebugPrint("YP events: ", event)
             if event[0]==2 and event[1]==1 and id == ActImager.id: # play avatar oneshot, regardless of whether button is going on or off
-                print("clftYeeshaPageImager.OnNotify():Imager Button pressed. Playfull = ", PlayFull)
+                PtDebugPrint("clftYeeshaPageImager.OnNotify():Imager Button pressed. Playfull = ", PlayFull)
                 if PtWasLocallyNotified(self.key):
                     #AvatarOneshot.run(self.key,events=events)
                     AvatarOneshot.run(self.key,avatar=PtGetLocalAvatar())
@@ -173,7 +173,7 @@ class clftYeeshaPageImager(ptModifier):
             elif event[0]==8 and event[1]==1: # A "Notify triggerer" command was received from one of several responders. The id distinguishes which it is
                 if not self.ImagerUsable:
                     # imager not usable and event is something other than the oneshot
-                    print("clftYeeshaPageImager.OnNotify(): imager should be not working right now")
+                    PtDebugPrint("clftYeeshaPageImager.OnNotify(): imager should be not working right now")
                     ActImager.enable()
                     return
 
@@ -185,12 +185,12 @@ class clftYeeshaPageImager(ptModifier):
                 
                 elif id == ImagerOpen.id: #the Imager Open animation sequences completed. Determine if we should loop or auto shut off.
                     if PlayFull != 1:
-#                        print "Closing. Playfull = ", PlayFull
+#                        PtDebugPrint("Closing. Playfull = ", PlayFull)
                         self.CloseImager()
                     else:
                         # imager is done opening and it is starting to loop so enable the clickable
                         ActImager.enable()
-#                        print "Will loop indefinitely. Playfull = ", PlayFull
+#                        PtDebugPrint("Will loop indefinitely. Playfull = ", PlayFull)
                         ImagerLoop.run(self.key)
 
                 elif id == ImagerClose.id: # imager close anim is complete, reenable clickable.
@@ -202,7 +202,7 @@ class clftYeeshaPageImager(ptModifier):
         global visionplaying
         global PlayFull
         
-        print("clftYeeshaPageImager: Turning on YP Imager")
+        PtDebugPrint("clftYeeshaPageImager: Turning on YP Imager")
 
         # disable imager clickable so it can't be turned off while opening
         ActImager.disable()
@@ -216,7 +216,7 @@ class clftYeeshaPageImager(ptModifier):
         
     def CloseImager(self,ff=0):
         global visionplaying
-        print("clftYeeshaPageImager: Turning off YP Imager")
+        PtDebugPrint("clftYeeshaPageImager: Turning off YP Imager")
 
         # disable imager clickable so it can't be turned off while closing
         ActImager.disable()

--- a/Python/dsntKILightMachine.py
+++ b/Python/dsntKILightMachine.py
@@ -138,10 +138,10 @@ class dsntKILightMachine(ptModifier):
         elif id == respDispensor.id:
             kiLevel = PtGetLocalKILevel()
             if kiLevel > 1:
-                print "dsntKILightMachine.OnNotify(): you've got your KI, proceeding..."
+                print("dsntKILightMachine.OnNotify(): you've got your KI, proceeding...")
                 respGotKI.run(self.key)
             else:
-                print "dsntKILightMachine.OnNotify(): you don't have your KI yet, machine won't respond"
+                print("dsntKILightMachine.OnNotify(): you don't have your KI yet, machine won't respond")
         
         elif id == respGotKI.id:        	
             if IsAvatarLocal:
@@ -150,14 +150,14 @@ class dsntKILightMachine(ptModifier):
                     PtSendKIMessage(kStartKIAlert,0)
                     self.SetKILightTime(1)
                 else:
-                    print "light already on, resetting..."
+                    print("light already on, resetting...")
                     self.SetKILightTime(2)
 
 
     def SetKILightTime(self,on):
         global lightStop
         global lightOn
-        print "dsntKILightMachine.SetKILightTime(): byteKILightFunc = ",byteKILightFunc
+        print("dsntKILightMachine.SetKILightTime(): byteKILightFunc = ",byteKILightFunc)
         lightStart = PtGetDniTime()
 
         if not byteKILightFunc:
@@ -168,14 +168,14 @@ class dsntKILightMachine(ptModifier):
             lightStop = (lightStart + kLightTimeLong)
 
         timeRemaining = (lightStop - lightStart)
-        print "timer set, light will shut off in ",timeRemaining," seconds; lightStop = ",lightStop
+        print("timer set, light will shut off in ",timeRemaining," seconds; lightStop = ",lightStop)
         self.SetKILightChron(0)
 
         if on == 1:
             self.DoKILight(1,0,timeRemaining)
         elif on == 2:
             PtAtTimeCallback(self.key,timeRemaining,kLightStopID)
-            print "light was reset, so don't run the responder as it's already on"
+            print("light was reset, so don't run the responder as it's already on")
 
  
     def SetKILightChron(self,remaining):
@@ -186,7 +186,7 @@ class dsntKILightMachine(ptModifier):
             oldVal = string.atoi(entryValue)
             if remaining == oldVal:
                 return
-            print "set KI light chron to: ",remaining
+            print("set KI light chron to: ",remaining)
             entry.chronicleSetValue("%d" % (remaining))
             entry.save()
         else:
@@ -198,11 +198,11 @@ class dsntKILightMachine(ptModifier):
         #print "dsntKILightMachine.OnTimer(): id = ",id
         if id == kLightStopID:
             curTime = PtGetDniTime()
-            print "dsntKILightMachine.OnTimer():  lightStop = ",lightStop,", curTime = ",curTime
+            print("dsntKILightMachine.OnTimer():  lightStop = ",lightStop,", curTime = ",curTime)
             if curTime >= (lightStop - 1):
                 self.DoKILight(0,0)
             else:
-                print "dsntKILightMachine.OnTimer(): timer says shut off light, but times don't match.  Light must have been reset, ignoring this callback"
+                print("dsntKILightMachine.OnTimer(): timer says shut off light, but times don't match.  Light must have been reset, ignoring this callback")
 
 
     def DoKILight(self,state,ff,remaining=0):
@@ -229,10 +229,10 @@ class dsntKILightMachine(ptModifier):
                     atResp.run(self.key,avatar=LocalAvatar,fastforward=ff)
                     if state:
                         PtAtTimeCallback(self.key,remaining,kLightStopID)
-                        print "dsntKILightMachine.DoKILight(): turning light on for ",remaining," seconds"
+                        print("dsntKILightMachine.DoKILight(): turning light on for ",remaining," seconds")
                         lightOn = 1
                     else:
-                        print "dsntKILightMachine.DoKILight(): light is shut off, updating chron if it needs it"
+                        print("dsntKILightMachine.DoKILight(): light is shut off, updating chron if it needs it")
                         self.SetKILightChron(remaining)
                         lightOn = 0
                         PtSetLightAnimStart(avatarKey, KILightObjectName, False)
@@ -250,7 +250,7 @@ class dsntKILightMachine(ptModifier):
             return
         
         if (LocalAvatar == avObj):
-            print "dsntKILightMachine.BeginAgeUnLoad()-->\tavatar page out"
+            print("dsntKILightMachine.BeginAgeUnLoad()-->\tavatar page out")
             curTime = PtGetDniTime()
             timeRemaining = (lightStop - curTime)
             if timeRemaining > 0:

--- a/Python/dsntKILightMachine.py
+++ b/Python/dsntKILightMachine.py
@@ -138,10 +138,10 @@ class dsntKILightMachine(ptModifier):
         elif id == respDispensor.id:
             kiLevel = PtGetLocalKILevel()
             if kiLevel > 1:
-                print("dsntKILightMachine.OnNotify(): you've got your KI, proceeding...")
+                PtDebugPrint("dsntKILightMachine.OnNotify(): you've got your KI, proceeding...")
                 respGotKI.run(self.key)
             else:
-                print("dsntKILightMachine.OnNotify(): you don't have your KI yet, machine won't respond")
+                PtDebugPrint("dsntKILightMachine.OnNotify(): you don't have your KI yet, machine won't respond")
         
         elif id == respGotKI.id:        	
             if IsAvatarLocal:
@@ -150,14 +150,14 @@ class dsntKILightMachine(ptModifier):
                     PtSendKIMessage(kStartKIAlert,0)
                     self.SetKILightTime(1)
                 else:
-                    print("light already on, resetting...")
+                    PtDebugPrint("light already on, resetting...")
                     self.SetKILightTime(2)
 
 
     def SetKILightTime(self,on):
         global lightStop
         global lightOn
-        print("dsntKILightMachine.SetKILightTime(): byteKILightFunc = ",byteKILightFunc)
+        PtDebugPrint("dsntKILightMachine.SetKILightTime(): byteKILightFunc = ",byteKILightFunc)
         lightStart = PtGetDniTime()
 
         if not byteKILightFunc:
@@ -168,14 +168,14 @@ class dsntKILightMachine(ptModifier):
             lightStop = (lightStart + kLightTimeLong)
 
         timeRemaining = (lightStop - lightStart)
-        print("timer set, light will shut off in ",timeRemaining," seconds; lightStop = ",lightStop)
+        PtDebugPrint("timer set, light will shut off in ",timeRemaining," seconds; lightStop = ",lightStop)
         self.SetKILightChron(0)
 
         if on == 1:
             self.DoKILight(1,0,timeRemaining)
         elif on == 2:
             PtAtTimeCallback(self.key,timeRemaining,kLightStopID)
-            print("light was reset, so don't run the responder as it's already on")
+            PtDebugPrint("light was reset, so don't run the responder as it's already on")
 
  
     def SetKILightChron(self,remaining):
@@ -186,7 +186,7 @@ class dsntKILightMachine(ptModifier):
             oldVal = string.atoi(entryValue)
             if remaining == oldVal:
                 return
-            print("set KI light chron to: ",remaining)
+            PtDebugPrint("set KI light chron to: ",remaining)
             entry.chronicleSetValue("%d" % (remaining))
             entry.save()
         else:
@@ -195,14 +195,14 @@ class dsntKILightMachine(ptModifier):
 
 
     def OnTimer(self,id):
-        #print "dsntKILightMachine.OnTimer(): id = ",id
+        #PtDebugPrint("dsntKILightMachine.OnTimer(): id = ",id)
         if id == kLightStopID:
             curTime = PtGetDniTime()
-            print("dsntKILightMachine.OnTimer():  lightStop = ",lightStop,", curTime = ",curTime)
+            PtDebugPrint("dsntKILightMachine.OnTimer():  lightStop = ",lightStop,", curTime = ",curTime)
             if curTime >= (lightStop - 1):
                 self.DoKILight(0,0)
             else:
-                print("dsntKILightMachine.OnTimer(): timer says shut off light, but times don't match.  Light must have been reset, ignoring this callback")
+                PtDebugPrint("dsntKILightMachine.OnTimer(): timer says shut off light, but times don't match.  Light must have been reset, ignoring this callback")
 
 
     def DoKILight(self,state,ff,remaining=0):
@@ -229,10 +229,10 @@ class dsntKILightMachine(ptModifier):
                     atResp.run(self.key,avatar=LocalAvatar,fastforward=ff)
                     if state:
                         PtAtTimeCallback(self.key,remaining,kLightStopID)
-                        print("dsntKILightMachine.DoKILight(): turning light on for ",remaining," seconds")
+                        PtDebugPrint("dsntKILightMachine.DoKILight(): turning light on for ",remaining," seconds")
                         lightOn = 1
                     else:
-                        print("dsntKILightMachine.DoKILight(): light is shut off, updating chron if it needs it")
+                        PtDebugPrint("dsntKILightMachine.DoKILight(): light is shut off, updating chron if it needs it")
                         self.SetKILightChron(remaining)
                         lightOn = 0
                         PtSetLightAnimStart(avatarKey, KILightObjectName, False)
@@ -250,7 +250,7 @@ class dsntKILightMachine(ptModifier):
             return
         
         if (LocalAvatar == avObj):
-            print("dsntKILightMachine.BeginAgeUnLoad()-->\tavatar page out")
+            PtDebugPrint("dsntKILightMachine.BeginAgeUnLoad()-->\tavatar page out")
             curTime = PtGetDniTime()
             timeRemaining = (lightStop - curTime)
             if timeRemaining > 0:

--- a/Python/ercaBakePellets.py
+++ b/Python/ercaBakePellets.py
@@ -154,7 +154,7 @@ class ercaBakePellets(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "ercaBakePellet.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL"
+            print("ercaBakePellet.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL")
             if self.sceneobject.isLocallyOwned():
                 ageSDL[SDLFinishTime.value] = (0,)
                 ageSDL[SDLPellet1.value] = (0,)
@@ -218,11 +218,11 @@ class ercaBakePellets(ptResponder):
             byteFinishTime = ageSDL[SDLFinishTime.value][0]
             PtDebugPrint("ercaBakePellets:OnSDLNotify:  SDL for ercaBakeFinishTime is now %d" % (byteFinishTime))
             if byteFinishTime == 1:
-                print "ONLY CALL GetRecipe ONCE"
+                print("ONLY CALL GetRecipe ONCE")
                 fastforward = 0
                 self.IGetRecipe(fastforward)
             elif byteFinishTime == 0:
-                print "BYTEFINISHTIME set to O"
+                print("BYTEFINISHTIME set to O")
                 if Oven1On:
                     RespOven1.run(self.key,state="off")
                     Oven1On = 0
@@ -320,16 +320,16 @@ class ercaBakePellets(ptResponder):
         
         ovenStartList = [Oven1Start,Oven2Start,Oven3Start,Oven4Start]
         
-        print "IGetRecipe.Oven1Start = ",Oven1Start
-        print "IGetRecipe.Oven2Start = ",Oven2Start
-        print "IGetRecipe.Oven3Start = ",Oven3Start
-        print "IGetRecipe.Oven4Start = ",Oven4Start
+        print("IGetRecipe.Oven1Start = ",Oven1Start)
+        print("IGetRecipe.Oven2Start = ",Oven2Start)
+        print("IGetRecipe.Oven3Start = ",Oven3Start)
+        print("IGetRecipe.Oven4Start = ",Oven4Start)
         
         self.IUpdateOvens(fastforward)
 
 
     def IUpdateOvens(self,fastforward):
-        print "ercaBakePellets.IUpdateOvens()"
+        print("ercaBakePellets.IUpdateOvens()")
         global ovenStartList
         global Oven1On
         global Oven2On
@@ -344,7 +344,7 @@ class ercaBakePellets(ptResponder):
                     #~ PtDebugPrint("%s start baking." % (start))
             if fastforward == 0:
                 if boolPelletMachine and ((CurTime+7) >= byteFinishTime) and self.sceneobject.isLocallyOwned():
-                    print "7 seconds or less until baking is done, and the machine is open, so CLOSING..."
+                    print("7 seconds or less until baking is done, and the machine is open, so CLOSING...")
                     ageSDL[SDLPellet1.value] = (0,)
                     ageSDL[SDLPellet2.value] = (0,)
                     ageSDL[SDLPellet3.value] = (0,)
@@ -352,36 +352,36 @@ class ercaBakePellets(ptResponder):
                     ageSDL[SDLPellet5.value] = (0,)
                     ageSDL["ercaPelletMachine"] = (0,)
                 if CurTime == Oven1Start:
-                    print "Start Oven1 bake"
+                    print("Start Oven1 bake")
                     RespOven1.run(self.key,state="on",fastforward=fastforward)
                     Oven1On = 1
                 if CurTime == Oven2Start:
-                    print "Start Oven2 bake"
+                    print("Start Oven2 bake")
                     RespOven2.run(self.key,state="on",fastforward=fastforward)
                     Oven2On = 1
                 if CurTime == Oven3Start:
-                    print "Start Oven3 bake"
+                    print("Start Oven3 bake")
                     RespOven3.run(self.key,state="on",fastforward=fastforward)
                     Oven3On = 1
                 if CurTime == Oven4Start:
-                    print "Start Oven4 bake"
+                    print("Start Oven4 bake")
                     RespOven4.run(self.key,state="on",fastforward=fastforward)
                     Oven4On = 1
             else:
                 if CurTime > Oven1Start:
-                    print "Start Oven1 bake"
+                    print("Start Oven1 bake")
                     RespOven1.run(self.key,state="on",fastforward=fastforward)
                     Oven1On = 1
                 if CurTime > Oven2Start:
-                    print "Start Oven2 bake"
+                    print("Start Oven2 bake")
                     RespOven2.run(self.key,state="on",fastforward=fastforward)
                     Oven2On = 1
                 if CurTime > Oven3Start:
-                    print "Start Oven3 bake"
+                    print("Start Oven3 bake")
                     RespOven3.run(self.key,state="on",fastforward=fastforward)
                     Oven3On = 1
                 if CurTime > Oven4Start:
-                    print "Start Oven4 bake"
+                    print("Start Oven4 bake")
                     RespOven4.run(self.key,state="on",fastforward=fastforward)
                     Oven4On = 1
                 
@@ -400,10 +400,10 @@ class ercaBakePellets(ptResponder):
                 fastforward = 0
                 self.IUpdateOvens(fastforward)
             else:
-                print "OnTimer callback, but baking was either finished or cancelled.  Doing nothing."
+                print("OnTimer callback, but baking was either finished or cancelled.  Doing nothing.")
         elif id == 2:
             if self.sceneobject.isLocallyOwned():
-                print "Timer done, Pellets now created with Recipe of: ",Recipe
+                print("Timer done, Pellets now created with Recipe of: ",Recipe)
                 ageSDL[SDLPellet1.value] = (RecipeSDL,)
                 ageSDL[SDLPellet2.value] = (RecipeSDL,)
                 ageSDL[SDLPellet3.value] = (RecipeSDL,)
@@ -413,7 +413,7 @@ class ercaBakePellets(ptResponder):
 
     def IDoFormula(self,backdoor=0):
         if not backdoor:
-            print "Baking done.  IDoFormula called."
+            print("Baking done.  IDoFormula called.")
         global time1
         global time2
         global time3
@@ -524,25 +524,25 @@ class ercaBakePellets(ptResponder):
         z = z1 + z2 + z3 + z4
         
         if backdoor:
-            print "time1_val = ",time1_val
-            print "amt1_val = ",amt1_val
-            print "temp1_val = ",temp1_val,"\n"
-            print "time2_val = ",time2_val
-            print "amt2_val = ",amt2_val
-            print "temp2_val = ",temp2_val,"\n"
-            print "time3_val = ",time3_val
-            print "amt3_val = ",amt3_val
-            print "temp3_val = ",temp3_val,"\n"
-            print "time4_val = ",time4_val
-            print "amt4_val = ",amt4_val
-            print "temp4_val = ",temp4_val,"\n"
-            print "z1 = ",z1
-            print "z2 = ",z2
-            print "z3 = ",z3
-            print "z4 = ",z4
-            print "z = ",z,"\n"
+            print("time1_val = ",time1_val)
+            print("amt1_val = ",amt1_val)
+            print("temp1_val = ",temp1_val,"\n")
+            print("time2_val = ",time2_val)
+            print("amt2_val = ",amt2_val)
+            print("temp2_val = ",temp2_val,"\n")
+            print("time3_val = ",time3_val)
+            print("amt3_val = ",amt3_val)
+            print("temp3_val = ",temp3_val,"\n")
+            print("time4_val = ",time4_val)
+            print("amt4_val = ",amt4_val)
+            print("temp4_val = ",temp4_val,"\n")
+            print("z1 = ",z1)
+            print("z2 = ",z2)
+            print("z3 = ",z3)
+            print("z4 = ",z4)
+            print("z = ",z,"\n")
             recipetest = int(round(100 * z))
-            print "recipe test = ",recipetest
+            print("recipe test = ",recipetest)
             return
 
         Recipe = int(round(100 * z))
@@ -550,14 +550,14 @@ class ercaBakePellets(ptResponder):
 #        if Recipe == 0:
 #            Recipe = 1
             
-        print "Pellet recipe = ",Recipe
+        print("Pellet recipe = ",Recipe)
         
         RecipeSDL = Recipe + 300
         
         if RecipeSDL < 1:
             RecipeSDL = 1
         
-        print "Recipe SDL converted to ",RecipeSDL
+        print("Recipe SDL converted to ",RecipeSDL)
         
         if self.sceneobject.isLocallyOwned():
             ageSDL[SDLFinishTime.value] = (0,)
@@ -592,7 +592,7 @@ class ercaBakePellets(ptResponder):
             temp2 = ageSDL[TempSDLs[1]][0]
             temp3 = ageSDL[TempSDLs[2]][0]
             temp4 = ageSDL[TempSDLs[3]][0]
-            print "RECIPE TEST:\n"
+            print("RECIPE TEST:\n")
             PtDebugPrint("oven1 = %d, %d, %d" % (time1,amt1,temp1))
             PtDebugPrint("oven2 = %d, %d, %d" % (time2,amt2,temp2))
             PtDebugPrint("oven3 = %d, %d, %d" % (time3,amt3,temp3))

--- a/Python/ercaBakePellets.py
+++ b/Python/ercaBakePellets.py
@@ -154,7 +154,7 @@ class ercaBakePellets(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("ercaBakePellet.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL")
+            PtDebugPrint("ercaBakePellet.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL")
             if self.sceneobject.isLocallyOwned():
                 ageSDL[SDLFinishTime.value] = (0,)
                 ageSDL[SDLPellet1.value] = (0,)
@@ -218,11 +218,11 @@ class ercaBakePellets(ptResponder):
             byteFinishTime = ageSDL[SDLFinishTime.value][0]
             PtDebugPrint("ercaBakePellets:OnSDLNotify:  SDL for ercaBakeFinishTime is now %d" % (byteFinishTime))
             if byteFinishTime == 1:
-                print("ONLY CALL GetRecipe ONCE")
+                PtDebugPrint("ONLY CALL GetRecipe ONCE")
                 fastforward = 0
                 self.IGetRecipe(fastforward)
             elif byteFinishTime == 0:
-                print("BYTEFINISHTIME set to O")
+                PtDebugPrint("BYTEFINISHTIME set to O")
                 if Oven1On:
                     RespOven1.run(self.key,state="off")
                     Oven1On = 0
@@ -320,16 +320,16 @@ class ercaBakePellets(ptResponder):
         
         ovenStartList = [Oven1Start,Oven2Start,Oven3Start,Oven4Start]
         
-        print("IGetRecipe.Oven1Start = ",Oven1Start)
-        print("IGetRecipe.Oven2Start = ",Oven2Start)
-        print("IGetRecipe.Oven3Start = ",Oven3Start)
-        print("IGetRecipe.Oven4Start = ",Oven4Start)
+        PtDebugPrint("IGetRecipe.Oven1Start = ",Oven1Start)
+        PtDebugPrint("IGetRecipe.Oven2Start = ",Oven2Start)
+        PtDebugPrint("IGetRecipe.Oven3Start = ",Oven3Start)
+        PtDebugPrint("IGetRecipe.Oven4Start = ",Oven4Start)
         
         self.IUpdateOvens(fastforward)
 
 
     def IUpdateOvens(self,fastforward):
-        print("ercaBakePellets.IUpdateOvens()")
+        PtDebugPrint("ercaBakePellets.IUpdateOvens()")
         global ovenStartList
         global Oven1On
         global Oven2On
@@ -344,7 +344,7 @@ class ercaBakePellets(ptResponder):
                     #~ PtDebugPrint("%s start baking." % (start))
             if fastforward == 0:
                 if boolPelletMachine and ((CurTime+7) >= byteFinishTime) and self.sceneobject.isLocallyOwned():
-                    print("7 seconds or less until baking is done, and the machine is open, so CLOSING...")
+                    PtDebugPrint("7 seconds or less until baking is done, and the machine is open, so CLOSING...")
                     ageSDL[SDLPellet1.value] = (0,)
                     ageSDL[SDLPellet2.value] = (0,)
                     ageSDL[SDLPellet3.value] = (0,)
@@ -352,36 +352,36 @@ class ercaBakePellets(ptResponder):
                     ageSDL[SDLPellet5.value] = (0,)
                     ageSDL["ercaPelletMachine"] = (0,)
                 if CurTime == Oven1Start:
-                    print("Start Oven1 bake")
+                    PtDebugPrint("Start Oven1 bake")
                     RespOven1.run(self.key,state="on",fastforward=fastforward)
                     Oven1On = 1
                 if CurTime == Oven2Start:
-                    print("Start Oven2 bake")
+                    PtDebugPrint("Start Oven2 bake")
                     RespOven2.run(self.key,state="on",fastforward=fastforward)
                     Oven2On = 1
                 if CurTime == Oven3Start:
-                    print("Start Oven3 bake")
+                    PtDebugPrint("Start Oven3 bake")
                     RespOven3.run(self.key,state="on",fastforward=fastforward)
                     Oven3On = 1
                 if CurTime == Oven4Start:
-                    print("Start Oven4 bake")
+                    PtDebugPrint("Start Oven4 bake")
                     RespOven4.run(self.key,state="on",fastforward=fastforward)
                     Oven4On = 1
             else:
                 if CurTime > Oven1Start:
-                    print("Start Oven1 bake")
+                    PtDebugPrint("Start Oven1 bake")
                     RespOven1.run(self.key,state="on",fastforward=fastforward)
                     Oven1On = 1
                 if CurTime > Oven2Start:
-                    print("Start Oven2 bake")
+                    PtDebugPrint("Start Oven2 bake")
                     RespOven2.run(self.key,state="on",fastforward=fastforward)
                     Oven2On = 1
                 if CurTime > Oven3Start:
-                    print("Start Oven3 bake")
+                    PtDebugPrint("Start Oven3 bake")
                     RespOven3.run(self.key,state="on",fastforward=fastforward)
                     Oven3On = 1
                 if CurTime > Oven4Start:
-                    print("Start Oven4 bake")
+                    PtDebugPrint("Start Oven4 bake")
                     RespOven4.run(self.key,state="on",fastforward=fastforward)
                     Oven4On = 1
                 
@@ -400,10 +400,10 @@ class ercaBakePellets(ptResponder):
                 fastforward = 0
                 self.IUpdateOvens(fastforward)
             else:
-                print("OnTimer callback, but baking was either finished or cancelled.  Doing nothing.")
+                PtDebugPrint("OnTimer callback, but baking was either finished or cancelled.  Doing nothing.")
         elif id == 2:
             if self.sceneobject.isLocallyOwned():
-                print("Timer done, Pellets now created with Recipe of: ",Recipe)
+                PtDebugPrint("Timer done, Pellets now created with Recipe of: ",Recipe)
                 ageSDL[SDLPellet1.value] = (RecipeSDL,)
                 ageSDL[SDLPellet2.value] = (RecipeSDL,)
                 ageSDL[SDLPellet3.value] = (RecipeSDL,)
@@ -413,7 +413,7 @@ class ercaBakePellets(ptResponder):
 
     def IDoFormula(self,backdoor=0):
         if not backdoor:
-            print("Baking done.  IDoFormula called.")
+            PtDebugPrint("Baking done.  IDoFormula called.")
         global time1
         global time2
         global time3
@@ -524,25 +524,25 @@ class ercaBakePellets(ptResponder):
         z = z1 + z2 + z3 + z4
         
         if backdoor:
-            print("time1_val = ",time1_val)
-            print("amt1_val = ",amt1_val)
-            print("temp1_val = ",temp1_val,"\n")
-            print("time2_val = ",time2_val)
-            print("amt2_val = ",amt2_val)
-            print("temp2_val = ",temp2_val,"\n")
-            print("time3_val = ",time3_val)
-            print("amt3_val = ",amt3_val)
-            print("temp3_val = ",temp3_val,"\n")
-            print("time4_val = ",time4_val)
-            print("amt4_val = ",amt4_val)
-            print("temp4_val = ",temp4_val,"\n")
-            print("z1 = ",z1)
-            print("z2 = ",z2)
-            print("z3 = ",z3)
-            print("z4 = ",z4)
-            print("z = ",z,"\n")
+            PtDebugPrint("time1_val = ",time1_val)
+            PtDebugPrint("amt1_val = ",amt1_val)
+            PtDebugPrint("temp1_val = ",temp1_val,"\n")
+            PtDebugPrint("time2_val = ",time2_val)
+            PtDebugPrint("amt2_val = ",amt2_val)
+            PtDebugPrint("temp2_val = ",temp2_val,"\n")
+            PtDebugPrint("time3_val = ",time3_val)
+            PtDebugPrint("amt3_val = ",amt3_val)
+            PtDebugPrint("temp3_val = ",temp3_val,"\n")
+            PtDebugPrint("time4_val = ",time4_val)
+            PtDebugPrint("amt4_val = ",amt4_val)
+            PtDebugPrint("temp4_val = ",temp4_val,"\n")
+            PtDebugPrint("z1 = ",z1)
+            PtDebugPrint("z2 = ",z2)
+            PtDebugPrint("z3 = ",z3)
+            PtDebugPrint("z4 = ",z4)
+            PtDebugPrint("z = ",z,"\n")
             recipetest = int(round(100 * z))
-            print("recipe test = ",recipetest)
+            PtDebugPrint("recipe test = ",recipetest)
             return
 
         Recipe = int(round(100 * z))
@@ -550,14 +550,14 @@ class ercaBakePellets(ptResponder):
 #        if Recipe == 0:
 #            Recipe = 1
             
-        print("Pellet recipe = ",Recipe)
+        PtDebugPrint("Pellet recipe = ",Recipe)
         
         RecipeSDL = Recipe + 300
         
         if RecipeSDL < 1:
             RecipeSDL = 1
         
-        print("Recipe SDL converted to ",RecipeSDL)
+        PtDebugPrint("Recipe SDL converted to ",RecipeSDL)
         
         if self.sceneobject.isLocallyOwned():
             ageSDL[SDLFinishTime.value] = (0,)
@@ -592,7 +592,7 @@ class ercaBakePellets(ptResponder):
             temp2 = ageSDL[TempSDLs[1]][0]
             temp3 = ageSDL[TempSDLs[2]][0]
             temp4 = ageSDL[TempSDLs[3]][0]
-            print("RECIPE TEST:\n")
+            PtDebugPrint("RECIPE TEST:\n")
             PtDebugPrint("oven1 = %d, %d, %d" % (time1,amt1,temp1))
             PtDebugPrint("oven2 = %d, %d, %d" % (time2,amt2,temp2))
             PtDebugPrint("oven3 = %d, %d, %d" % (time3,amt3,temp3))

--- a/Python/ercaBakeryElev.py
+++ b/Python/ercaBakeryElev.py
@@ -265,14 +265,14 @@ class ercaBakeryElev(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if (id == ActElevBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActElevBtn callback"
+            print("ActElevBtn callback")
             ageSDL[SDLElevBusy.value] = (1,)
 
         if (id == RespElevClk.id):
-            print "RespElevClk callback"
+            print("RespElevClk callback")
             if boolElevPos:
                 if self.sceneobject.isLocallyOwned():
-                    print "owner"
+                    print("owner")
                     ageSDL[SDLElevPos.value] = (0,)
                 else:
                     pass
@@ -282,13 +282,13 @@ class ercaBakeryElev(ptResponder):
                     RespElevOps.run(self.key,state="jam")
                 else:
                     if self.sceneobject.isLocallyOwned():
-                        print "owner"
+                        print("owner")
                         ageSDL[SDLElevPos.value] = (1,)
 
         if (id == RespElevOps.id):
-            print "RespElevOps callback"
+            print("RespElevOps callback")
             if self.sceneobject.isLocallyOwned():
-                print "owner"
+                print("owner")
                 ageSDL[SDLElevBusy.value] = (0,)
             if boolPwr:
                 RespElevPwr.run(self.key,state="on")
@@ -304,10 +304,10 @@ class ercaBakeryElev(ptResponder):
                 RespBkryPwrOn.run(self.key,avatar=objAvatar)
         
         if (id == RespBkryPwrOff.id) and self.sceneobject.isLocallyOwned():
-            print "owner"
+            print("owner")
             ageSDL[SDLPower.value] = (0,)
         
         if (id == RespBkryPwrOn.id) and self.sceneobject.isLocallyOwned():
-            print "owner"    
+            print("owner")    
             ageSDL[SDLPower.value] = (1,)
 

--- a/Python/ercaBakeryElev.py
+++ b/Python/ercaBakeryElev.py
@@ -265,14 +265,14 @@ class ercaBakeryElev(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if (id == ActElevBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActElevBtn callback")
+            PtDebugPrint("ActElevBtn callback")
             ageSDL[SDLElevBusy.value] = (1,)
 
         if (id == RespElevClk.id):
-            print("RespElevClk callback")
+            PtDebugPrint("RespElevClk callback")
             if boolElevPos:
                 if self.sceneobject.isLocallyOwned():
-                    print("owner")
+                    PtDebugPrint("owner")
                     ageSDL[SDLElevPos.value] = (0,)
                 else:
                     pass
@@ -282,13 +282,13 @@ class ercaBakeryElev(ptResponder):
                     RespElevOps.run(self.key,state="jam")
                 else:
                     if self.sceneobject.isLocallyOwned():
-                        print("owner")
+                        PtDebugPrint("owner")
                         ageSDL[SDLElevPos.value] = (1,)
 
         if (id == RespElevOps.id):
-            print("RespElevOps callback")
+            PtDebugPrint("RespElevOps callback")
             if self.sceneobject.isLocallyOwned():
-                print("owner")
+                PtDebugPrint("owner")
                 ageSDL[SDLElevBusy.value] = (0,)
             if boolPwr:
                 RespElevPwr.run(self.key,state="on")
@@ -304,10 +304,10 @@ class ercaBakeryElev(ptResponder):
                 RespBkryPwrOn.run(self.key,avatar=objAvatar)
         
         if (id == RespBkryPwrOff.id) and self.sceneobject.isLocallyOwned():
-            print("owner")
+            PtDebugPrint("owner")
             ageSDL[SDLPower.value] = (0,)
         
         if (id == RespBkryPwrOn.id) and self.sceneobject.isLocallyOwned():
-            print("owner")    
+            PtDebugPrint("owner")    
             ageSDL[SDLPower.value] = (1,)
 

--- a/Python/ercaControlRoom.py
+++ b/Python/ercaControlRoom.py
@@ -232,10 +232,10 @@ class ercaControlRoom(ptResponder):
 #            if not self.sceneobject.isLocallyOwned():
 #                return
             if byteMixBtnNew > 0 and self.sceneobject.isLocallyOwned():
-                print("setting SDLMixBtn to 0")
+                PtDebugPrint("setting SDLMixBtn to 0")
                 ageSDL[SDLMixBtn.value] = (0,)
             elif byteOvenBtnNew > 0 and self.sceneobject.isLocallyOwned():
-                print("setting SDLOvenBtn to 0")
+                PtDebugPrint("setting SDLOvenBtn to 0")
                 ageSDL[SDLOvenBtn.value] = (0,)
             self.ImgrView(byteImgrOld,"exit")
             PtDebugPrint("DEBUG: ercaControlRoom.OnSDLNotify():\t%s = %d" % (SDLImgrView.value,byteImgrNew) )
@@ -300,7 +300,7 @@ class ercaControlRoom(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if (id == ActScrollLeft.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActScrollLeft callback")
+            PtDebugPrint("ActScrollLeft callback")
             if byteImgrNew > 0:
                 #scrollDir = 0
                 tempVal = byteImgrNew - 1
@@ -309,7 +309,7 @@ class ercaControlRoom(ptResponder):
                 PtDebugPrint("DEBUG: ercaControlRoom.OnNotify():\tCan't scroll any further to the left.")
 
         elif (id == ActScrollRight.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActScrollRight callback")
+            PtDebugPrint("ActScrollRight callback")
             if byteImgrNew < 3:
                 #scrollDir = 1
                 tempVal = byteImgrNew + 1
@@ -318,11 +318,11 @@ class ercaControlRoom(ptResponder):
                 PtDebugPrint("DEBUG: ercaControlRoom.OnNotify():\tCan't scroll any further to the right.")
         
         elif (id == RespScrollLeft.id) or (id == RespScrollRight.id):
-            print("RespScrollX callback")
+            PtDebugPrint("RespScrollX callback")
             self.ImgrView(byteImgrNew,"enter")
         
         elif (id == RespImgrView0.id) or (id == RespImgrView1.id) or (id == RespImgrView2.id) or (id == RespImgrView3.id):
-            print("RespImgrView# callback")
+            PtDebugPrint("RespImgrView# callback")
             if (id == RespImgrView0.id):
                 RespScrollBtnRt.run(self.key,state="on")
             elif (id == RespImgrView1.id):
@@ -383,7 +383,7 @@ class ercaControlRoom(ptResponder):
             RespOvenIcons.run(self.key,state="on")
 
         elif (id == ActBladesBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("mixer blades btn clicked")
+            PtDebugPrint("mixer blades btn clicked")
             if byteMixBtnNew != 0:
                 blade = bladesSDLs[byteMixBtnNew - 1]
                 if ageSDL[blade][0] == 0:
@@ -401,7 +401,7 @@ class ercaControlRoom(ptResponder):
                 return
 
         elif (id == ActHatchBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("mixer hatch btn clicked")
+            PtDebugPrint("mixer hatch btn clicked")
             if byteMixBtnNew != 0:
                 hatchNum = byteMixBtnNew - 1
                 hatch = hatchSDLs[hatchNum]
@@ -423,25 +423,25 @@ class ercaControlRoom(ptResponder):
                 return
         
         elif (id == ActValveBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("mixer valve btn clicked")
+            PtDebugPrint("mixer valve btn clicked")
             if byteMixBtnNew != 0:
                 valveNum = byteMixBtnNew - 1
                 valve = valveSDLs[valveNum]
                 if valve == "ercaPool1Valve":
                     PtDebugPrint("Tried to operate pool 1 valve, but it's stuck; request denied!")
                     return
-                #print "valveNum = ",valveNum
+                #PtDebugPrint("valveNum = ",valveNum)
                 tunnel = TunnelsOccupied[valveNum]
-                #print "tunnel = ",tunnel
+                #PtDebugPrint("tunnel = ",tunnel)
                 if tunnel != []:
                     PtDebugPrint("tried to operate valve %d, but the tunnel is occupied; denied!" % (valveNum))
-                    print("players in this tunnel:")
+                    PtDebugPrint("players in this tunnel:")
                     for player in tunnel:
-                        print(player)
+                        PtDebugPrint(player)
                     RespWarningLight.run(self.key)
                     return
                 else:
-                    print("that tunnel is clear of players, proceeding...")
+                    PtDebugPrint("that tunnel is clear of players, proceeding...")
                 if ageSDL[valve][0] == 0:
                     ageSDL[valve] = (1,)
                     PtDebugPrint("now setting SDL for %s to %d" % (valve,1))
@@ -457,7 +457,7 @@ class ercaControlRoom(ptResponder):
                 return
 
         elif (id == ActOvenPwrBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("oven-scope power btn clicked")
+            PtDebugPrint("oven-scope power btn clicked")
             if byteOvenBtnNew != 0:
                 oven = ovenSDLs[byteOvenBtnNew - 1]
                 if (ageSDL["ercaBakeryElevPos"][0] != 0) or byteAmBaking:
@@ -474,7 +474,7 @@ class ercaControlRoom(ptResponder):
                 return
         
         elif id == RgnTunnel1.id or id == RgnTunnel2.id or id == RgnTunnel3.id or id == RgnTunnel4.id:
-            #print "callback from rgn tunnel ID: ",id
+            #PtDebugPrint("callback from rgn tunnel ID: ",id)
             for event in events:
                 if event[0] == kCollisionEvent:
                     try:
@@ -482,14 +482,14 @@ class ercaControlRoom(ptResponder):
                             playerID = PtGetLocalPlayer().getPlayerID()
                             if event[1] == 1:
                                 state = 1
-                                #print "enter tunnel ",id
+                                #PtDebugPrint("enter tunnel ",id)
                             else:
-                                #print "exit tunnel ",id
+                                #PtDebugPrint("exit tunnel ",id)
                                 state = 0
                         else:
                             return
                     except NameError:
-                        print("no more local avatar to see if in region")
+                        PtDebugPrint("no more local avatar to see if in region")
                         return
             rgn = 0
             for rgnID in RgnTunnelIDs:
@@ -498,20 +498,20 @@ class ercaControlRoom(ptResponder):
                 else:
                     rgn += 1
 #            if state:
-#                print "playerID: %d has ENTERED tunnel: %d" % (playerID,rgn)
+#                PtDebugPrint("playerID: %d has ENTERED tunnel: %d" % (playerID,rgn))
 #            else:
-#                print "playerID: %d has EXITED tunnel: %d" % (playerID,rgn)
+#                PtDebugPrint("playerID: %d has EXITED tunnel: %d" % (playerID,rgn))
             self.SendNote('%d;%d;%d' % (rgn,state,playerID))
 
         elif id == (-1):
-            #print "incoming event: %s" % (events[0][1])
+            #PtDebugPrint("incoming event: %s" % (events[0][1]))
             code = events[0][1]
-            #print "playing command: %s" % (code)
+            #PtDebugPrint("playing command: %s" % (code))
             self.ExecCode(code)
 
 
     def UpdateTunnelRgn(self,rgn,state,playerID):
-        #print "ercaControlRoom.UpdateTunnelRgn(): rgn = %d, state = %d, playerID = %d" % (rgn,state,playerID)
+        #PtDebugPrint("ercaControlRoom.UpdateTunnelRgn(): rgn = %d, state = %d, playerID = %d" % (rgn,state,playerID))
         global TunnelsOccupied
         if state:
             if playerID not in TunnelsOccupied[rgn]:
@@ -519,7 +519,7 @@ class ercaControlRoom(ptResponder):
         else:
             if playerID in TunnelsOccupied[rgn]:
                 TunnelsOccupied[rgn].remove(playerID)
-        print("TunnelsOccupied = ",TunnelsOccupied)
+        PtDebugPrint("TunnelsOccupied = ",TunnelsOccupied)
 
 
     def ImgrView(self,view,mode,ff=0):
@@ -584,4 +584,4 @@ class ercaControlRoom(ptResponder):
             ecPlayerID = int(chunks[2])
             self.UpdateTunnelRgn(ecRgn,ecState,ecPlayerID)
         except:
-            print("ercaControlRoom.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("ercaControlRoom.ExecCode(): ERROR! Invalid code '%s'." % (code))

--- a/Python/ercaControlRoom.py
+++ b/Python/ercaControlRoom.py
@@ -232,10 +232,10 @@ class ercaControlRoom(ptResponder):
 #            if not self.sceneobject.isLocallyOwned():
 #                return
             if byteMixBtnNew > 0 and self.sceneobject.isLocallyOwned():
-                print "setting SDLMixBtn to 0"
+                print("setting SDLMixBtn to 0")
                 ageSDL[SDLMixBtn.value] = (0,)
             elif byteOvenBtnNew > 0 and self.sceneobject.isLocallyOwned():
-                print "setting SDLOvenBtn to 0"
+                print("setting SDLOvenBtn to 0")
                 ageSDL[SDLOvenBtn.value] = (0,)
             self.ImgrView(byteImgrOld,"exit")
             PtDebugPrint("DEBUG: ercaControlRoom.OnSDLNotify():\t%s = %d" % (SDLImgrView.value,byteImgrNew) )
@@ -300,7 +300,7 @@ class ercaControlRoom(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if (id == ActScrollLeft.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActScrollLeft callback"
+            print("ActScrollLeft callback")
             if byteImgrNew > 0:
                 #scrollDir = 0
                 tempVal = byteImgrNew - 1
@@ -309,7 +309,7 @@ class ercaControlRoom(ptResponder):
                 PtDebugPrint("DEBUG: ercaControlRoom.OnNotify():\tCan't scroll any further to the left.")
 
         elif (id == ActScrollRight.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActScrollRight callback"
+            print("ActScrollRight callback")
             if byteImgrNew < 3:
                 #scrollDir = 1
                 tempVal = byteImgrNew + 1
@@ -318,11 +318,11 @@ class ercaControlRoom(ptResponder):
                 PtDebugPrint("DEBUG: ercaControlRoom.OnNotify():\tCan't scroll any further to the right.")
         
         elif (id == RespScrollLeft.id) or (id == RespScrollRight.id):
-            print "RespScrollX callback"
+            print("RespScrollX callback")
             self.ImgrView(byteImgrNew,"enter")
         
         elif (id == RespImgrView0.id) or (id == RespImgrView1.id) or (id == RespImgrView2.id) or (id == RespImgrView3.id):
-            print "RespImgrView# callback"
+            print("RespImgrView# callback")
             if (id == RespImgrView0.id):
                 RespScrollBtnRt.run(self.key,state="on")
             elif (id == RespImgrView1.id):
@@ -383,7 +383,7 @@ class ercaControlRoom(ptResponder):
             RespOvenIcons.run(self.key,state="on")
 
         elif (id == ActBladesBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "mixer blades btn clicked"
+            print("mixer blades btn clicked")
             if byteMixBtnNew != 0:
                 blade = bladesSDLs[byteMixBtnNew - 1]
                 if ageSDL[blade][0] == 0:
@@ -401,7 +401,7 @@ class ercaControlRoom(ptResponder):
                 return
 
         elif (id == ActHatchBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "mixer hatch btn clicked"
+            print("mixer hatch btn clicked")
             if byteMixBtnNew != 0:
                 hatchNum = byteMixBtnNew - 1
                 hatch = hatchSDLs[hatchNum]
@@ -423,7 +423,7 @@ class ercaControlRoom(ptResponder):
                 return
         
         elif (id == ActValveBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "mixer valve btn clicked"
+            print("mixer valve btn clicked")
             if byteMixBtnNew != 0:
                 valveNum = byteMixBtnNew - 1
                 valve = valveSDLs[valveNum]
@@ -435,13 +435,13 @@ class ercaControlRoom(ptResponder):
                 #print "tunnel = ",tunnel
                 if tunnel != []:
                     PtDebugPrint("tried to operate valve %d, but the tunnel is occupied; denied!" % (valveNum))
-                    print "players in this tunnel:"
+                    print("players in this tunnel:")
                     for player in tunnel:
-                        print player
+                        print(player)
                     RespWarningLight.run(self.key)
                     return
                 else:
-                    print "that tunnel is clear of players, proceeding..."
+                    print("that tunnel is clear of players, proceeding...")
                 if ageSDL[valve][0] == 0:
                     ageSDL[valve] = (1,)
                     PtDebugPrint("now setting SDL for %s to %d" % (valve,1))
@@ -457,7 +457,7 @@ class ercaControlRoom(ptResponder):
                 return
 
         elif (id == ActOvenPwrBtn.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "oven-scope power btn clicked"
+            print("oven-scope power btn clicked")
             if byteOvenBtnNew != 0:
                 oven = ovenSDLs[byteOvenBtnNew - 1]
                 if (ageSDL["ercaBakeryElevPos"][0] != 0) or byteAmBaking:
@@ -489,7 +489,7 @@ class ercaControlRoom(ptResponder):
                         else:
                             return
                     except NameError:
-                        print "no more local avatar to see if in region"
+                        print("no more local avatar to see if in region")
                         return
             rgn = 0
             for rgnID in RgnTunnelIDs:
@@ -519,7 +519,7 @@ class ercaControlRoom(ptResponder):
         else:
             if playerID in TunnelsOccupied[rgn]:
                 TunnelsOccupied[rgn].remove(playerID)
-        print "TunnelsOccupied = ",TunnelsOccupied
+        print("TunnelsOccupied = ",TunnelsOccupied)
 
 
     def ImgrView(self,view,mode,ff=0):
@@ -584,4 +584,4 @@ class ercaControlRoom(ptResponder):
             ecPlayerID = int(chunks[2])
             self.UpdateTunnelRgn(ecRgn,ecState,ecPlayerID)
         except:
-            print "ercaControlRoom.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("ercaControlRoom.ExecCode(): ERROR! Invalid code '%s'." % (code))

--- a/Python/ercaHrvstr.py
+++ b/Python/ercaHrvstr.py
@@ -388,7 +388,7 @@ class ercaHrvstr(ptResponder):
                 if boolRev == 1:
                     ageSDL[SDLHrvstrPwr.value] = (0,)
             elif bytePos == 2:
-                print "SDLHrvstrPos set to 2"
+                print("SDLHrvstrPos set to 2")
             elif bytePos == 4:
                 ageSDL[SDLHrvstrDrvLev.value] = (0,)
                 if boolRev == 0:
@@ -401,23 +401,23 @@ class ercaHrvstr(ptResponder):
             boolDrvLev = ageSDL[SDLHrvstrDrvLev.value][0]
             if boolDrvLev:
                 if callHrvstr:
-                    print "onSDLnotify for drvlev, if callHrvstr true will DriveHrvstr"
+                    print("onSDLnotify for drvlev, if callHrvstr true will DriveHrvstr")
                     self.DriveHrvstr()
                 else:
-                    print "onSDLnotify for drvlev, says callHrvstr is false and will runRespLadderGoUp"
+                    print("onSDLnotify for drvlev, says callHrvstr is false and will runRespLadderGoUp")
                     if bytePos == 0 and byteCarPos == 0:
                         RespRampsGoUp.run(self.key)
                     elif bytePos == 4 and byteCarPos == 1:
                         RespRampsGoUp.run(self.key)
                     RespLadderGoUp.run(self.key)
                     if TopLadder:
-                        print "I'm getting kicked from top ladder multistage"
+                        print("I'm getting kicked from top ladder multistage")
                         MltStgLadderTop.gotoStage(LocalAvatar, -1)
                     if BtmLadder:
-                        print "I'm getting kicked from bottom ladder multistage"
+                        print("I'm getting kicked from bottom ladder multistage")
                         MltStgLadderBtm.gotoStage(LocalAvatar, -1)                	
             else:
-                print "SDL for lever set to 0, did this happen?"
+                print("SDL for lever set to 0, did this happen?")
                 self.DriveHrvstr()
 
         if VARname == SDLHrvstrWngOk.value:
@@ -465,31 +465,31 @@ class ercaHrvstr(ptResponder):
 
         #if (id == ActRevKnob.id and state and LocalAvatar == PtFindAvatar(events)):
         if (id == ActRevKnob.id and state):
-            print "ActRevKnob callback"
+            print("ActRevKnob callback")
             if boolRev:
                 if boolMoving:
-                    print "insert stuck/down oneshot here"
+                    print("insert stuck/down oneshot here")
                 else:
                     PtDebugPrint("DEBUG: ercaHrvstr.OnNotify:\tRev knob moving up.")
                     RespRevKnobUp.run(self.key,avatar=PtFindAvatar(events))
             else:
                 if boolMoving:
-                    print "insert stuck/up oneshot here"
+                    print("insert stuck/up oneshot here")
                 else:
                     PtDebugPrint("DEBUG: ercaHrvstr.OnNotify:\tRev knob moving down.")
                     RespRevKnobDwn.run(self.key,avatar=PtFindAvatar(events))
         
         if (id == RespRevKnobUp.id) and self.sceneobject.isLocallyOwned():
-            print "RespRevKnobDwn callback"
+            print("RespRevKnobDwn callback")
             ageSDL[SDLHrvstrRev.value] = (0,)
             
         if (id == RespRevKnobDwn.id) and self.sceneobject.isLocallyOwned():
-            print "RespRevKnobDwn callback"
+            print("RespRevKnobDwn callback")
             ageSDL[SDLHrvstrRev.value] = (1,)
         
         if (id == RespRevKnobAutoUp.id) and self.sceneobject.isLocallyOwned():
             if callHrvstr:
-                print "in RespRevKnobAutoUp, will set SDL for rev to 0"
+                print("in RespRevKnobAutoUp, will set SDL for rev to 0")
                 ageSDL[SDLHrvstrRev.value] = (0,)
         
         if (id == ActDrvLev.id and state):
@@ -514,7 +514,7 @@ class ercaHrvstr(ptResponder):
             
         if (id == RespDrvLevAutoUp.id) and self.sceneobject.isLocallyOwned():
             if callHrvstr:
-                print "in RespDrvLevAutoUp, will set SDL for drvlev to 0"
+                print("in RespDrvLevAutoUp, will set SDL for drvlev to 0")
                 ageSDL[SDLHrvstrDrvLev.value] = (0,)
         
         if (id == RespDrvLevDwn.id) and self.sceneobject.isLocallyOwned():
@@ -523,20 +523,20 @@ class ercaHrvstr(ptResponder):
         if (id == ActHrvstrAtStart.id and state) and self.sceneobject.isLocallyOwned():
             if boolRev:
                 ageSDL[SDLHrvstrPos.value] = (0,)
-                print "Anim event to set SDLHrvstrPos to 0, is this happening?"
+                print("Anim event to set SDLHrvstrPos to 0, is this happening?")
         
         if (id == ActHrvstrNearStart.id and state) and self.sceneobject.isLocallyOwned():
-            print "blah"
+            print("blah")
             #ageSDL[SDLHrvstrPos.value] = (1,)
         
         if (id == ActHrvstrNearEnd.id and state) and self.sceneobject.isLocallyOwned():
-            print "blah"
+            print("blah")
             #ageSDL[SDLHrvstrPos.value] = (3,)
         
         if (id == ActHrvstrAtEnd.id and state) and self.sceneobject.isLocallyOwned():
             if not boolRev:
                 ageSDL[SDLHrvstrPos.value] = (4,)
-                print "Anim event to set SDLHrvstrPos to 4, is this happening?"
+                print("Anim event to set SDLHrvstrPos to 4, is this happening?")
         
         if (id == RespLadderGoUp.id):
             self.DriveHrvstr()
@@ -615,7 +615,7 @@ class ercaHrvstr(ptResponder):
             if byteCarPos == 3 and bytePos != 4:
                 callHrvstr = 1
                 if boolMoving:
-                    print "in RespCallHrvstrBtnDown, will now run lev auto up"
+                    print("in RespCallHrvstrBtnDown, will now run lev auto up")
                     RespDrvLevAutoUp.run(self.key)
                 else:
                     RespCallHrvstr.run(self.key)
@@ -629,19 +629,19 @@ class ercaHrvstr(ptResponder):
             
         if (id == RespCallHrvstr.id):
             if boolRev:
-                print "in RespCallHrvstr, boolRev is true so will run RespRevKnobAutoUp"
+                print("in RespCallHrvstr, boolRev is true so will run RespRevKnobAutoUp")
                 RespRevKnobAutoUp.run(self.key)
             else:
-                print "in RespCallHrvstr, will set drvlev SDL to true"
+                print("in RespCallHrvstr, will set drvlev SDL to true")
                 if self.sceneobject.isLocallyOwned():
                     ageSDL[SDLHrvstrDrvLev.value] = (1,)
 
         if (id == RespHrvstrStop.id):
-            print "resp hrvstr stop, did this happen?"
+            print("resp hrvstr stop, did this happen?")
             if self.sceneobject.isLocallyOwned():
                 ageSDL[SDLHrvstrMoving.value] = (0,)
             if callHrvstr:
-                print "will run RespCallHrvstr, if callHrvstr in RespHrvstrStop notify"
+                print("will run RespCallHrvstr, if callHrvstr in RespHrvstrStop notify")
                 RespCallHrvstr.run(self.key)
 
         if (id == RespCallCarUp.id) and self.sceneobject.isLocallyOwned():
@@ -652,7 +652,7 @@ class ercaHrvstr(ptResponder):
         if (id == ActLadderTop.id and state):
             #print "ActLadderTop callback"
             if LocalAvatar == PtFindAvatar(events):
-                print "TopLadder = 1"
+                print("TopLadder = 1")
                 TopLadder = 1
                 MltStgLadderTop.run(avatar=PtFindAvatar(events))
             #ageSDL[SDLHrvstrPwr.value] = (0,)
@@ -660,7 +660,7 @@ class ercaHrvstr(ptResponder):
         if (id == ActLadderBtm.id and state):
             #print "ActLadderBtm callback"
             if LocalAvatar == PtFindAvatar(events):
-                print "BtmLadder = 1"
+                print("BtmLadder = 1")
                 BtmLadder = 1
                 MltStgLadderBtm.run(avatar=PtFindAvatar(events))
             #ageSDL[SDLHrvstrPwr.value] = (0,)
@@ -668,14 +668,14 @@ class ercaHrvstr(ptResponder):
         if (id == MltStgLadderTop.id):
             #print "MltStgLadderTop callback"
             if LocalAvatar == PtFindAvatar(events):
-                print "TopLadder = 0"
+                print("TopLadder = 0")
                 TopLadder = 0
             #ageSDL[SDLHrvstrPwr.value] = (1,)
         
         if (id == MltStgLadderBtm.id):
             #print "MltStgLadderBtm callback"
             if LocalAvatar == PtFindAvatar(events):
-                print "BtmLadder = 0"
+                print("BtmLadder = 0")
                 BtmLadder = 0
             #ageSDL[SDLHrvstrPwr.value] = (1,)
 
@@ -697,14 +697,14 @@ class ercaHrvstr(ptResponder):
         if boolDrvLev:
             if boolPwr:
                 if boolRev:
-                    print "in DriveHrvstr, will now run RespHrvstrGoRev"
+                    print("in DriveHrvstr, will now run RespHrvstrGoRev")
                     RespHrvstrGoRev.run(self.key)
                     if self.sceneobject.isLocallyOwned():
                         ageSDL[SDLHrvstrMoving.value] = (1,)
                     if byteCarPos == 0 or byteCarPos == 1:
                         RespCarGoRev.run(self.key)
                 else:
-                    print "in DriveHrvstr, will now run RespHrvstrGoFwd"
+                    print("in DriveHrvstr, will now run RespHrvstrGoFwd")
                     RespHrvstrGoFwd.run(self.key)
                     if self.sceneobject.isLocallyOwned():
                         ageSDL[SDLHrvstrMoving.value] = (1,)
@@ -713,7 +713,7 @@ class ercaHrvstr(ptResponder):
             else:
                 PtDebugPrint("DEBUG: ercaHrvstr.DriveHrvstr:\tThis shouldn't be possible.")
         else:
-            print "DriveHrvstr, boolDrvLev is 0, is this happening?"
+            print("DriveHrvstr, boolDrvLev is 0, is this happening?")
             if bytePos == 0 or bytePos == 4:
                 if callHrvstr:
                     RespCallHrvstrBtnUp.run(self.key)
@@ -751,7 +751,7 @@ class ercaHrvstr(ptResponder):
 
 
     def OnTimer(self,id):
-        print "ercaHrvstr.OnTimer"
+        print("ercaHrvstr.OnTimer")
 
 
 

--- a/Python/ercaHrvstr.py
+++ b/Python/ercaHrvstr.py
@@ -388,7 +388,7 @@ class ercaHrvstr(ptResponder):
                 if boolRev == 1:
                     ageSDL[SDLHrvstrPwr.value] = (0,)
             elif bytePos == 2:
-                print("SDLHrvstrPos set to 2")
+                PtDebugPrint("SDLHrvstrPos set to 2")
             elif bytePos == 4:
                 ageSDL[SDLHrvstrDrvLev.value] = (0,)
                 if boolRev == 0:
@@ -401,23 +401,23 @@ class ercaHrvstr(ptResponder):
             boolDrvLev = ageSDL[SDLHrvstrDrvLev.value][0]
             if boolDrvLev:
                 if callHrvstr:
-                    print("onSDLnotify for drvlev, if callHrvstr true will DriveHrvstr")
+                    PtDebugPrint("onSDLnotify for drvlev, if callHrvstr true will DriveHrvstr")
                     self.DriveHrvstr()
                 else:
-                    print("onSDLnotify for drvlev, says callHrvstr is false and will runRespLadderGoUp")
+                    PtDebugPrint("onSDLnotify for drvlev, says callHrvstr is false and will runRespLadderGoUp")
                     if bytePos == 0 and byteCarPos == 0:
                         RespRampsGoUp.run(self.key)
                     elif bytePos == 4 and byteCarPos == 1:
                         RespRampsGoUp.run(self.key)
                     RespLadderGoUp.run(self.key)
                     if TopLadder:
-                        print("I'm getting kicked from top ladder multistage")
+                        PtDebugPrint("I'm getting kicked from top ladder multistage")
                         MltStgLadderTop.gotoStage(LocalAvatar, -1)
                     if BtmLadder:
-                        print("I'm getting kicked from bottom ladder multistage")
+                        PtDebugPrint("I'm getting kicked from bottom ladder multistage")
                         MltStgLadderBtm.gotoStage(LocalAvatar, -1)                	
             else:
-                print("SDL for lever set to 0, did this happen?")
+                PtDebugPrint("SDL for lever set to 0, did this happen?")
                 self.DriveHrvstr()
 
         if VARname == SDLHrvstrWngOk.value:
@@ -465,31 +465,31 @@ class ercaHrvstr(ptResponder):
 
         #if (id == ActRevKnob.id and state and LocalAvatar == PtFindAvatar(events)):
         if (id == ActRevKnob.id and state):
-            print("ActRevKnob callback")
+            PtDebugPrint("ActRevKnob callback")
             if boolRev:
                 if boolMoving:
-                    print("insert stuck/down oneshot here")
+                    PtDebugPrint("insert stuck/down oneshot here")
                 else:
                     PtDebugPrint("DEBUG: ercaHrvstr.OnNotify:\tRev knob moving up.")
                     RespRevKnobUp.run(self.key,avatar=PtFindAvatar(events))
             else:
                 if boolMoving:
-                    print("insert stuck/up oneshot here")
+                    PtDebugPrint("insert stuck/up oneshot here")
                 else:
                     PtDebugPrint("DEBUG: ercaHrvstr.OnNotify:\tRev knob moving down.")
                     RespRevKnobDwn.run(self.key,avatar=PtFindAvatar(events))
         
         if (id == RespRevKnobUp.id) and self.sceneobject.isLocallyOwned():
-            print("RespRevKnobDwn callback")
+            PtDebugPrint("RespRevKnobDwn callback")
             ageSDL[SDLHrvstrRev.value] = (0,)
             
         if (id == RespRevKnobDwn.id) and self.sceneobject.isLocallyOwned():
-            print("RespRevKnobDwn callback")
+            PtDebugPrint("RespRevKnobDwn callback")
             ageSDL[SDLHrvstrRev.value] = (1,)
         
         if (id == RespRevKnobAutoUp.id) and self.sceneobject.isLocallyOwned():
             if callHrvstr:
-                print("in RespRevKnobAutoUp, will set SDL for rev to 0")
+                PtDebugPrint("in RespRevKnobAutoUp, will set SDL for rev to 0")
                 ageSDL[SDLHrvstrRev.value] = (0,)
         
         if (id == ActDrvLev.id and state):
@@ -514,7 +514,7 @@ class ercaHrvstr(ptResponder):
             
         if (id == RespDrvLevAutoUp.id) and self.sceneobject.isLocallyOwned():
             if callHrvstr:
-                print("in RespDrvLevAutoUp, will set SDL for drvlev to 0")
+                PtDebugPrint("in RespDrvLevAutoUp, will set SDL for drvlev to 0")
                 ageSDL[SDLHrvstrDrvLev.value] = (0,)
         
         if (id == RespDrvLevDwn.id) and self.sceneobject.isLocallyOwned():
@@ -523,20 +523,20 @@ class ercaHrvstr(ptResponder):
         if (id == ActHrvstrAtStart.id and state) and self.sceneobject.isLocallyOwned():
             if boolRev:
                 ageSDL[SDLHrvstrPos.value] = (0,)
-                print("Anim event to set SDLHrvstrPos to 0, is this happening?")
+                PtDebugPrint("Anim event to set SDLHrvstrPos to 0, is this happening?")
         
         if (id == ActHrvstrNearStart.id and state) and self.sceneobject.isLocallyOwned():
-            print("blah")
+            PtDebugPrint("blah")
             #ageSDL[SDLHrvstrPos.value] = (1,)
         
         if (id == ActHrvstrNearEnd.id and state) and self.sceneobject.isLocallyOwned():
-            print("blah")
+            PtDebugPrint("blah")
             #ageSDL[SDLHrvstrPos.value] = (3,)
         
         if (id == ActHrvstrAtEnd.id and state) and self.sceneobject.isLocallyOwned():
             if not boolRev:
                 ageSDL[SDLHrvstrPos.value] = (4,)
-                print("Anim event to set SDLHrvstrPos to 4, is this happening?")
+                PtDebugPrint("Anim event to set SDLHrvstrPos to 4, is this happening?")
         
         if (id == RespLadderGoUp.id):
             self.DriveHrvstr()
@@ -615,7 +615,7 @@ class ercaHrvstr(ptResponder):
             if byteCarPos == 3 and bytePos != 4:
                 callHrvstr = 1
                 if boolMoving:
-                    print("in RespCallHrvstrBtnDown, will now run lev auto up")
+                    PtDebugPrint("in RespCallHrvstrBtnDown, will now run lev auto up")
                     RespDrvLevAutoUp.run(self.key)
                 else:
                     RespCallHrvstr.run(self.key)
@@ -629,19 +629,19 @@ class ercaHrvstr(ptResponder):
             
         if (id == RespCallHrvstr.id):
             if boolRev:
-                print("in RespCallHrvstr, boolRev is true so will run RespRevKnobAutoUp")
+                PtDebugPrint("in RespCallHrvstr, boolRev is true so will run RespRevKnobAutoUp")
                 RespRevKnobAutoUp.run(self.key)
             else:
-                print("in RespCallHrvstr, will set drvlev SDL to true")
+                PtDebugPrint("in RespCallHrvstr, will set drvlev SDL to true")
                 if self.sceneobject.isLocallyOwned():
                     ageSDL[SDLHrvstrDrvLev.value] = (1,)
 
         if (id == RespHrvstrStop.id):
-            print("resp hrvstr stop, did this happen?")
+            PtDebugPrint("resp hrvstr stop, did this happen?")
             if self.sceneobject.isLocallyOwned():
                 ageSDL[SDLHrvstrMoving.value] = (0,)
             if callHrvstr:
-                print("will run RespCallHrvstr, if callHrvstr in RespHrvstrStop notify")
+                PtDebugPrint("will run RespCallHrvstr, if callHrvstr in RespHrvstrStop notify")
                 RespCallHrvstr.run(self.key)
 
         if (id == RespCallCarUp.id) and self.sceneobject.isLocallyOwned():
@@ -650,32 +650,32 @@ class ercaHrvstr(ptResponder):
             ageSDL[SDLDockGate.value] = (1,)
         
         if (id == ActLadderTop.id and state):
-            #print "ActLadderTop callback"
+            #PtDebugPrint("ActLadderTop callback")
             if LocalAvatar == PtFindAvatar(events):
-                print("TopLadder = 1")
+                PtDebugPrint("TopLadder = 1")
                 TopLadder = 1
                 MltStgLadderTop.run(avatar=PtFindAvatar(events))
             #ageSDL[SDLHrvstrPwr.value] = (0,)
         
         if (id == ActLadderBtm.id and state):
-            #print "ActLadderBtm callback"
+            #PtDebugPrint("ActLadderBtm callback")
             if LocalAvatar == PtFindAvatar(events):
-                print("BtmLadder = 1")
+                PtDebugPrint("BtmLadder = 1")
                 BtmLadder = 1
                 MltStgLadderBtm.run(avatar=PtFindAvatar(events))
             #ageSDL[SDLHrvstrPwr.value] = (0,)
         
         if (id == MltStgLadderTop.id):
-            #print "MltStgLadderTop callback"
+            #PtDebugPrint("MltStgLadderTop callback")
             if LocalAvatar == PtFindAvatar(events):
-                print("TopLadder = 0")
+                PtDebugPrint("TopLadder = 0")
                 TopLadder = 0
             #ageSDL[SDLHrvstrPwr.value] = (1,)
         
         if (id == MltStgLadderBtm.id):
-            #print "MltStgLadderBtm callback"
+            #PtDebugPrint("MltStgLadderBtm callback")
             if LocalAvatar == PtFindAvatar(events):
-                print("BtmLadder = 0")
+                PtDebugPrint("BtmLadder = 0")
                 BtmLadder = 0
             #ageSDL[SDLHrvstrPwr.value] = (1,)
 
@@ -697,14 +697,14 @@ class ercaHrvstr(ptResponder):
         if boolDrvLev:
             if boolPwr:
                 if boolRev:
-                    print("in DriveHrvstr, will now run RespHrvstrGoRev")
+                    PtDebugPrint("in DriveHrvstr, will now run RespHrvstrGoRev")
                     RespHrvstrGoRev.run(self.key)
                     if self.sceneobject.isLocallyOwned():
                         ageSDL[SDLHrvstrMoving.value] = (1,)
                     if byteCarPos == 0 or byteCarPos == 1:
                         RespCarGoRev.run(self.key)
                 else:
-                    print("in DriveHrvstr, will now run RespHrvstrGoFwd")
+                    PtDebugPrint("in DriveHrvstr, will now run RespHrvstrGoFwd")
                     RespHrvstrGoFwd.run(self.key)
                     if self.sceneobject.isLocallyOwned():
                         ageSDL[SDLHrvstrMoving.value] = (1,)
@@ -713,7 +713,7 @@ class ercaHrvstr(ptResponder):
             else:
                 PtDebugPrint("DEBUG: ercaHrvstr.DriveHrvstr:\tThis shouldn't be possible.")
         else:
-            print("DriveHrvstr, boolDrvLev is 0, is this happening?")
+            PtDebugPrint("DriveHrvstr, boolDrvLev is 0, is this happening?")
             if bytePos == 0 or bytePos == 4:
                 if callHrvstr:
                     RespCallHrvstrBtnUp.run(self.key)
@@ -751,7 +751,7 @@ class ercaHrvstr(ptResponder):
 
 
     def OnTimer(self,id):
-        print("ercaHrvstr.OnTimer")
+        PtDebugPrint("ercaHrvstr.OnTimer")
 
 
 

--- a/Python/ercaLadderHatch.py
+++ b/Python/ercaLadderHatch.py
@@ -161,43 +161,43 @@ class ercaLadderHatch(ptResponder):
                     if (StrDirection.value) == "up":
                         if event[2] == kAdvanceNextStage:
                             stageNum = event[1]
-                            print "Going up.  Got stage advance callback from stage %d" % stageNum
+                            print("Going up.  Got stage advance callback from stage %d" % stageNum)
                             if stageNum == 1:
-                                print "In stage 2, negotiating hatch."
+                                print("In stage 2, negotiating hatch.")
                                 self.INegotiateHatch();
                             elif stageNum == 2:
                                 # after the "it's locked" anim, return to the climb...
                                 MltStgLddr.gotoStage(LocalAvatar, 1,0,0)
                             elif stageNum == 2 or stageNum == 3 or stageNum == 5:
-                                print "Got through hatch: finishing & removing brain."
+                                print("Got through hatch: finishing & removing brain.")
                                 MltStgLddr.gotoStage(LocalAvatar, -1)
                                 
                     elif (StrDirection.value) == "down":
                         stageNum = event[1]
-                        print "Going down.  Message from multistage %i" % stageNum
+                        print("Going down.  Message from multistage %i" % stageNum)
                         if event[2] == kRegressPrevStage: # and stageNum == 2:
-                            print "Got stage Regress callback from stage %d" % stageNum
+                            print("Got stage Regress callback from stage %d" % stageNum)
                             self.INegotiateHatch()
                         elif event[2] == kAdvanceNextStage:
                             if stageNum == 1: # finished getting on, now find out if water is up
-                                print "checking drained"
+                                print("checking drained")
                                 if boolEmpty == 0:
                                     MltStgLddr.gotoStage(LocalAvatar, 7,0,0);                            
-                                    print "water not drained"
+                                    print("water not drained")
                             if stageNum == 4:
                                 if boolEmpty == 0:
                                     MltStgLddr.gotoStage(LocalAvatar, 7,dirFlag=1,isForward=1)
                                     # after the "it's locked" anim, return to the climb...
                                 else:
                                     MltStgLddr.gotoStage(LocalAvatar, 2,dirFlag=1,isForward=1)
-                                print "now stage 3/7 again"
+                                print("now stage 3/7 again")
                             elif stageNum == 6:
-                                print "Got through hatch: finishing & removing brain."
+                                print("Got through hatch: finishing & removing brain.")
                                 MltStgLddr.gotoStage(LocalAvatar, -1)
                                 iamclimber = False
                                 #ActStart.enable()
                             elif stageNum == 3:
-                                print "done with bottom"
+                                print("done with bottom")
                                 iamclimber = False
                                 MltStgLddr.gotoStage(LocalAvatar, -1)
 
@@ -207,7 +207,7 @@ class ercaLadderHatch(ptResponder):
 
     def INegotiateHatch(self):
         global boolHatch
-        print "Negotiating hatch"
+        print("Negotiating hatch")
         if boolHatch == 0:
             self.IHatchLocked()
         else:
@@ -218,11 +218,11 @@ class ercaLadderHatch(ptResponder):
         "Hatch is locked; show the frustrated animation and return to previous stage"
         global LocalAvatar
         if (StrDirection.value) == "up":
-            print "Going up.  Hatch is locked; Sending gotoStage(2)"
+            print("Going up.  Hatch is locked; Sending gotoStage(2)")
             RespHatchOps.run(self.key,state='lockedbelow')
             MltStgLddr.gotoStage(LocalAvatar,2,0,1)
         elif (StrDirection.value) == "down":
-            print "Going down.  Hatch is locked; Sending gotoStage(4)"
+            print("Going down.  Hatch is locked; Sending gotoStage(4)")
             MltStgLddr.gotoStage(LocalAvatar,4,dirFlag=1,isForward=1,setTimeFlag=1,newTime=0.0)
             RespHatchOps.run(self.key,state='lockedbelow')
 
@@ -232,11 +232,11 @@ class ercaLadderHatch(ptResponder):
         global LocalAvatar
         global iamclimber
         if (StrDirection.value) == "up":
-            print "Going up.  Hatch is unlocked; Sending gotoStage(3)"
+            print("Going up.  Hatch is unlocked; Sending gotoStage(3)")
             #RespHatchOps.run(self.key,state='openbelow')
             MltStgLddr.gotoStage(LocalAvatar,4,0,0)
         elif (StrDirection.value) == "down":
-            print "Going down.  Hatch is unlocked; Sending gotoStage(5)"
+            print("Going down.  Hatch is unlocked; Sending gotoStage(5)")
             MltStgLddr.gotoStage(LocalAvatar,5,dirFlag=1,isForward=1,setTimeFlag=1,newTime=0.0)
             #RespHatchOps.run(self.key,state='openbelow')
             iamclimber = False

--- a/Python/ercaLadderHatch.py
+++ b/Python/ercaLadderHatch.py
@@ -161,43 +161,43 @@ class ercaLadderHatch(ptResponder):
                     if (StrDirection.value) == "up":
                         if event[2] == kAdvanceNextStage:
                             stageNum = event[1]
-                            print("Going up.  Got stage advance callback from stage %d" % stageNum)
+                            PtDebugPrint("Going up.  Got stage advance callback from stage %d" % stageNum)
                             if stageNum == 1:
-                                print("In stage 2, negotiating hatch.")
+                                PtDebugPrint("In stage 2, negotiating hatch.")
                                 self.INegotiateHatch();
                             elif stageNum == 2:
                                 # after the "it's locked" anim, return to the climb...
                                 MltStgLddr.gotoStage(LocalAvatar, 1,0,0)
                             elif stageNum == 2 or stageNum == 3 or stageNum == 5:
-                                print("Got through hatch: finishing & removing brain.")
+                                PtDebugPrint("Got through hatch: finishing & removing brain.")
                                 MltStgLddr.gotoStage(LocalAvatar, -1)
                                 
                     elif (StrDirection.value) == "down":
                         stageNum = event[1]
-                        print("Going down.  Message from multistage %i" % stageNum)
+                        PtDebugPrint("Going down.  Message from multistage %i" % stageNum)
                         if event[2] == kRegressPrevStage: # and stageNum == 2:
-                            print("Got stage Regress callback from stage %d" % stageNum)
+                            PtDebugPrint("Got stage Regress callback from stage %d" % stageNum)
                             self.INegotiateHatch()
                         elif event[2] == kAdvanceNextStage:
                             if stageNum == 1: # finished getting on, now find out if water is up
-                                print("checking drained")
+                                PtDebugPrint("checking drained")
                                 if boolEmpty == 0:
                                     MltStgLddr.gotoStage(LocalAvatar, 7,0,0);                            
-                                    print("water not drained")
+                                    PtDebugPrint("water not drained")
                             if stageNum == 4:
                                 if boolEmpty == 0:
                                     MltStgLddr.gotoStage(LocalAvatar, 7,dirFlag=1,isForward=1)
                                     # after the "it's locked" anim, return to the climb...
                                 else:
                                     MltStgLddr.gotoStage(LocalAvatar, 2,dirFlag=1,isForward=1)
-                                print("now stage 3/7 again")
+                                PtDebugPrint("now stage 3/7 again")
                             elif stageNum == 6:
-                                print("Got through hatch: finishing & removing brain.")
+                                PtDebugPrint("Got through hatch: finishing & removing brain.")
                                 MltStgLddr.gotoStage(LocalAvatar, -1)
                                 iamclimber = False
                                 #ActStart.enable()
                             elif stageNum == 3:
-                                print("done with bottom")
+                                PtDebugPrint("done with bottom")
                                 iamclimber = False
                                 MltStgLddr.gotoStage(LocalAvatar, -1)
 
@@ -207,7 +207,7 @@ class ercaLadderHatch(ptResponder):
 
     def INegotiateHatch(self):
         global boolHatch
-        print("Negotiating hatch")
+        PtDebugPrint("Negotiating hatch")
         if boolHatch == 0:
             self.IHatchLocked()
         else:
@@ -218,11 +218,11 @@ class ercaLadderHatch(ptResponder):
         "Hatch is locked; show the frustrated animation and return to previous stage"
         global LocalAvatar
         if (StrDirection.value) == "up":
-            print("Going up.  Hatch is locked; Sending gotoStage(2)")
+            PtDebugPrint("Going up.  Hatch is locked; Sending gotoStage(2)")
             RespHatchOps.run(self.key,state='lockedbelow')
             MltStgLddr.gotoStage(LocalAvatar,2,0,1)
         elif (StrDirection.value) == "down":
-            print("Going down.  Hatch is locked; Sending gotoStage(4)")
+            PtDebugPrint("Going down.  Hatch is locked; Sending gotoStage(4)")
             MltStgLddr.gotoStage(LocalAvatar,4,dirFlag=1,isForward=1,setTimeFlag=1,newTime=0.0)
             RespHatchOps.run(self.key,state='lockedbelow')
 
@@ -232,11 +232,11 @@ class ercaLadderHatch(ptResponder):
         global LocalAvatar
         global iamclimber
         if (StrDirection.value) == "up":
-            print("Going up.  Hatch is unlocked; Sending gotoStage(3)")
+            PtDebugPrint("Going up.  Hatch is unlocked; Sending gotoStage(3)")
             #RespHatchOps.run(self.key,state='openbelow')
             MltStgLddr.gotoStage(LocalAvatar,4,0,0)
         elif (StrDirection.value) == "down":
-            print("Going down.  Hatch is unlocked; Sending gotoStage(5)")
+            PtDebugPrint("Going down.  Hatch is unlocked; Sending gotoStage(5)")
             MltStgLddr.gotoStage(LocalAvatar,5,dirFlag=1,isForward=1,setTimeFlag=1,newTime=0.0)
             #RespHatchOps.run(self.key,state='openbelow')
             iamclimber = False

--- a/Python/ercaOvenScope.py
+++ b/Python/ercaOvenScope.py
@@ -432,8 +432,8 @@ class ercaOvenScope(ptModifier):
                 PtDebugPrint("ercaOvenScope:OnGUINotify:  SDL %s is %d" % (amountSDL,byteAmount))
                 PtDebugPrint("ercaOvenScope:OnGUINotify:  SDL %s is %d" % (tempSDL,byteTemp))
                 if IsBaking != 0:
-                    print "OnGUINotfiy.ShowHide: will now set timerWheel to: ",byteTime
-                    print "OInGUINotfiy.ShowHide: will now set tempWheel to: ",byteTemp
+                    print("OnGUINotfiy.ShowHide: will now set timerWheel to: ",byteTime)
+                    print("OInGUINotfiy.ShowHide: will now set tempWheel to: ",byteTemp)
                     if setTempWheel:
                         tempWheel.setValue(byteTemp)
                     self.IDoTimerWheel()
@@ -626,7 +626,7 @@ class ercaOvenScope(ptModifier):
 
 
     def IDoTimerWheel(self):
-        print "in IDoTimerWheel."
+        print("in IDoTimerWheel.")
         global byteTime
         global IsBaking
         global timerWheel
@@ -637,7 +637,7 @@ class ercaOvenScope(ptModifier):
         
         if not IsBaking:
             return
-        print "ercaOvenScope:IDoTimerWheel: IsBaking is true"
+        print("ercaOvenScope:IDoTimerWheel: IsBaking is true")
         StartTime = (IsBaking - (byteTime * kTimeScale))
         FinishTime = IsBaking
         CurTime = PtGetDniTime()
@@ -652,7 +652,7 @@ class ercaOvenScope(ptModifier):
             if PreHeat < CurTime:
                 #print "PostHeat = ",PostHeat
                 if PostHeat < CurTime:
-                    print "setTempWheel =",setTempWheel
+                    print("setTempWheel =",setTempWheel)
                     if not setTempWheel:
                         tempWheel.setValue(byteTemp)
                         setTempWheel = 1
@@ -660,8 +660,8 @@ class ercaOvenScope(ptModifier):
                     if not setTempWheel:
                         tempPercent = byteTemp * .01
                         tempWheel.animateToPercent(tempPercent)
-                        print "animating Temp Wheel, byteTemp = ",byteTemp
-                        print "animating Temp Wheel, tempPercent = ",tempPercent
+                        print("animating Temp Wheel, byteTemp = ",byteTemp)
+                        print("animating Temp Wheel, tempPercent = ",tempPercent)
                         setTempWheel = 1
             #print "StartTime = ",StartTime
             if StartTime < CurTime:

--- a/Python/ercaOvenScope.py
+++ b/Python/ercaOvenScope.py
@@ -432,8 +432,8 @@ class ercaOvenScope(ptModifier):
                 PtDebugPrint("ercaOvenScope:OnGUINotify:  SDL %s is %d" % (amountSDL,byteAmount))
                 PtDebugPrint("ercaOvenScope:OnGUINotify:  SDL %s is %d" % (tempSDL,byteTemp))
                 if IsBaking != 0:
-                    print("OnGUINotfiy.ShowHide: will now set timerWheel to: ",byteTime)
-                    print("OInGUINotfiy.ShowHide: will now set tempWheel to: ",byteTemp)
+                    PtDebugPrint("OnGUINotfiy.ShowHide: will now set timerWheel to: ",byteTime)
+                    PtDebugPrint("OInGUINotfiy.ShowHide: will now set tempWheel to: ",byteTemp)
                     if setTempWheel:
                         tempWheel.setValue(byteTemp)
                     self.IDoTimerWheel()
@@ -626,7 +626,7 @@ class ercaOvenScope(ptModifier):
 
 
     def IDoTimerWheel(self):
-        print("in IDoTimerWheel.")
+        PtDebugPrint("in IDoTimerWheel.")
         global byteTime
         global IsBaking
         global timerWheel
@@ -637,7 +637,7 @@ class ercaOvenScope(ptModifier):
         
         if not IsBaking:
             return
-        print("ercaOvenScope:IDoTimerWheel: IsBaking is true")
+        PtDebugPrint("ercaOvenScope:IDoTimerWheel: IsBaking is true")
         StartTime = (IsBaking - (byteTime * kTimeScale))
         FinishTime = IsBaking
         CurTime = PtGetDniTime()
@@ -647,12 +647,12 @@ class ercaOvenScope(ptModifier):
         PostHeat = (StartTime + 2)
         
         if CurTime < FinishTime:
-            #print "PreHeat = ",PreHeat
-            #print "CurTime = ",CurTime
+            #PtDebugPrint("PreHeat = ",PreHeat)
+            #PtDebugPrint("CurTime = ",CurTime)
             if PreHeat < CurTime:
-                #print "PostHeat = ",PostHeat
+                #PtDebugPrint("PostHeat = ",PostHeat)
                 if PostHeat < CurTime:
-                    print("setTempWheel =",setTempWheel)
+                    PtDebugPrint("setTempWheel =",setTempWheel)
                     if not setTempWheel:
                         tempWheel.setValue(byteTemp)
                         setTempWheel = 1
@@ -660,10 +660,10 @@ class ercaOvenScope(ptModifier):
                     if not setTempWheel:
                         tempPercent = byteTemp * .01
                         tempWheel.animateToPercent(tempPercent)
-                        print("animating Temp Wheel, byteTemp = ",byteTemp)
-                        print("animating Temp Wheel, tempPercent = ",tempPercent)
+                        PtDebugPrint("animating Temp Wheel, byteTemp = ",byteTemp)
+                        PtDebugPrint("animating Temp Wheel, tempPercent = ",tempPercent)
                         setTempWheel = 1
-            #print "StartTime = ",StartTime
+            #PtDebugPrint("StartTime = ",StartTime)
             if StartTime < CurTime:
                 PtDebugPrint("ercaOvenScope:IDoTimerWheel:  Now updating timer wheel of scope# %d to %d seconds remaining" % (ScopeNum.value,TimeRemaining))
                 TimeRemaining = (TimeRemaining * 1.0)

--- a/Python/ercaPelletRoom.py
+++ b/Python/ercaPelletRoom.py
@@ -135,7 +135,7 @@ class ercaPelletRoom(ptResponder):
 
 
     def OnServerInitComplete(self):
-        print "ercaPelletRoom.OnServerInitComplete()"
+        print("ercaPelletRoom.OnServerInitComplete()")
         global Pellet1
         global Pellet2
         global Pellet3
@@ -189,7 +189,7 @@ class ercaPelletRoom(ptResponder):
             ageSDL.sendToClients(SDLFlush.value)
             ageSDL.setNotify(self.key,SDLFlush.value,0.0)
         except:
-            print "ercaPelletRoom.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL"
+            print("ercaPelletRoom.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL")
             ageSDL[SDLPellet1.value] = (0,)
             ageSDL[SDLPellet2.value] = (0,)
             ageSDL[SDLPellet3.value] = (0,)
@@ -200,15 +200,15 @@ class ercaPelletRoom(ptResponder):
             ageSDL[SDLFlush.value] = (0,)
 
         boolMachine = ageSDL[SDLMachine.value][0]
-        print "boolMachine = ",boolMachine
+        print("boolMachine = ",boolMachine)
         byteChamber = ageSDL[SDLChamber.value][0]
-        print "byteChamber = ",byteChamber
+        print("byteChamber = ",byteChamber)
         boolFlush = ageSDL[SDLFlush.value][0]
         if not boolMachine and byteChamber:
-            print "machine is closed, but chamber = ",byteChamber,". Resetting chamber to 0"
+            print("machine is closed, but chamber = ",byteChamber,". Resetting chamber to 0")
             ageSDL[SDLChamber.value] = (0,)
             byteChamber = 0
-            print "corrected chamber = ",byteChamber
+            print("corrected chamber = ",byteChamber)
         
         Pellet1 = ageSDL[SDLPellet1.value][0]
         if not Pellet1 or (Pellet1 and byteChamber == 1):
@@ -216,7 +216,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet1:
                 Pellet1 = 0
                 ageSDL[SDLPellet1.value] = (0,)
-                print "must've left age before pellet1 dropped and no other players were there, correcting..."
+                print("must've left age before pellet1 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet2 = ageSDL[SDLPellet2.value][0]
         if not Pellet2 or (Pellet2 and byteChamber == 2):
@@ -224,7 +224,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet2:
                 Pellet2 = 0
                 ageSDL[SDLPellet2.value] = (0,)
-                print "must've left age before pellet2 dropped and no other players were there, correcting..."
+                print("must've left age before pellet2 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet3 = ageSDL[SDLPellet3.value][0]
         if not Pellet3 or (Pellet3 and byteChamber == 3):
@@ -232,7 +232,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet3:
                 Pellet3 = 0
                 ageSDL[SDLPellet3.value] = (0,)
-                print "must've left age before pellet3 dropped and no other players were there, correcting..."
+                print("must've left age before pellet3 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet4 = ageSDL[SDLPellet4.value][0]
         if not Pellet4 or (Pellet4 and byteChamber == 4):
@@ -240,7 +240,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet4:
                 Pellet4 = 0
                 ageSDL[SDLPellet4.value] = (0,)
-                print "must've left age before pellet4 dropped and no other players were there, correcting..."
+                print("must've left age before pellet4 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet5 = ageSDL[SDLPellet5.value][0]
         if not Pellet5 or (Pellet5 and byteChamber == 5):
@@ -248,7 +248,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet5:
                 Pellet5 = 0
                 ageSDL[SDLPellet5.value] = (0,)
-                print "must've left age before pellet5 dropped and no other players were there, correcting..."
+                print("must've left age before pellet5 dropped and no other players were there, correcting...")
                 InitCorrection = 1
 
         pelletList = [Pellet1,Pellet2,Pellet3,Pellet4,Pellet5]
@@ -256,7 +256,7 @@ class ercaPelletRoom(ptResponder):
             if pellet > 0:
                 PelletReady = 1
                 break
-        print "PelletReady = ",PelletReady
+        print("PelletReady = ",PelletReady)
         
         if PelletReady:
             if boolMachine:
@@ -282,7 +282,7 @@ class ercaPelletRoom(ptResponder):
             RespMachineEnable.run(self.key,state="Disable",fastforward=1)
             MayFlush = 0
             if boolMachine:
-                print "We shouldn't get here.  Just in case some states got hosed."
+                print("We shouldn't get here.  Just in case some states got hosed.")
                 RespMachineMode.run(self.key,state="Close",fastforward=1)
                 if not len(PtGetPlayerList()):
                     ageSDL[SDLMachine.value] = (0,)
@@ -341,7 +341,7 @@ class ercaPelletRoom(ptResponder):
             if boolMachine:
                 RespShowAllPellets.run(self.key)
                 objAvatar = ptSceneobject(PtGetAvatarKeyFromClientID(playerID),self.key)
-                print "Got boolMachine SDL = 1 notify, will now run RespUseMachine"
+                print("Got boolMachine SDL = 1 notify, will now run RespUseMachine")
                 RespUseMachine.run(self.key,avatar=objAvatar)
             else:
                 MayFlush = 0
@@ -362,14 +362,14 @@ class ercaPelletRoom(ptResponder):
             PtDebugPrint("ercaPelletRoom:OnSDLNotify:  SDL for flush lever is now %d" % (boolFlush))
             if boolFlush:
                 objAvatar = ptSceneobject(PtGetAvatarKeyFromClientID(playerID),self.key)
-                print "Got boolFlush SDL = 1 notify, will now run RespFlushOneShot"
+                print("Got boolFlush SDL = 1 notify, will now run RespFlushOneShot")
                 RespFlushOneShot.run(self.key,avatar=objAvatar)
             else:
                 pass
         
         if pelletUpdate:
             pelletList = [Pellet1,Pellet2,Pellet3,Pellet4,Pellet5]
-            print "ercaPelletRoom:OnSDLNotify(): pelletList = ",pelletList
+            print("ercaPelletRoom:OnSDLNotify(): pelletList = ",pelletList)
             testVal = 0
             for pellet in pelletList:
                 if pellet > 0:
@@ -407,38 +407,38 @@ class ercaPelletRoom(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if (id == ActUseMachine.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActUseMachine callback"
+            print("ActUseMachine callback")
             #RespUseMachineOneShot.run(self.key,avatar=PtFindAvatar(events))
             ageSDL[SDLMachine.value] = (1,)
         
         elif (id == RespUseMachine.id):
-            print "Got notify from RespUseMachine, will now open machine"
+            print("Got notify from RespUseMachine, will now open machine")
             RespMachineEnable.run(self.key,state="IfOpening")
             RespMachineMode.run(self.key,state="Open")
         
         elif (id == RespMachineMode.id):
-            print "ercaPelletRoom.OnNotify:  Machine has closed."
+            print("ercaPelletRoom.OnNotify:  Machine has closed.")
             if not PelletReady:
                 RespMachineEnable.run(self.key,state="Disable")
             if byteChamber:
                 ageSDL[SDLChamber.value] = (0,)
         
         elif (id == RespMachineEnable.id):
-            print "RespMachineEnable callback"
+            print("RespMachineEnable callback")
             MayFlush = 1
-            print "set MayFlush = ",MayFlush
+            print("set MayFlush = ",MayFlush)
         
         elif (id == ActSpitPellet.id and state and LocalAvatar == PtFindAvatar(events)):
             if TakePellet:
-                print "TakePellet is still active, must wait a few seconds before allowing another pellet to be spit out"
+                print("TakePellet is still active, must wait a few seconds before allowing another pellet to be spit out")
                 RespUseSpitBtn.run(self.key,avatar=LocalAvatar,state="deny")
                 return
-            print "ActSpitPellet callback"
+            print("ActSpitPellet callback")
             #ISpit = 1
             ActSpitPellet.disableActivator()
             MayFlush = 0
             if byteChamber == 5:
-                print "Trying to spit pellet, but we're on Chamber5.  This shouldn't be possible.  Closing machine..."
+                print("Trying to spit pellet, but we're on Chamber5.  This shouldn't be possible.  Closing machine...")
                 ageSDL[SDLMachine.value] = (0,)
                 ageSDL[SDLChamber.value] = (0,)
                 ageSDL[SDLPellet1.value] = (0,)
@@ -452,7 +452,7 @@ class ercaPelletRoom(ptResponder):
             ageSDL[SDLChamber.value] = (newVal,)
         
         elif (id == RespUseSpitBtn.id):
-            print "RespUseSpitBtn callback"
+            print("RespUseSpitBtn callback")
             if byteChamber == 1:
                 RespRotateChamber.run(self.key,state="Chamber1")
             elif byteChamber == 2:
@@ -465,7 +465,7 @@ class ercaPelletRoom(ptResponder):
                 RespRotateChamber.run(self.key,state="Chamber5")
         
         elif (id == RespRotateChamber.id):
-            print "RespRotateChamber callback"
+            print("RespRotateChamber callback")
             if byteChamber == 1:
                 RespSpitPellet.run(self.key,state="Chamber1")
             elif byteChamber == 2:
@@ -480,7 +480,7 @@ class ercaPelletRoom(ptResponder):
         elif (id == RespSpitPellet.id):
 #            if not ISpit:
 #                return
-            print "RespSpitPellet callback"
+            print("RespSpitPellet callback")
             #TakePellet = 0
             self.SendNote('0')
             #ActTakePellet.enableActivator()
@@ -488,7 +488,7 @@ class ercaPelletRoom(ptResponder):
             #ISpit = 0
         
         elif (id == ActTakePellet.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActTakePellet callback"
+            print("ActTakePellet callback")
             #ActTakePellet.disableActivator()
             #TakePellet = 1
             self.SendNote('1')
@@ -502,14 +502,14 @@ class ercaPelletRoom(ptResponder):
 
         elif (id == RespTouchPellet.id):
             if Toucher:
-                print "RespTouchPellet callback for Untouch, will now try to kill multistage"
+                print("RespTouchPellet callback for Untouch, will now try to kill multistage")
                 MltStgLinkPellet.gotoStage(Toucher, -1)
                 cam = ptCamera()
                 cam.enableFirstPersonOverride()
                 Toucher = None
         
         elif (id == ActPelletToSilo.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActPelletToSilo callback"
+            print("ActPelletToSilo callback")
             iLink = 1
             #TakePellet = 2
             self.SendNote('2')
@@ -517,7 +517,7 @@ class ercaPelletRoom(ptResponder):
             PtAtTimeCallback(self.key,0.6,3)
         
         elif (id == ActPelletToCave.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActPelletToCave callback"
+            print("ActPelletToCave callback")
             iLink = 1
             #TakePellet = 2
             self.SendNote('2')
@@ -528,7 +528,7 @@ class ercaPelletRoom(ptResponder):
             if not iLink:
                 return
             iLink = 0
-            print "RespLinkPellet callback"
+            print("RespLinkPellet callback")
             Recipe = 0
             if byteChamber == 1:
                 Recipe = Pellet1
@@ -564,7 +564,7 @@ class ercaPelletRoom(ptResponder):
 
 
         elif (id == RespDropPellet.id):
-            print "RespDropPellet callback"
+            print("RespDropPellet callback")
             #WaitHack = 1
             #PtAtTimeCallback(self.key,5,6)
             #ActSpitPellet.enableActivator()
@@ -588,19 +588,19 @@ class ercaPelletRoom(ptResponder):
                     LastPellet = 0
         
         elif (id == ActFlushLever.id and state and LocalAvatar == PtFindAvatar(events)):
-            print "ActFlushLever callback"
+            print("ActFlushLever callback")
             ageSDL[SDLFlush.value] = (1,)
         
         elif (id == RespFlushOneShot.id):
-            print "RespFlushOneShot callback"
-            print "MayFlush = ",MayFlush
+            print("RespFlushOneShot callback")
+            print("MayFlush = ",MayFlush)
             RespFlushLever.run(self.key)
             if MayFlush:
                 ActSpitPellet.disableActivator()
         
         elif (id == RespFlushLever.id):
-            print "RespFlushLever callback"
-            print "MayFlush = ",MayFlush
+            print("RespFlushLever callback")
+            print("MayFlush = ",MayFlush)
             if MayFlush:
                 #MayFlush = 0
                 self.IFlushPellets()
@@ -609,7 +609,7 @@ class ercaPelletRoom(ptResponder):
                     ageSDL[SDLFlush.value] = (0,)
         
         elif (id == RespFlushAPellet.id):
-            print "RespFlushAPellet callback"
+            print("RespFlushAPellet callback")
             if self.sceneobject.isLocallyOwned():
                 ageSDL[SDLPellet1.value] = (0,)
                 ageSDL[SDLPellet2.value] = (0,)
@@ -630,7 +630,7 @@ class ercaPelletRoom(ptResponder):
         global Toucher
         if controlKey == PlasmaControlKeys.kKeyExitMode:
             if TakePellet == 1:
-                print "ercaPelletRoom.OnControlKeyEvent(): hit exit key"
+                print("ercaPelletRoom.OnControlKeyEvent(): hit exit key")
                 #TakePellet = 0
                 self.SendNote('0')
                 #ActTakePellet.enableActivator()
@@ -639,7 +639,7 @@ class ercaPelletRoom(ptResponder):
                 PtAtTimeCallback(self.key,0.8,5)
         elif controlKey == PlasmaControlKeys.kKeyMoveBackward or controlKey == PlasmaControlKeys.kKeyRotateLeft or controlKey == PlasmaControlKeys.kKeyRotateRight:
             if TakePellet == 1:
-                print "ercaPelletRoom.OnControlKeyEvent(): hit movement key"
+                print("ercaPelletRoom.OnControlKeyEvent(): hit movement key")
                 #TakePellet = 0
                 self.SendNote('0')
                 #ActTakePellet.enableActivator()
@@ -649,7 +649,7 @@ class ercaPelletRoom(ptResponder):
 
 
     def OnTimer(self,id):
-        print "ercaPelletRoom.OnTimer():  id = ",id
+        print("ercaPelletRoom.OnTimer():  id = ",id)
         global byteChamber
         global TakePellet
         global Toucher
@@ -670,12 +670,12 @@ class ercaPelletRoom(ptResponder):
                 if TakePellet == 1:
                     #TakePellet = 0
                     self.SendNote('0')
-                    print "onTimer, TakePellet = 1"
+                    print("onTimer, TakePellet = 1")
                     if Toucher:
                         MltStgLinkPellet.gotoStage(Toucher, 0,newTime=1.2,dirFlag=1,isForward=0)
                     PtAtTimeCallback(self.key,0.8,5)
         elif id == 2:
-            print "OnTimer.Is taking a pellet reseting it's SDL to O???"
+            print("OnTimer.Is taking a pellet reseting it's SDL to O???")
             ActSpitPellet.enableActivator()
         elif id == 3:
             RespLinkPellet.run(self.key,avatar=Toucher,state="CitySilo")
@@ -688,7 +688,7 @@ class ercaPelletRoom(ptResponder):
 
 
     def IFlushPellets(self):
-        print "in IFlushPellets."
+        print("in IFlushPellets.")
         global Pellet1
         global Pellet2
         global Pellet3
@@ -721,7 +721,7 @@ class ercaPelletRoom(ptResponder):
 
     def UpdateTakePellet(self,tp):
         global TakePellet
-        print "ercaPelletRoom.UpdateTakePellet(): tp = ",tp
+        print("ercaPelletRoom.UpdateTakePellet(): tp = ",tp)
         TakePellet = tp
 
 
@@ -751,14 +751,14 @@ class ercaPelletRoom(ptResponder):
                     ageDataChild = ageDataChildRef.getChild()
                     chron = ageDataChild.upcastToChronicleNode()
                     if chron and chron.getName() == "PelletCaveGUID":
-                        print "Found pellet cave guid - ", chron.getValue()
+                        print("Found pellet cave guid - ", chron.getValue())
                         return chron.getValue()
                     return ""
 
 
     def LinkToPelletCave(self,spawnPt):
         pelletCaveGUID = str(self.OnClickToLinkToPelletCaveFromErcana())
-        print "pelletCaveGUID = ",pelletCaveGUID
+        print("pelletCaveGUID = ",pelletCaveGUID)
         caveInfo = ptAgeInfoStruct()
         caveInfo.setAgeFilename("PelletBahroCave")
         caveInfo.setAgeInstanceName("PelletBahroCave")
@@ -778,7 +778,7 @@ class ercaPelletRoom(ptResponder):
         als.setAgeInfo(info)
         als.setSpawnPoint(spawnPoint)
         als.setLinkingRules(PtLinkingRules.kBasicLink)
-        print "-- linking to pellet cave --"
+        print("-- linking to pellet cave --")
         linkMgr = ptNetLinkingMgr()
         #linkMgr.linkToAge(als)
         linkMgr.linkToAge(als,"TouchPellet")
@@ -790,4 +790,4 @@ class ercaPelletRoom(ptResponder):
             if takePellet >= 0 and takePellet <= 2:
                 self.UpdateTakePellet(takePellet);
         except:
-            print "ercaPelletRoom.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("ercaPelletRoom.ExecCode(): ERROR! Invalid code '%s'." % (code))

--- a/Python/ercaPelletRoom.py
+++ b/Python/ercaPelletRoom.py
@@ -135,7 +135,7 @@ class ercaPelletRoom(ptResponder):
 
 
     def OnServerInitComplete(self):
-        print("ercaPelletRoom.OnServerInitComplete()")
+        PtDebugPrint("ercaPelletRoom.OnServerInitComplete()")
         global Pellet1
         global Pellet2
         global Pellet3
@@ -189,7 +189,7 @@ class ercaPelletRoom(ptResponder):
             ageSDL.sendToClients(SDLFlush.value)
             ageSDL.setNotify(self.key,SDLFlush.value,0.0)
         except:
-            print("ercaPelletRoom.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL")
+            PtDebugPrint("ercaPelletRoom.OnServerInitComplete():\tERROR---Cannot find the Ercana Age SDL")
             ageSDL[SDLPellet1.value] = (0,)
             ageSDL[SDLPellet2.value] = (0,)
             ageSDL[SDLPellet3.value] = (0,)
@@ -200,15 +200,15 @@ class ercaPelletRoom(ptResponder):
             ageSDL[SDLFlush.value] = (0,)
 
         boolMachine = ageSDL[SDLMachine.value][0]
-        print("boolMachine = ",boolMachine)
+        PtDebugPrint("boolMachine = ",boolMachine)
         byteChamber = ageSDL[SDLChamber.value][0]
-        print("byteChamber = ",byteChamber)
+        PtDebugPrint("byteChamber = ",byteChamber)
         boolFlush = ageSDL[SDLFlush.value][0]
         if not boolMachine and byteChamber:
-            print("machine is closed, but chamber = ",byteChamber,". Resetting chamber to 0")
+            PtDebugPrint("machine is closed, but chamber = ",byteChamber,". Resetting chamber to 0")
             ageSDL[SDLChamber.value] = (0,)
             byteChamber = 0
-            print("corrected chamber = ",byteChamber)
+            PtDebugPrint("corrected chamber = ",byteChamber)
         
         Pellet1 = ageSDL[SDLPellet1.value][0]
         if not Pellet1 or (Pellet1 and byteChamber == 1):
@@ -216,7 +216,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet1:
                 Pellet1 = 0
                 ageSDL[SDLPellet1.value] = (0,)
-                print("must've left age before pellet1 dropped and no other players were there, correcting...")
+                PtDebugPrint("must've left age before pellet1 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet2 = ageSDL[SDLPellet2.value][0]
         if not Pellet2 or (Pellet2 and byteChamber == 2):
@@ -224,7 +224,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet2:
                 Pellet2 = 0
                 ageSDL[SDLPellet2.value] = (0,)
-                print("must've left age before pellet2 dropped and no other players were there, correcting...")
+                PtDebugPrint("must've left age before pellet2 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet3 = ageSDL[SDLPellet3.value][0]
         if not Pellet3 or (Pellet3 and byteChamber == 3):
@@ -232,7 +232,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet3:
                 Pellet3 = 0
                 ageSDL[SDLPellet3.value] = (0,)
-                print("must've left age before pellet3 dropped and no other players were there, correcting...")
+                PtDebugPrint("must've left age before pellet3 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet4 = ageSDL[SDLPellet4.value][0]
         if not Pellet4 or (Pellet4 and byteChamber == 4):
@@ -240,7 +240,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet4:
                 Pellet4 = 0
                 ageSDL[SDLPellet4.value] = (0,)
-                print("must've left age before pellet4 dropped and no other players were there, correcting...")
+                PtDebugPrint("must've left age before pellet4 dropped and no other players were there, correcting...")
                 InitCorrection = 1
         Pellet5 = ageSDL[SDLPellet5.value][0]
         if not Pellet5 or (Pellet5 and byteChamber == 5):
@@ -248,7 +248,7 @@ class ercaPelletRoom(ptResponder):
             if Pellet5:
                 Pellet5 = 0
                 ageSDL[SDLPellet5.value] = (0,)
-                print("must've left age before pellet5 dropped and no other players were there, correcting...")
+                PtDebugPrint("must've left age before pellet5 dropped and no other players were there, correcting...")
                 InitCorrection = 1
 
         pelletList = [Pellet1,Pellet2,Pellet3,Pellet4,Pellet5]
@@ -256,7 +256,7 @@ class ercaPelletRoom(ptResponder):
             if pellet > 0:
                 PelletReady = 1
                 break
-        print("PelletReady = ",PelletReady)
+        PtDebugPrint("PelletReady = ",PelletReady)
         
         if PelletReady:
             if boolMachine:
@@ -282,7 +282,7 @@ class ercaPelletRoom(ptResponder):
             RespMachineEnable.run(self.key,state="Disable",fastforward=1)
             MayFlush = 0
             if boolMachine:
-                print("We shouldn't get here.  Just in case some states got hosed.")
+                PtDebugPrint("We shouldn't get here.  Just in case some states got hosed.")
                 RespMachineMode.run(self.key,state="Close",fastforward=1)
                 if not len(PtGetPlayerList()):
                     ageSDL[SDLMachine.value] = (0,)
@@ -341,7 +341,7 @@ class ercaPelletRoom(ptResponder):
             if boolMachine:
                 RespShowAllPellets.run(self.key)
                 objAvatar = ptSceneobject(PtGetAvatarKeyFromClientID(playerID),self.key)
-                print("Got boolMachine SDL = 1 notify, will now run RespUseMachine")
+                PtDebugPrint("Got boolMachine SDL = 1 notify, will now run RespUseMachine")
                 RespUseMachine.run(self.key,avatar=objAvatar)
             else:
                 MayFlush = 0
@@ -362,14 +362,14 @@ class ercaPelletRoom(ptResponder):
             PtDebugPrint("ercaPelletRoom:OnSDLNotify:  SDL for flush lever is now %d" % (boolFlush))
             if boolFlush:
                 objAvatar = ptSceneobject(PtGetAvatarKeyFromClientID(playerID),self.key)
-                print("Got boolFlush SDL = 1 notify, will now run RespFlushOneShot")
+                PtDebugPrint("Got boolFlush SDL = 1 notify, will now run RespFlushOneShot")
                 RespFlushOneShot.run(self.key,avatar=objAvatar)
             else:
                 pass
         
         if pelletUpdate:
             pelletList = [Pellet1,Pellet2,Pellet3,Pellet4,Pellet5]
-            print("ercaPelletRoom:OnSDLNotify(): pelletList = ",pelletList)
+            PtDebugPrint("ercaPelletRoom:OnSDLNotify(): pelletList = ",pelletList)
             testVal = 0
             for pellet in pelletList:
                 if pellet > 0:
@@ -407,38 +407,38 @@ class ercaPelletRoom(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if (id == ActUseMachine.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActUseMachine callback")
+            PtDebugPrint("ActUseMachine callback")
             #RespUseMachineOneShot.run(self.key,avatar=PtFindAvatar(events))
             ageSDL[SDLMachine.value] = (1,)
         
         elif (id == RespUseMachine.id):
-            print("Got notify from RespUseMachine, will now open machine")
+            PtDebugPrint("Got notify from RespUseMachine, will now open machine")
             RespMachineEnable.run(self.key,state="IfOpening")
             RespMachineMode.run(self.key,state="Open")
         
         elif (id == RespMachineMode.id):
-            print("ercaPelletRoom.OnNotify:  Machine has closed.")
+            PtDebugPrint("ercaPelletRoom.OnNotify:  Machine has closed.")
             if not PelletReady:
                 RespMachineEnable.run(self.key,state="Disable")
             if byteChamber:
                 ageSDL[SDLChamber.value] = (0,)
         
         elif (id == RespMachineEnable.id):
-            print("RespMachineEnable callback")
+            PtDebugPrint("RespMachineEnable callback")
             MayFlush = 1
-            print("set MayFlush = ",MayFlush)
+            PtDebugPrint("set MayFlush = ",MayFlush)
         
         elif (id == ActSpitPellet.id and state and LocalAvatar == PtFindAvatar(events)):
             if TakePellet:
-                print("TakePellet is still active, must wait a few seconds before allowing another pellet to be spit out")
+                PtDebugPrint("TakePellet is still active, must wait a few seconds before allowing another pellet to be spit out")
                 RespUseSpitBtn.run(self.key,avatar=LocalAvatar,state="deny")
                 return
-            print("ActSpitPellet callback")
+            PtDebugPrint("ActSpitPellet callback")
             #ISpit = 1
             ActSpitPellet.disableActivator()
             MayFlush = 0
             if byteChamber == 5:
-                print("Trying to spit pellet, but we're on Chamber5.  This shouldn't be possible.  Closing machine...")
+                PtDebugPrint("Trying to spit pellet, but we're on Chamber5.  This shouldn't be possible.  Closing machine...")
                 ageSDL[SDLMachine.value] = (0,)
                 ageSDL[SDLChamber.value] = (0,)
                 ageSDL[SDLPellet1.value] = (0,)
@@ -452,7 +452,7 @@ class ercaPelletRoom(ptResponder):
             ageSDL[SDLChamber.value] = (newVal,)
         
         elif (id == RespUseSpitBtn.id):
-            print("RespUseSpitBtn callback")
+            PtDebugPrint("RespUseSpitBtn callback")
             if byteChamber == 1:
                 RespRotateChamber.run(self.key,state="Chamber1")
             elif byteChamber == 2:
@@ -465,7 +465,7 @@ class ercaPelletRoom(ptResponder):
                 RespRotateChamber.run(self.key,state="Chamber5")
         
         elif (id == RespRotateChamber.id):
-            print("RespRotateChamber callback")
+            PtDebugPrint("RespRotateChamber callback")
             if byteChamber == 1:
                 RespSpitPellet.run(self.key,state="Chamber1")
             elif byteChamber == 2:
@@ -480,7 +480,7 @@ class ercaPelletRoom(ptResponder):
         elif (id == RespSpitPellet.id):
 #            if not ISpit:
 #                return
-            print("RespSpitPellet callback")
+            PtDebugPrint("RespSpitPellet callback")
             #TakePellet = 0
             self.SendNote('0')
             #ActTakePellet.enableActivator()
@@ -488,7 +488,7 @@ class ercaPelletRoom(ptResponder):
             #ISpit = 0
         
         elif (id == ActTakePellet.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActTakePellet callback")
+            PtDebugPrint("ActTakePellet callback")
             #ActTakePellet.disableActivator()
             #TakePellet = 1
             self.SendNote('1')
@@ -502,14 +502,14 @@ class ercaPelletRoom(ptResponder):
 
         elif (id == RespTouchPellet.id):
             if Toucher:
-                print("RespTouchPellet callback for Untouch, will now try to kill multistage")
+                PtDebugPrint("RespTouchPellet callback for Untouch, will now try to kill multistage")
                 MltStgLinkPellet.gotoStage(Toucher, -1)
                 cam = ptCamera()
                 cam.enableFirstPersonOverride()
                 Toucher = None
         
         elif (id == ActPelletToSilo.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActPelletToSilo callback")
+            PtDebugPrint("ActPelletToSilo callback")
             iLink = 1
             #TakePellet = 2
             self.SendNote('2')
@@ -517,7 +517,7 @@ class ercaPelletRoom(ptResponder):
             PtAtTimeCallback(self.key,0.6,3)
         
         elif (id == ActPelletToCave.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActPelletToCave callback")
+            PtDebugPrint("ActPelletToCave callback")
             iLink = 1
             #TakePellet = 2
             self.SendNote('2')
@@ -528,7 +528,7 @@ class ercaPelletRoom(ptResponder):
             if not iLink:
                 return
             iLink = 0
-            print("RespLinkPellet callback")
+            PtDebugPrint("RespLinkPellet callback")
             Recipe = 0
             if byteChamber == 1:
                 Recipe = Pellet1
@@ -564,7 +564,7 @@ class ercaPelletRoom(ptResponder):
 
 
         elif (id == RespDropPellet.id):
-            print("RespDropPellet callback")
+            PtDebugPrint("RespDropPellet callback")
             #WaitHack = 1
             #PtAtTimeCallback(self.key,5,6)
             #ActSpitPellet.enableActivator()
@@ -588,19 +588,19 @@ class ercaPelletRoom(ptResponder):
                     LastPellet = 0
         
         elif (id == ActFlushLever.id and state and LocalAvatar == PtFindAvatar(events)):
-            print("ActFlushLever callback")
+            PtDebugPrint("ActFlushLever callback")
             ageSDL[SDLFlush.value] = (1,)
         
         elif (id == RespFlushOneShot.id):
-            print("RespFlushOneShot callback")
-            print("MayFlush = ",MayFlush)
+            PtDebugPrint("RespFlushOneShot callback")
+            PtDebugPrint("MayFlush = ",MayFlush)
             RespFlushLever.run(self.key)
             if MayFlush:
                 ActSpitPellet.disableActivator()
         
         elif (id == RespFlushLever.id):
-            print("RespFlushLever callback")
-            print("MayFlush = ",MayFlush)
+            PtDebugPrint("RespFlushLever callback")
+            PtDebugPrint("MayFlush = ",MayFlush)
             if MayFlush:
                 #MayFlush = 0
                 self.IFlushPellets()
@@ -609,7 +609,7 @@ class ercaPelletRoom(ptResponder):
                     ageSDL[SDLFlush.value] = (0,)
         
         elif (id == RespFlushAPellet.id):
-            print("RespFlushAPellet callback")
+            PtDebugPrint("RespFlushAPellet callback")
             if self.sceneobject.isLocallyOwned():
                 ageSDL[SDLPellet1.value] = (0,)
                 ageSDL[SDLPellet2.value] = (0,)
@@ -619,9 +619,9 @@ class ercaPelletRoom(ptResponder):
                 ageSDL[SDLMachine.value] = (0,)
         	
         elif id == (-1):
-            #print "incoming event: %s" % (events[0][1])
+            #PtDebugPrint("incoming event: %s" % (events[0][1]))
             code = events[0][1]
-            #print "playing command: %s" % (code)
+            #PtDebugPrint("playing command: %s" % (code))
             self.ExecCode(code)  
 
 
@@ -630,7 +630,7 @@ class ercaPelletRoom(ptResponder):
         global Toucher
         if controlKey == PlasmaControlKeys.kKeyExitMode:
             if TakePellet == 1:
-                print("ercaPelletRoom.OnControlKeyEvent(): hit exit key")
+                PtDebugPrint("ercaPelletRoom.OnControlKeyEvent(): hit exit key")
                 #TakePellet = 0
                 self.SendNote('0')
                 #ActTakePellet.enableActivator()
@@ -639,7 +639,7 @@ class ercaPelletRoom(ptResponder):
                 PtAtTimeCallback(self.key,0.8,5)
         elif controlKey == PlasmaControlKeys.kKeyMoveBackward or controlKey == PlasmaControlKeys.kKeyRotateLeft or controlKey == PlasmaControlKeys.kKeyRotateRight:
             if TakePellet == 1:
-                print("ercaPelletRoom.OnControlKeyEvent(): hit movement key")
+                PtDebugPrint("ercaPelletRoom.OnControlKeyEvent(): hit movement key")
                 #TakePellet = 0
                 self.SendNote('0')
                 #ActTakePellet.enableActivator()
@@ -649,7 +649,7 @@ class ercaPelletRoom(ptResponder):
 
 
     def OnTimer(self,id):
-        print("ercaPelletRoom.OnTimer():  id = ",id)
+        PtDebugPrint("ercaPelletRoom.OnTimer():  id = ",id)
         global byteChamber
         global TakePellet
         global Toucher
@@ -660,7 +660,7 @@ class ercaPelletRoom(ptResponder):
         if id == 1:
             if TakePellet == 2:
                 RespDropPellet.run(self.key,state="taken")
-                #print "taken"
+                #PtDebugPrint("taken")
                 #TakePellet = 0
                 #self.SendNote('0')
                 PtAtTimeCallback(self.key,10,6)
@@ -670,12 +670,12 @@ class ercaPelletRoom(ptResponder):
                 if TakePellet == 1:
                     #TakePellet = 0
                     self.SendNote('0')
-                    print("onTimer, TakePellet = 1")
+                    PtDebugPrint("onTimer, TakePellet = 1")
                     if Toucher:
                         MltStgLinkPellet.gotoStage(Toucher, 0,newTime=1.2,dirFlag=1,isForward=0)
                     PtAtTimeCallback(self.key,0.8,5)
         elif id == 2:
-            print("OnTimer.Is taking a pellet reseting it's SDL to O???")
+            PtDebugPrint("OnTimer.Is taking a pellet reseting it's SDL to O???")
             ActSpitPellet.enableActivator()
         elif id == 3:
             RespLinkPellet.run(self.key,avatar=Toucher,state="CitySilo")
@@ -688,7 +688,7 @@ class ercaPelletRoom(ptResponder):
 
 
     def IFlushPellets(self):
-        print("in IFlushPellets.")
+        PtDebugPrint("in IFlushPellets.")
         global Pellet1
         global Pellet2
         global Pellet3
@@ -721,7 +721,7 @@ class ercaPelletRoom(ptResponder):
 
     def UpdateTakePellet(self,tp):
         global TakePellet
-        print("ercaPelletRoom.UpdateTakePellet(): tp = ",tp)
+        PtDebugPrint("ercaPelletRoom.UpdateTakePellet(): tp = ",tp)
         TakePellet = tp
 
 
@@ -751,14 +751,14 @@ class ercaPelletRoom(ptResponder):
                     ageDataChild = ageDataChildRef.getChild()
                     chron = ageDataChild.upcastToChronicleNode()
                     if chron and chron.getName() == "PelletCaveGUID":
-                        print("Found pellet cave guid - ", chron.getValue())
+                        PtDebugPrint("Found pellet cave guid - ", chron.getValue())
                         return chron.getValue()
                     return ""
 
 
     def LinkToPelletCave(self,spawnPt):
         pelletCaveGUID = str(self.OnClickToLinkToPelletCaveFromErcana())
-        print("pelletCaveGUID = ",pelletCaveGUID)
+        PtDebugPrint("pelletCaveGUID = ",pelletCaveGUID)
         caveInfo = ptAgeInfoStruct()
         caveInfo.setAgeFilename("PelletBahroCave")
         caveInfo.setAgeInstanceName("PelletBahroCave")
@@ -778,7 +778,7 @@ class ercaPelletRoom(ptResponder):
         als.setAgeInfo(info)
         als.setSpawnPoint(spawnPoint)
         als.setLinkingRules(PtLinkingRules.kBasicLink)
-        print("-- linking to pellet cave --")
+        PtDebugPrint("-- linking to pellet cave --")
         linkMgr = ptNetLinkingMgr()
         #linkMgr.linkToAge(als)
         linkMgr.linkToAge(als,"TouchPellet")
@@ -790,4 +790,4 @@ class ercaPelletRoom(ptResponder):
             if takePellet >= 0 and takePellet <= 2:
                 self.UpdateTakePellet(takePellet);
         except:
-            print("ercaPelletRoom.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("ercaPelletRoom.ExecCode(): ERROR! Invalid code '%s'." % (code))

--- a/Python/giraAgeSDLBoolRespondLightpost.py
+++ b/Python/giraAgeSDLBoolRespondLightpost.py
@@ -83,7 +83,7 @@ class giraAgeSDLBoolRespondLightpost(ptResponder):
         ageSDL.setNotify(self.key,stringVarSolved.value,0.0)
         solved = ageSDL[stringVarSolved.value][0]
         if (solved):
-            print "solved ",stringVarSolved.value
+            print("solved ",stringVarSolved.value)
         else:
             return
         if (ageSDL[stringVarName.value][0]):
@@ -105,7 +105,7 @@ class giraAgeSDLBoolRespondLightpost(ptResponder):
         solved = ageSDL[stringVarSolved.value][0]
         if not solved:
             return
-        print "cave puzzle solved ",stringVarSolved.value
+        print("cave puzzle solved ",stringVarSolved.value)
         # is state change from player or vault manager?
         if playerID: # non-zero means it's a player
             objAvatar = ptSceneobject(PtGetAvatarKeyFromClientID(playerID),self.key)

--- a/Python/giraAgeSDLBoolRespondLightpost.py
+++ b/Python/giraAgeSDLBoolRespondLightpost.py
@@ -83,7 +83,7 @@ class giraAgeSDLBoolRespondLightpost(ptResponder):
         ageSDL.setNotify(self.key,stringVarSolved.value,0.0)
         solved = ageSDL[stringVarSolved.value][0]
         if (solved):
-            print("solved ",stringVarSolved.value)
+            PtDebugPrint("solved ",stringVarSolved.value)
         else:
             return
         if (ageSDL[stringVarName.value][0]):
@@ -105,7 +105,7 @@ class giraAgeSDLBoolRespondLightpost(ptResponder):
         solved = ageSDL[stringVarSolved.value][0]
         if not solved:
             return
-        print("cave puzzle solved ",stringVarSolved.value)
+        PtDebugPrint("cave puzzle solved ",stringVarSolved.value)
         # is state change from player or vault manager?
         if playerID: # non-zero means it's a player
             objAvatar = ptSceneobject(PtGetAvatarKeyFromClientID(playerID),self.key)

--- a/Python/grsn1stFloorClimb.py
+++ b/Python/grsn1stFloorClimb.py
@@ -91,17 +91,17 @@ class grsn1stFloorClimb(ptResponder):
          PtDebugPrint("********************************")
          for event in events:
 
-             PtDebugPrint("event[0] " + `event[0]`)
-             PtDebugPrint("event[1] " + `event[1]`)
-             PtDebugPrint("event[2] " + `event[2]`)
+             PtDebugPrint("event[0] " + repr(event[0]))
+             PtDebugPrint("event[1] " + repr(event[1]))
+             PtDebugPrint("event[2] " + repr(event[2]))
              
              climber = PtFindAvatar(events)
              climberID = PtGetClientIDFromAvatarKey(climber.getKey())
-             PtDebugPrint("climber ID = " + `climberID`)
+             PtDebugPrint("climber ID = " + repr(climberID))
              currentClimber = self.SDL["intSDLClimber"][0]
              currentDescender = self.SDL["intSDLDescender"][0]
-             PtDebugPrint("current climber = " + `currentClimber`)
-             PtDebugPrint("current descender = " + `currentClimber`)
+             PtDebugPrint("current climber = " + repr(currentClimber))
+             PtDebugPrint("current descender = " + repr(currentClimber))
              
              # execute climb behaviors
                                                     
@@ -130,7 +130,7 @@ class grsn1stFloorClimb(ptResponder):
              
              if id == climbTrigger.id and event[0] == 1 and event[1] == 1: #someone is entering
                  if self.SDL["intSDLClimber"][0] == -1 and self.SDL["intSDLDescender"][0] == -1: #nobody currently climbing up/down
-                     PtDebugPrint("initiated climbing avatar # "+ `climberID`)
+                     PtDebugPrint("initiated climbing avatar # "+ repr(climberID))
                      self.SDL["intSDLClimber"]=(climberID,)
                      climbBehavior.run(climber)
                  return
@@ -141,7 +141,7 @@ class grsn1stFloorClimb(ptResponder):
                      self.SDL["intSDLDescender"]=(climberID,)
 
                      test = self.SDL["intSDLDescender"][0]
-                     PtDebugPrint("just set descender to " + `test`)
+                     PtDebugPrint("just set descender to " + repr(test))
 
                      descendBehavior.run(climber)
                  return

--- a/Python/grsnDownElevator.py
+++ b/Python/grsnDownElevator.py
@@ -113,7 +113,7 @@ class grsnDownElevator(ptResponder):
         ptResponder.__init__(self)
         self.id = 51001
         self.version = 9
-        print("Initialized: grsnDownElevator")
+        PtDebugPrint("Initialized: grsnDownElevator")
 
     def OnServerInitComplete(self):
         #set initial elevator state
@@ -127,21 +127,21 @@ class grsnDownElevator(ptResponder):
         if (downOn):
             dnElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
             downElevTrigger.enable()
-            print("grsnDownElevator: down elevator on at load")
+            PtDebugPrint("grsnDownElevator: down elevator on at load")
         else:
             dnElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
             downElevTrigger.disable()
-            print("grsnDownElevator: down elevator off at load")
+            PtDebugPrint("grsnDownElevator: down elevator off at load")
             
         upOn = ageSDL[upElevSDL.value][0]
         if (upOn):
             upElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
             upElevatorBottomTrigger.enable()
-            print("grsnDownElevator: up elevator on at load")
+            PtDebugPrint("grsnDownElevator: up elevator on at load")
         else:
             upElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
             upElevatorBottomTrigger.disable()
-            print("grsnDownElevator: up elevator off at load")
+            PtDebugPrint("grsnDownElevator: up elevator off at load")
 
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
@@ -151,22 +151,22 @@ class grsnDownElevator(ptResponder):
             if (downOn):
                 dnElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
                 downElevTrigger.enable()
-                print("grsnDownElevator: turn on down elevator")
+                PtDebugPrint("grsnDownElevator: turn on down elevator")
             else:
                 dnElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
                 downElevTrigger.disable()
-                print("grsnDownElevator: turn off down elevator")
+                PtDebugPrint("grsnDownElevator: turn off down elevator")
         
         elif VARname == upElevSDL.value:
             upOn = ageSDL[upElevSDL.value][0]
             if (upOn):
                 upElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
                 upElevatorBottomTrigger.enable()
-                print("grsnDownElevator: turn on up elevator")
+                PtDebugPrint("grsnDownElevator: turn on up elevator")
             else:
                 upElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
                 upElevatorBottomTrigger.disable()
-                print("grsnDownElevator: turn off up elevator")
+                PtDebugPrint("grsnDownElevator: turn off up elevator")
         
     def OnTimer(self,id):
         global kOpenUpElevatorTop
@@ -194,18 +194,18 @@ class grsnDownElevator(ptResponder):
     def OnNotify(self,state,id,events):
         global avatarInElevator
 
-        print("grsnDownElevator.OnNotify: state=%s id=%d events=%s %s" % (state, id, str(events[0][1]), str(events[0][2])))
+        PtDebugPrint("grsnDownElevator.OnNotify: state=%s id=%d events=%s %s" % (state, id, str(events[0][1]), str(events[0][2])))
 
         if id == downBehavior.id:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print("grsnDownElevator: enter stage play")
+                    PtDebugPrint("grsnDownElevator: enter stage play")
                     PtAtTimeCallback(self.key, 1, kOpenDownElevatorTop)
                     dnElevTopSoundDummyAnim.animation.play()
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print("grsnDownElevator: warping to down point")
+                    PtDebugPrint("grsnDownElevator: warping to down point")
                     respDnElevFloorAnim.run(self.key)
                     dnElevBotSoundDummyAnim.animation.play()
                     #downElevatorTopCloseAnim.animation.play()
@@ -218,13 +218,13 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
-                    print("grsnDownElevator: other player warp")
+                    PtDebugPrint("grsnDownElevator: other player warp")
                     avatarInElevator.avatar.exitSubWorld()
                     avatarInElevator.physics.warpObj(downElevWarpPoint.value.getKey())
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print("grsnDownElevator: finished coming out of elevator")
+                    PtDebugPrint("grsnDownElevator: finished coming out of elevator")
                     #avatarInElevator.physics.warp(ptPoint3(78,-561.3,-279.041))
                     startDownCamera.value.pushCamera(avatarInElevator.getKey())
                     startDownCamera.value.popCutsceneCamera(avatarInElevator.getKey())
@@ -235,21 +235,21 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage:
-                    print("grsnDownElevator: enable trigger")
+                    PtDebugPrint("grsnDownElevator: enable trigger")
                     downElevTrigger.enable()
                     return
 
         elif id == upBehavior.id:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print("grsnDownElevator: enter stage play")
+                    PtDebugPrint("grsnDownElevator: enter stage play")
                     respUpElevFloorAnim.run(self.key)
                     PtAtTimeCallback(self.key,1,kOpenUpElevatorBottom)
                     upElevBotSoundDummyAnim.animation.play()
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print("grsnDownElevator: warping to up point")
+                    PtDebugPrint("grsnDownElevator: warping to up point")
                     upElevTopSoundDummyAnim.animation.play()
                     avatarInElevator.avatar.enterSubWorld(subworld.value)
                     avatarInElevator.physics.warpObj(upElevWarpPoint.value.getKey())
@@ -259,13 +259,13 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
-                    print("grsnDownElevator: other player warp")
+                    PtDebugPrint("grsnDownElevator: other player warp")
                     avatarInElevator.avatar.enterSubWorld(subworld.value)
                     avatarInElevator.physics.warpObj(upElevWarpPoint.value.getKey())
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print("grsnDownElevator: finished coming out of elevator")
+                    PtDebugPrint("grsnDownElevator: finished coming out of elevator")
                     cam = ptCamera()
                     cam.enableFirstPersonOverride()
                     WellTopDefaultCam.value.pushCamera(avatarInElevator.getKey())
@@ -275,7 +275,7 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage:
-                    print("grsnDownElevator: enable trigger")
+                    PtDebugPrint("grsnDownElevator: enable trigger")
                     upElevatorBottomTrigger.enable()
                     return
 
@@ -289,13 +289,13 @@ class grsnDownElevator(ptResponder):
                     cam.undoFirstPerson()
                     PtSendKIMessage(kDisableEntireYeeshaBook,0)
                 finishDownCamera.value.pushCutsceneCamera(0, avatarInElevator.getKey())
-                print("grsnDownElevator: triggered down elevator")
+                PtDebugPrint("grsnDownElevator: triggered down elevator")
                 downBehavior.run(avatarInElevator)
 
             elif id == upElevatorBottomTrigger.id:
                 upElevatorBottomTrigger.disable()
                 avatarInElevator = PtFindAvatar(events)
-                print("grsnDownElevator: triggered up elevator")
+                PtDebugPrint("grsnDownElevator: triggered up elevator")
                 cam = ptCamera()
                 if (avatarInElevator == PtGetLocalAvatar()):
                     cam.disableFirstPersonOverride()

--- a/Python/grsnDownElevator.py
+++ b/Python/grsnDownElevator.py
@@ -113,7 +113,7 @@ class grsnDownElevator(ptResponder):
         ptResponder.__init__(self)
         self.id = 51001
         self.version = 9
-        print "Initialized: grsnDownElevator"
+        print("Initialized: grsnDownElevator")
 
     def OnServerInitComplete(self):
         #set initial elevator state
@@ -127,21 +127,21 @@ class grsnDownElevator(ptResponder):
         if (downOn):
             dnElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
             downElevTrigger.enable()
-            print "grsnDownElevator: down elevator on at load"
+            print("grsnDownElevator: down elevator on at load")
         else:
             dnElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
             downElevTrigger.disable()
-            print "grsnDownElevator: down elevator off at load"
+            print("grsnDownElevator: down elevator off at load")
             
         upOn = ageSDL[upElevSDL.value][0]
         if (upOn):
             upElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
             upElevatorBottomTrigger.enable()
-            print "grsnDownElevator: up elevator on at load"
+            print("grsnDownElevator: up elevator on at load")
         else:
             upElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
             upElevatorBottomTrigger.disable()
-            print "grsnDownElevator: up elevator off at load"
+            print("grsnDownElevator: up elevator off at load")
 
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
@@ -151,22 +151,22 @@ class grsnDownElevator(ptResponder):
             if (downOn):
                 dnElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
                 downElevTrigger.enable()
-                print "grsnDownElevator: turn on down elevator"
+                print("grsnDownElevator: turn on down elevator")
             else:
                 dnElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
                 downElevTrigger.disable()
-                print "grsnDownElevator: turn off down elevator"
+                print("grsnDownElevator: turn off down elevator")
         
         elif VARname == upElevSDL.value:
             upOn = ageSDL[upElevSDL.value][0]
             if (upOn):
                 upElevatorLights.run(self.key,state='TurnOn',avatar=PtGetLocalAvatar())
                 upElevatorBottomTrigger.enable()
-                print "grsnDownElevator: turn on up elevator"
+                print("grsnDownElevator: turn on up elevator")
             else:
                 upElevatorLights.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
                 upElevatorBottomTrigger.disable()
-                print "grsnDownElevator: turn off up elevator"
+                print("grsnDownElevator: turn off up elevator")
         
     def OnTimer(self,id):
         global kOpenUpElevatorTop
@@ -194,18 +194,18 @@ class grsnDownElevator(ptResponder):
     def OnNotify(self,state,id,events):
         global avatarInElevator
 
-        print "grsnDownElevator.OnNotify: state=%s id=%d events=%s %s" % (state, id, str(events[0][1]), str(events[0][2]))
+        print("grsnDownElevator.OnNotify: state=%s id=%d events=%s %s" % (state, id, str(events[0][1]), str(events[0][2])))
 
         if id == downBehavior.id:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print "grsnDownElevator: enter stage play"
+                    print("grsnDownElevator: enter stage play")
                     PtAtTimeCallback(self.key, 1, kOpenDownElevatorTop)
                     dnElevTopSoundDummyAnim.animation.play()
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print "grsnDownElevator: warping to down point"
+                    print("grsnDownElevator: warping to down point")
                     respDnElevFloorAnim.run(self.key)
                     dnElevBotSoundDummyAnim.animation.play()
                     #downElevatorTopCloseAnim.animation.play()
@@ -218,13 +218,13 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
-                    print "grsnDownElevator: other player warp"
+                    print("grsnDownElevator: other player warp")
                     avatarInElevator.avatar.exitSubWorld()
                     avatarInElevator.physics.warpObj(downElevWarpPoint.value.getKey())
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print "grsnDownElevator: finished coming out of elevator"
+                    print("grsnDownElevator: finished coming out of elevator")
                     #avatarInElevator.physics.warp(ptPoint3(78,-561.3,-279.041))
                     startDownCamera.value.pushCamera(avatarInElevator.getKey())
                     startDownCamera.value.popCutsceneCamera(avatarInElevator.getKey())
@@ -235,21 +235,21 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage:
-                    print "grsnDownElevator: enable trigger"
+                    print("grsnDownElevator: enable trigger")
                     downElevTrigger.enable()
                     return
 
         elif id == upBehavior.id:
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print "grsnDownElevator: enter stage play"
+                    print("grsnDownElevator: enter stage play")
                     respUpElevFloorAnim.run(self.key)
                     PtAtTimeCallback(self.key,1,kOpenUpElevatorBottom)
                     upElevBotSoundDummyAnim.animation.play()
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print "grsnDownElevator: warping to up point"
+                    print("grsnDownElevator: warping to up point")
                     upElevTopSoundDummyAnim.animation.play()
                     avatarInElevator.avatar.enterSubWorld(subworld.value)
                     avatarInElevator.physics.warpObj(upElevWarpPoint.value.getKey())
@@ -259,13 +259,13 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
-                    print "grsnDownElevator: other player warp"
+                    print("grsnDownElevator: other player warp")
                     avatarInElevator.avatar.enterSubWorld(subworld.value)
                     avatarInElevator.physics.warpObj(upElevWarpPoint.value.getKey())
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage and avatarInElevator == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                    print "grsnDownElevator: finished coming out of elevator"
+                    print("grsnDownElevator: finished coming out of elevator")
                     cam = ptCamera()
                     cam.enableFirstPersonOverride()
                     WellTopDefaultCam.value.pushCamera(avatarInElevator.getKey())
@@ -275,7 +275,7 @@ class grsnDownElevator(ptResponder):
                     return
 
                 elif event[0] == kMultiStageEvent and event[1] == 1 and event[2] == kAdvanceNextStage:
-                    print "grsnDownElevator: enable trigger"
+                    print("grsnDownElevator: enable trigger")
                     upElevatorBottomTrigger.enable()
                     return
 
@@ -289,13 +289,13 @@ class grsnDownElevator(ptResponder):
                     cam.undoFirstPerson()
                     PtSendKIMessage(kDisableEntireYeeshaBook,0)
                 finishDownCamera.value.pushCutsceneCamera(0, avatarInElevator.getKey())
-                print "grsnDownElevator: triggered down elevator"
+                print("grsnDownElevator: triggered down elevator")
                 downBehavior.run(avatarInElevator)
 
             elif id == upElevatorBottomTrigger.id:
                 upElevatorBottomTrigger.disable()
                 avatarInElevator = PtFindAvatar(events)
-                print "grsnDownElevator: triggered up elevator"
+                print("grsnDownElevator: triggered up elevator")
                 cam = ptCamera()
                 if (avatarInElevator == PtGetLocalAvatar()):
                     cam.disableFirstPersonOverride()

--- a/Python/grsnEmgrPhase0.py
+++ b/Python/grsnEmgrPhase0.py
@@ -70,7 +70,7 @@ class grsnEmgrPhase0(ptResponder):
 
         version = 1
         self.version = version
-        print "__init__grsnEmgrPhase0 v.", version
+        print("__init__grsnEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -80,7 +80,7 @@ class grsnEmgrPhase0(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             for variable in BooleanVARs:
-                print "tying together", variable
+                print("tying together", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
        
@@ -92,7 +92,7 @@ class grsnEmgrPhase0(ptResponder):
         PtDebugPrint("grsnEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
         
         if VARname in BooleanVARs:
-            print "grsnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname)
+            print("grsnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
             self.IManageBOOLs(VARname,SDLname)
             
         else:
@@ -107,7 +107,7 @@ class grsnEmgrPhase0(ptResponder):
                 PtDebugPrint("grsnEmgrPhase0.OnSDLNotify:\tPaging in room ", VARname)
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print "variable = ", VARname
+                print("variable = ", VARname)
                 PtDebugPrint("grsnEmgrPhase0.OnSDLNotify:\tPaging out room ", VARname)
                 PtPageOutNode(VARname)
             else:

--- a/Python/grsnEmgrPhase0.py
+++ b/Python/grsnEmgrPhase0.py
@@ -70,7 +70,7 @@ class grsnEmgrPhase0(ptResponder):
 
         version = 1
         self.version = version
-        print("__init__grsnEmgrPhase0 v.", version)
+        PtDebugPrint("__init__grsnEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -80,7 +80,7 @@ class grsnEmgrPhase0(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             for variable in BooleanVARs:
-                print("tying together", variable)
+                PtDebugPrint("tying together", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
        
@@ -92,7 +92,7 @@ class grsnEmgrPhase0(ptResponder):
         PtDebugPrint("grsnEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
         
         if VARname in BooleanVARs:
-            print("grsnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
+            PtDebugPrint("grsnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
             self.IManageBOOLs(VARname,SDLname)
             
         else:
@@ -107,7 +107,7 @@ class grsnEmgrPhase0(ptResponder):
                 PtDebugPrint("grsnEmgrPhase0.OnSDLNotify:\tPaging in room ", VARname)
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print("variable = ", VARname)
+                PtDebugPrint("variable = ", VARname)
                 PtDebugPrint("grsnEmgrPhase0.OnSDLNotify:\tPaging out room ", VARname)
                 PtPageOutNode(VARname)
             else:

--- a/Python/grsnMainWallPython.py
+++ b/Python/grsnMainWallPython.py
@@ -112,20 +112,20 @@ class grsnMainWallPython(ptResponder):
         if PtGetPlayerList():
             ReceiveInit = True
         else:
-            print"solo in climbing wall"
+            PtDebugPrint("solo in climbing wall")
     
     def OnClimbingBlockerEvent(self,blocker):
         
-        print"looking for blocker named ",blocker.getName()
+        PtDebugPrint("looking for blocker named ",blocker.getName())
         i = 0
         while i < 171:
             if (northBlocker.value[i] == blocker):
                 northWall.value[i].runAttachedResponder(kTeamLightsBlink)
-                print"found matching texture named ",northWall.value[i].getName()
+                PtDebugPrint("found matching texture named ",northWall.value[i].getName())
                 return
             elif (southBlocker.value[i] == blocker):
                 southWall.value[i].runAttachedResponder(kTeamLightsBlink)
-                print"found matching texture named ",southWall.value[i].getName()
+                PtDebugPrint("found matching texture named ",southWall.value[i].getName())
                 return
             i = i + 1
         
@@ -135,13 +135,13 @@ class grsnMainWallPython(ptResponder):
         global SouthState
         global NorthState
         
-        print"grsnMainClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value
+        PtDebugPrint("grsnMainClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value)
         if not ReceiveInit:
-            print"failed to receive init"
+            PtDebugPrint("failed to receive init")
             return
         if (type == ptClimbingWallMsgType.kEndGameState):
             ReceiveInit = False
-            print "finished receiving total game state"
+            PtDebugPrint("finished receiving total game state")
             # update lights display 
             if (SouthState == ptClimbingWallMsgState.kSouthWin or \
                 NorthState == ptClimbingWallMsgState.kNorthWin or \
@@ -153,17 +153,17 @@ class grsnMainWallPython(ptResponder):
                     value = SouthBlockers[i] 
                     if (value > -1):
                         southWall.value[value].runAttachedResponder(kTeamLightsOn)
-                        print"drawing s wall index",value
+                        PtDebugPrint("drawing s wall index",value)
                     value = NorthBlockers[i] 
                     if (value >  -1):
                         northWall.value[value].runAttachedResponder(kTeamLightsOn)
-                        print"drawing n wall index",value
+                        PtDebugPrint("drawing n wall index",value)
                     i = i + 1
         
         if (type == ptClimbingWallMsgType.kTotalGameState):
             SouthState = state
             NorthState = value
-            print "begin receiving total game state"
+            PtDebugPrint("begin receiving total game state")
         
         elif (type == ptClimbingWallMsgType.kAddBlocker and state > 0):
             self.SetWallIndex(state,True,value)
@@ -175,7 +175,7 @@ class grsnMainWallPython(ptResponder):
         global NorthBlockers
         global SouthBlockers
         
-        print"grsnMainClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value
+        PtDebugPrint("grsnMainClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value)
         
         if (type == ptClimbingWallMsgType.kNewState):
             if (value == 1):
@@ -192,11 +192,11 @@ class grsnMainWallPython(ptResponder):
                     value = SouthBlockers[i] 
                     if (value > -1):
                         southWall.value[value].runAttachedResponder(kTeamLightsOn)
-                        print"drawing s wall index",value
+                        PtDebugPrint("drawing s wall index",value)
                     value = NorthBlockers[i] 
                     if (value >  -1):
                         northWall.value[value].runAttachedResponder(kTeamLightsOn)
-                        print"drawing n wall index",value
+                        PtDebugPrint("drawing n wall index",value)
                     i = i + 1
             elif (state == ptClimbingWallMsgState.kSouthSelect):
                 #clear wall settings
@@ -232,35 +232,35 @@ class grsnMainWallPython(ptResponder):
                 while (NorthBlockers[i] >= 0):
                     i = i + 1
                     if (i == 20):
-                        print"yikes - somehow overran the array!"
+                        PtDebugPrint("yikes - somehow overran the array!")
                         return
                 NorthBlockers[i] = index
-                print"set north wall index ",index," in slot ",i," to true"
+                PtDebugPrint("set north wall index ",index," in slot ",i," to true")
             else:
                 while (SouthBlockers[i] >= 0):
                     i = i + 1
                     if (i == 20):
-                        print"yikes - somehow overran the array!"
+                        PtDebugPrint("yikes - somehow overran the array!")
                         return
                 SouthBlockers[i] = index
-                print"set south wall index ",index," in slot ",i," to true"
+                PtDebugPrint("set south wall index ",index," in slot ",i," to true")
         else:
             if (north):
                 while (NorthBlockers[i] != index):
                     i = i + 1
                     if (i == 20):
-                        print"this should not get hit - looked for non-existent NorthWall entry!"
+                        PtDebugPrint("this should not get hit - looked for non-existent NorthWall entry!")
                         return
                 NorthBlockers[i] = -1
-                print"removed index ",index," from list slot ",i
+                PtDebugPrint("removed index ",index," from list slot ",i)
             else:
                 while (SouthBlockers[i] != index):
                     i = i + 1
                     if (i == 20):
-                        print"this should not get hit - looked for non-existent SouthWall entry!"
+                        PtDebugPrint("this should not get hit - looked for non-existent SouthWall entry!")
                         return
                 SouthBlockers[i] = -1
-                print"removed index ",index," from list slot ",i
+                PtDebugPrint("removed index ",index," from list slot ",i)
     
         
 

--- a/Python/grsnNexusBookMachine.py
+++ b/Python/grsnNexusBookMachine.py
@@ -69,7 +69,7 @@ class grsnNexusBookMachine(ptResponder):
 
     def __init__(self):
         ptResponder.__init__(self)
-        print("book machine init")
+        PtDebugPrint("book machine init")
         self.id = 53624
         self.version = 2
 
@@ -98,7 +98,7 @@ class grsnNexusBookMachine(ptResponder):
         global waitingOnYBook 
         global yellowLink
         
-        print("id ",id)
+        PtDebugPrint("id ",id)
         
         avatar=PtFindAvatar(events)
         local = PtGetLocalAvatar()
@@ -107,10 +107,10 @@ class grsnNexusBookMachine(ptResponder):
             return
         
         if (id == fakeLinkBehavior.id):
-            print("notified of link behavior, yellow book ",yellowLink)
+            PtDebugPrint("notified of link behavior, yellow book ",yellowLink)
             for event in events:
                 if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
-                    print("started touching book, set warp out timer")
+                    PtDebugPrint("started touching book, set warp out timer")
                     PtAtTimeCallback(self.key ,1.0 ,0)
                     return
         
@@ -118,22 +118,22 @@ class grsnNexusBookMachine(ptResponder):
             return
 
         if (id == bookPurpleInPos.id):
-            print("Purple book aligned")
+            PtDebugPrint("Purple book aligned")
             bookPurpleOutResponder.run(self.key)
             
         if (id == bookYellowInPos.id):
-            print("Yellow book aligned")
+            PtDebugPrint("Yellow book aligned")
             bookYellowOutResponder.run(self.key)
             
         if (id == entryTrigger.id):
             PtWearMaintainerSuit(avatar.getKey(),False)
             
         if (id == bookPurpleClickable.id):
-            print("touched purple team room book")
+            PtDebugPrint("touched purple team room book")
             yellowLink = False           
             avatar.avatar.runBehaviorSetNotify(fakeLinkBehavior.value,self.key,fakeLinkBehavior.netForce)
             
         if (id == bookYellowClickable.id):
-            print("touched yellow team room book")
+            PtDebugPrint("touched yellow team room book")
             yellowLink = True
             avatar.avatar.runBehaviorSetNotify(fakeLinkBehavior.value,self.key,fakeLinkBehavior.netForce)

--- a/Python/grsnNexusBookMachine.py
+++ b/Python/grsnNexusBookMachine.py
@@ -69,7 +69,7 @@ class grsnNexusBookMachine(ptResponder):
 
     def __init__(self):
         ptResponder.__init__(self)
-        print"book machine init"
+        print("book machine init")
         self.id = 53624
         self.version = 2
 
@@ -98,7 +98,7 @@ class grsnNexusBookMachine(ptResponder):
         global waitingOnYBook 
         global yellowLink
         
-        print"id ",id
+        print("id ",id)
         
         avatar=PtFindAvatar(events)
         local = PtGetLocalAvatar()
@@ -107,10 +107,10 @@ class grsnNexusBookMachine(ptResponder):
             return
         
         if (id == fakeLinkBehavior.id):
-            print"notified of link behavior, yellow book ",yellowLink
+            print("notified of link behavior, yellow book ",yellowLink)
             for event in events:
                 if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
-                    print"started touching book, set warp out timer"
+                    print("started touching book, set warp out timer")
                     PtAtTimeCallback(self.key ,1.0 ,0)
                     return
         
@@ -118,22 +118,22 @@ class grsnNexusBookMachine(ptResponder):
             return
 
         if (id == bookPurpleInPos.id):
-            print"Purple book aligned"
+            print("Purple book aligned")
             bookPurpleOutResponder.run(self.key)
             
         if (id == bookYellowInPos.id):
-            print"Yellow book aligned"
+            print("Yellow book aligned")
             bookYellowOutResponder.run(self.key)
             
         if (id == entryTrigger.id):
             PtWearMaintainerSuit(avatar.getKey(),False)
             
         if (id == bookPurpleClickable.id):
-            print"touched purple team room book"
+            print("touched purple team room book")
             yellowLink = False           
             avatar.avatar.runBehaviorSetNotify(fakeLinkBehavior.value,self.key,fakeLinkBehavior.netForce)
             
         if (id == bookYellowClickable.id):
-            print"touched yellow team room book"
+            print("touched yellow team room book")
             yellowLink = True
             avatar.avatar.runBehaviorSetNotify(fakeLinkBehavior.value,self.key,fakeLinkBehavior.netForce)

--- a/Python/grsnPageMaster.py
+++ b/Python/grsnPageMaster.py
@@ -76,9 +76,9 @@ class grsnPageMaster(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            print "grsnPageMaster.__init__(): Garrison version = public"
+            print("grsnPageMaster.__init__(): Garrison version = public")
         else:
-            print "grsnPageMaster.__init__(): Garrison version = Yeesha"
+            print("grsnPageMaster.__init__(): Garrison version = Yeesha")
 
         pages = []
 

--- a/Python/grsnPageMaster.py
+++ b/Python/grsnPageMaster.py
@@ -76,9 +76,9 @@ class grsnPageMaster(ptResponder):
     
         if parentname == "Neighborhood":
             IsPublic = 1
-            print("grsnPageMaster.__init__(): Garrison version = public")
+            PtDebugPrint("grsnPageMaster.__init__(): Garrison version = public")
         else:
-            print("grsnPageMaster.__init__(): Garrison version = Yeesha")
+            PtDebugPrint("grsnPageMaster.__init__(): Garrison version = Yeesha")
 
         pages = []
 

--- a/Python/grsnPowerOn.py
+++ b/Python/grsnPowerOn.py
@@ -155,7 +155,7 @@ class grsnPowerOn(ptResponder):
         ptResponder.__init__(self)
         self.id = 50119
         self.version = 5
-        print("grsnPowerGearOn::init end, version ",self.version)        
+        PtDebugPrint("grsnPowerGearOn::init end, version ",self.version)        
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -203,26 +203,26 @@ class grsnPowerOn(ptResponder):
             gearOn = False
             try:
                 gearOn = ageSDL[gearSwitchSDL.value][0]
-                print("server says gear on ",gearOn)
+                PtDebugPrint("server says gear on ",gearOn)
             except:
                 gearOn = False
-                print("failed to retrieve gear on state from server")
+                PtDebugPrint("failed to retrieve gear on state from server")
                 
             upElevOn = False
             try:
                 upElevOn = ageSDL[upElevSwitchSDL.value][0]
-                print("server says up elevator on ",upElevOn)
+                PtDebugPrint("server says up elevator on ",upElevOn)
             except:
                 upElevOn = False
-                print("failed to retrieve elevator switch state from server")
+                PtDebugPrint("failed to retrieve elevator switch state from server")
                 
             dnElevOn = False
             try:
                 dnElevOn = ageSDL[dnElevSwitchSDL.value][0]
-                print("server says down elevator on ",dnElevOn)
+                PtDebugPrint("server says down elevator on ",dnElevOn)
             except:
                 dnElevOn = False
-                print("failed to retrieve elevator switch state from server")
+                PtDebugPrint("failed to retrieve elevator switch state from server")
                 
             if (gearOn):
                 ageSDL[mainSwitchSDL.value] = (1,)
@@ -253,7 +253,7 @@ class grsnPowerOn(ptResponder):
                     dnElevSwitchResp.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar(),fastforward=True)
                     
             else: #main off
-                print("main off")
+                PtDebugPrint("main off")
                 ageSDL[mainSwitchSDL.value] = (0,)
                 ageSDL[gearSwitchSDL.value] = (0,)
                 ageSDL[upElevSwitchSDL.value] = (0,)
@@ -297,7 +297,7 @@ class grsnPowerOn(ptResponder):
         if (state == 0):
             return
         
-        print("id ",id)
+        PtDebugPrint("id ",id)
         ageSDL = PtGetAgeSDL()
 
         mainOn = False
@@ -341,19 +341,19 @@ class grsnPowerOn(ptResponder):
         
         if (id == weightTrigger.id):
             scaleEngaged = True
-            print("weight activator")
+            PtDebugPrint("weight activator")
             if (gearOn):
-                print("gear on")
+                PtDebugPrint("gear on")
                 import xSndLogTracks
                 xSndLogTracks.LogTrack("15","27")
                 weightEngageDisabled = True
                 return
-            print("set weight forward")
+            PtDebugPrint("set weight forward")
             reverser.run(self.key,state='Forward',avatar=triggerer)
             weightControlResponder.run(self.key,state='High',avatar=triggerer)
             weightDirection = kUp 
             if (weightNearDownEnd):
-                print("weight sound looping down")
+                PtDebugPrint("weight sound looping down")
                 weightStartSoundResp.run(self.key,state='Loop',avatar=triggerer)
                 weightNearDownEnd = False
                 weightSoundLoopingDown = True
@@ -361,7 +361,7 @@ class grsnPowerOn(ptResponder):
             if not generatorPrimed:
                 generatorPrimed = True
                 flashingLightsResponder.run(self.key,state='Blink',avatar=PtGetLocalAvatar())
-                print("generator primed")
+                PtDebugPrint("generator primed")
                 if (mainOn):
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
 
@@ -372,10 +372,10 @@ class grsnPowerOn(ptResponder):
             if not gearOn:
                 generatorPrimed = True
                 flashingLightsResponder.run(self.key,state='Blink',avatar=PtGetLocalAvatar())
-                print("generator primed")
+                PtDebugPrint("generator primed")
                 if (mainOn):
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
-            print("set weight reverse")
+            PtDebugPrint("set weight reverse")
             reverser.run(self.key,state='Reverse',avatar=triggerer)
             weightControlResponder.run(self.key,state='High',avatar=triggerer)
             weightDirection = kDown
@@ -390,11 +390,11 @@ class grsnPowerOn(ptResponder):
                 weightSoundLoopingDown = True
             elif (weightDirection == kDown): 
                 if (weightSoundLoopingDown):
-                    print("stop all at bottom")
+                    PtDebugPrint("stop all at bottom")
                     weightSoundLoopingDown = False
                     weightStartSoundResp.run(self.key,state='StopAll',avatar=triggerer)
                 else:
-                    print("let weight stop sound play out")
+                    PtDebugPrint("let weight stop sound play out")
             return
             
         if (id == weightStopSoundTrigger.id):
@@ -417,7 +417,7 @@ class grsnPowerOn(ptResponder):
             if (weightDirection == kDown):
                 weightStartSoundResp.run(self.key,state='Stop',avatar=triggerer)
                 weightNearDownEnd = True
-                print("weight near down end")
+                PtDebugPrint("weight near down end")
             elif (weightDirection == kUp):
                 weightNearDownEnd = False
                 weightSoundLoopingDown = False
@@ -430,7 +430,7 @@ class grsnPowerOn(ptResponder):
             #    weightLevel = weightLevel + 1
             #if (mainOn):
             #    weightLevel = weightLevel + 1
-            #print"weight level ",weightLevel
+            #PtDebugPrint("weight level ",weightLevel)
             #if (weightLevel == 0):
             #    weightControlResponder.run(self.key,state='High',avatar=triggerer)
             #elif (weightLevel == 1):
@@ -446,7 +446,7 @@ class grsnPowerOn(ptResponder):
 #            id == weightLowDown.id or \
 #            id == weightMedDown.id or \
 #            id == weightLowestDown.id):
-                print("weight down")
+                PtDebugPrint("weight down")
                 weightEngageDisabled = False
                 if (scaleEngaged):
                     return
@@ -479,28 +479,28 @@ class grsnPowerOn(ptResponder):
                 ageSDL[gearBrake02SDL.value] = (1,)
         
         if (id == gearStopTrigger.id):
-            print("gear stop trigger")
+            PtDebugPrint("gear stop trigger")
             if (gearStopping):
-                print("gear stop trigger: gear stopped, begin final descent")
+                PtDebugPrint("gear stop trigger: gear stopped, begin final descent")
                 gearStopping = False
                 if (gearStartingDown):
-                    print("gear stop trigger: gear still in initial descent - do nothing")
+                    PtDebugPrint("gear stop trigger: gear still in initial descent - do nothing")
                 else:
                     mainPowerOffResponder.run(self.key,state='GearDown',avatar=PtGetLocalAvatar())
         
         if (id == mainPowerOffResponder.id):
             if (gearStartingDown):
-                print("main power responder callback - gear finished initial descent") 
+                PtDebugPrint("main power responder callback - gear finished initial descent") 
                 #gear is finished moving partway down, okay to start second half
                 gearStartingDown = False
                 if not gearStopping:
-                    print("main power responder callback - gear also stopped, begin final descent")
+                    PtDebugPrint("main power responder callback - gear also stopped, begin final descent")
                     mainPowerOffResponder.run(self.key,state='GearDown',avatar=PtGetLocalAvatar())
                 else:
-                    print("main power responder callback - gear still turning, wait for it to stop")
+                    PtDebugPrint("main power responder callback - gear still turning, wait for it to stop")
                 return
             if not gearStopping and not gearStartingDown:
-                print("main power responder callback - reengage locks")
+                PtDebugPrint("main power responder callback - reengage locks")
                 #gear is down, reengage the locks
                 if not generatorPrimed:
                     if not brake01On:
@@ -512,13 +512,13 @@ class grsnPowerOn(ptResponder):
                         ageSDL[gearBrake02SDL.value] = (1,)
                 
         if (id == mainSwitchResp.id):
-            print("main switch callback")
+            PtDebugPrint("main switch callback")
             if (mainOn):
-                print("main switch now on")
+                PtDebugPrint("main switch now on")
                 if (generatorPrimed):
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
             else:
-                print("main switch now off")
+                PtDebugPrint("main switch now off")
                 flashingLightsResponder.run(self.key,state='Off',avatar=PtGetLocalAvatar())    
                 if (upElevOn):
                     upElevSwitchResp.run(self.key,state='Break',avatar=triggerer)
@@ -558,9 +558,9 @@ class grsnPowerOn(ptResponder):
                 
                 
         if (id == mainSwitch.id):
-            print("main switch")
+            PtDebugPrint("main switch")
             if (mainOn):
-                print("main going off")
+                PtDebugPrint("main going off")
                 ageSDL[mainSwitchSDL.value] = (0,)
                 if (gearOn):
                     gearRoomDoors.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
@@ -568,15 +568,15 @@ class grsnPowerOn(ptResponder):
                     secondFloorDoors.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
                     mainSwitchResp.run(self.key,state='Break',avatar=triggerer)
                     self.DisableCamera()
-                    print("break main switch")
+                    PtDebugPrint("break main switch")
                 else:    
                     mainSwitchResp.run(self.key,state='TurnOff',avatar=triggerer)
-                    print("turn off main switch")
+                    PtDebugPrint("turn off main switch")
                 if (generatorPrimed):
                     switchGlowResponder.run(self.key,state='Off',avatar=triggerer)
                 
             else:
-                print("main going on")
+                PtDebugPrint("main going on")
                 if (generatorPrimed):
                     ageSDL[mainSwitchSDL.value] = (1,)
                     mainSwitchResp.run(self.key,state='TurnOn',avatar=triggerer)
@@ -586,9 +586,9 @@ class grsnPowerOn(ptResponder):
             return
         
         if (id == gearSwitchResp.id):
-            print("gear switch callback")
+            PtDebugPrint("gear switch callback")
             if (gearOn):
-                print("gear switch now on")
+                PtDebugPrint("gear switch now on")
                 mainPowerOnResponder.run(self.key,avatar=triggerer)
                 flashingLightsResponder.run(self.key,state='On',avatar=triggerer)
                 gearGlowResponder.run(self.key,state='On',avatar=triggerer)   
@@ -596,7 +596,7 @@ class grsnPowerOn(ptResponder):
                     #lights went out while firing up
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
             else:
-                print("gear switch now off")
+                PtDebugPrint("gear switch now off")
                 mainPowerOffResponder.run(self.key,state='GearOff',avatar=triggerer)
                 gearStopping = True
                 gearStartingDown=True
@@ -690,50 +690,50 @@ class grsnPowerOn(ptResponder):
             return
             
         if (id == gearBrake01.id):
-            print("brake01")
+            PtDebugPrint("brake01")
             if (gearOn):
                 gearBrake01Resp.run(self.key,state='Trip',avatar=triggerer)
                 return
             elif not mainOn:
-                print("main off")
+                PtDebugPrint("main off")
                 gearBrake01Resp.run(self.key,state='Trip',avatar=triggerer)
             else: #main on
-                print("main on")
+                PtDebugPrint("main on")
                 if (generatorPrimed):
                     if (brake01On):
-                        print("unlock")
+                        PtDebugPrint("unlock")
                         gearBrake01Resp.run(self.key,state='Unlock',avatar=triggerer)
                         ageSDL[gearBrake01SDL.value]=(0,)
                     else:
-                        print("lock")
+                        PtDebugPrint("lock")
                         gearBrake01Resp.run(self.key,state='Lock',avatar=triggerer)
                         ageSDL[gearBrake01SDL.value]=(1,)
                 else: #generator not primed
-                    print("trip")
+                    PtDebugPrint("trip")
                     gearBrake01Resp.run(self.key,state='Trip',avatar=triggerer)
             return
         
         if (id == gearBrake02.id):
-            print("brake02")
+            PtDebugPrint("brake02")
             if (gearOn):
                 gearBrake02Resp.run(self.key,state='Trip',avatar=triggerer)
                 return
             elif not mainOn:
-                print("main off")
+                PtDebugPrint("main off")
                 gearBrake02Resp.run(self.key,state='Trip',avatar=triggerer)
             else: #main on
-                print("main on")
+                PtDebugPrint("main on")
                 if (generatorPrimed):
                     if (brake02On):
-                        print("unlock")
+                        PtDebugPrint("unlock")
                         gearBrake02Resp.run(self.key,state='Unlock',avatar=triggerer)
                         ageSDL[gearBrake02SDL.value]=(0,)
                     else:
-                        print("lock")
+                        PtDebugPrint("lock")
                         gearBrake02Resp.run(self.key,state='Lock',avatar=triggerer)
                         ageSDL[gearBrake02SDL.value]=(1,)
                 else: #generator not primed
-                    print("trip")
+                    PtDebugPrint("trip")
                     gearBrake02Resp.run(self.key,state='Trip',avatar=triggerer)
             return
         

--- a/Python/grsnPowerOn.py
+++ b/Python/grsnPowerOn.py
@@ -155,7 +155,7 @@ class grsnPowerOn(ptResponder):
         ptResponder.__init__(self)
         self.id = 50119
         self.version = 5
-        print "grsnPowerGearOn::init end, version ",self.version        
+        print("grsnPowerGearOn::init end, version ",self.version)        
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -203,26 +203,26 @@ class grsnPowerOn(ptResponder):
             gearOn = False
             try:
                 gearOn = ageSDL[gearSwitchSDL.value][0]
-                print"server says gear on ",gearOn
+                print("server says gear on ",gearOn)
             except:
                 gearOn = False
-                print"failed to retrieve gear on state from server"
+                print("failed to retrieve gear on state from server")
                 
             upElevOn = False
             try:
                 upElevOn = ageSDL[upElevSwitchSDL.value][0]
-                print"server says up elevator on ",upElevOn
+                print("server says up elevator on ",upElevOn)
             except:
                 upElevOn = False
-                print"failed to retrieve elevator switch state from server"
+                print("failed to retrieve elevator switch state from server")
                 
             dnElevOn = False
             try:
                 dnElevOn = ageSDL[dnElevSwitchSDL.value][0]
-                print"server says down elevator on ",dnElevOn
+                print("server says down elevator on ",dnElevOn)
             except:
                 dnElevOn = False
-                print"failed to retrieve elevator switch state from server"
+                print("failed to retrieve elevator switch state from server")
                 
             if (gearOn):
                 ageSDL[mainSwitchSDL.value] = (1,)
@@ -253,7 +253,7 @@ class grsnPowerOn(ptResponder):
                     dnElevSwitchResp.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar(),fastforward=True)
                     
             else: #main off
-                print"main off"
+                print("main off")
                 ageSDL[mainSwitchSDL.value] = (0,)
                 ageSDL[gearSwitchSDL.value] = (0,)
                 ageSDL[upElevSwitchSDL.value] = (0,)
@@ -297,7 +297,7 @@ class grsnPowerOn(ptResponder):
         if (state == 0):
             return
         
-        print"id ",id
+        print("id ",id)
         ageSDL = PtGetAgeSDL()
 
         mainOn = False
@@ -341,19 +341,19 @@ class grsnPowerOn(ptResponder):
         
         if (id == weightTrigger.id):
             scaleEngaged = True
-            print"weight activator"
+            print("weight activator")
             if (gearOn):
-                print"gear on"
+                print("gear on")
                 import xSndLogTracks
                 xSndLogTracks.LogTrack("15","27")
                 weightEngageDisabled = True
                 return
-            print"set weight forward"
+            print("set weight forward")
             reverser.run(self.key,state='Forward',avatar=triggerer)
             weightControlResponder.run(self.key,state='High',avatar=triggerer)
             weightDirection = kUp 
             if (weightNearDownEnd):
-                print"weight sound looping down"
+                print("weight sound looping down")
                 weightStartSoundResp.run(self.key,state='Loop',avatar=triggerer)
                 weightNearDownEnd = False
                 weightSoundLoopingDown = True
@@ -361,7 +361,7 @@ class grsnPowerOn(ptResponder):
             if not generatorPrimed:
                 generatorPrimed = True
                 flashingLightsResponder.run(self.key,state='Blink',avatar=PtGetLocalAvatar())
-                print"generator primed"
+                print("generator primed")
                 if (mainOn):
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
 
@@ -372,10 +372,10 @@ class grsnPowerOn(ptResponder):
             if not gearOn:
                 generatorPrimed = True
                 flashingLightsResponder.run(self.key,state='Blink',avatar=PtGetLocalAvatar())
-                print"generator primed"
+                print("generator primed")
                 if (mainOn):
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
-            print"set weight reverse"
+            print("set weight reverse")
             reverser.run(self.key,state='Reverse',avatar=triggerer)
             weightControlResponder.run(self.key,state='High',avatar=triggerer)
             weightDirection = kDown
@@ -390,11 +390,11 @@ class grsnPowerOn(ptResponder):
                 weightSoundLoopingDown = True
             elif (weightDirection == kDown): 
                 if (weightSoundLoopingDown):
-                    print"stop all at bottom"
+                    print("stop all at bottom")
                     weightSoundLoopingDown = False
                     weightStartSoundResp.run(self.key,state='StopAll',avatar=triggerer)
                 else:
-                    print"let weight stop sound play out"
+                    print("let weight stop sound play out")
             return
             
         if (id == weightStopSoundTrigger.id):
@@ -417,7 +417,7 @@ class grsnPowerOn(ptResponder):
             if (weightDirection == kDown):
                 weightStartSoundResp.run(self.key,state='Stop',avatar=triggerer)
                 weightNearDownEnd = True
-                print"weight near down end"
+                print("weight near down end")
             elif (weightDirection == kUp):
                 weightNearDownEnd = False
                 weightSoundLoopingDown = False
@@ -446,7 +446,7 @@ class grsnPowerOn(ptResponder):
 #            id == weightLowDown.id or \
 #            id == weightMedDown.id or \
 #            id == weightLowestDown.id):
-                print"weight down"
+                print("weight down")
                 weightEngageDisabled = False
                 if (scaleEngaged):
                     return
@@ -479,28 +479,28 @@ class grsnPowerOn(ptResponder):
                 ageSDL[gearBrake02SDL.value] = (1,)
         
         if (id == gearStopTrigger.id):
-            print"gear stop trigger"
+            print("gear stop trigger")
             if (gearStopping):
-                print"gear stop trigger: gear stopped, begin final descent"
+                print("gear stop trigger: gear stopped, begin final descent")
                 gearStopping = False
                 if (gearStartingDown):
-                    print"gear stop trigger: gear still in initial descent - do nothing"
+                    print("gear stop trigger: gear still in initial descent - do nothing")
                 else:
                     mainPowerOffResponder.run(self.key,state='GearDown',avatar=PtGetLocalAvatar())
         
         if (id == mainPowerOffResponder.id):
             if (gearStartingDown):
-                print"main power responder callback - gear finished initial descent" 
+                print("main power responder callback - gear finished initial descent") 
                 #gear is finished moving partway down, okay to start second half
                 gearStartingDown = False
                 if not gearStopping:
-                    print"main power responder callback - gear also stopped, begin final descent"
+                    print("main power responder callback - gear also stopped, begin final descent")
                     mainPowerOffResponder.run(self.key,state='GearDown',avatar=PtGetLocalAvatar())
                 else:
-                    print"main power responder callback - gear still turning, wait for it to stop"
+                    print("main power responder callback - gear still turning, wait for it to stop")
                 return
             if not gearStopping and not gearStartingDown:
-                print"main power responder callback - reengage locks"
+                print("main power responder callback - reengage locks")
                 #gear is down, reengage the locks
                 if not generatorPrimed:
                     if not brake01On:
@@ -512,13 +512,13 @@ class grsnPowerOn(ptResponder):
                         ageSDL[gearBrake02SDL.value] = (1,)
                 
         if (id == mainSwitchResp.id):
-            print"main switch callback"
+            print("main switch callback")
             if (mainOn):
-                print"main switch now on"
+                print("main switch now on")
                 if (generatorPrimed):
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
             else:
-                print"main switch now off"
+                print("main switch now off")
                 flashingLightsResponder.run(self.key,state='Off',avatar=PtGetLocalAvatar())    
                 if (upElevOn):
                     upElevSwitchResp.run(self.key,state='Break',avatar=triggerer)
@@ -558,9 +558,9 @@ class grsnPowerOn(ptResponder):
                 
                 
         if (id == mainSwitch.id):
-            print"main switch"
+            print("main switch")
             if (mainOn):
-                print"main going off"
+                print("main going off")
                 ageSDL[mainSwitchSDL.value] = (0,)
                 if (gearOn):
                     gearRoomDoors.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
@@ -568,15 +568,15 @@ class grsnPowerOn(ptResponder):
                     secondFloorDoors.run(self.key,state='TurnOff',avatar=PtGetLocalAvatar())
                     mainSwitchResp.run(self.key,state='Break',avatar=triggerer)
                     self.DisableCamera()
-                    print"break main switch"
+                    print("break main switch")
                 else:    
                     mainSwitchResp.run(self.key,state='TurnOff',avatar=triggerer)
-                    print"turn off main switch"
+                    print("turn off main switch")
                 if (generatorPrimed):
                     switchGlowResponder.run(self.key,state='Off',avatar=triggerer)
                 
             else:
-                print"main going on"
+                print("main going on")
                 if (generatorPrimed):
                     ageSDL[mainSwitchSDL.value] = (1,)
                     mainSwitchResp.run(self.key,state='TurnOn',avatar=triggerer)
@@ -586,9 +586,9 @@ class grsnPowerOn(ptResponder):
             return
         
         if (id == gearSwitchResp.id):
-            print"gear switch callback"
+            print("gear switch callback")
             if (gearOn):
-                print"gear switch now on"
+                print("gear switch now on")
                 mainPowerOnResponder.run(self.key,avatar=triggerer)
                 flashingLightsResponder.run(self.key,state='On',avatar=triggerer)
                 gearGlowResponder.run(self.key,state='On',avatar=triggerer)   
@@ -596,7 +596,7 @@ class grsnPowerOn(ptResponder):
                     #lights went out while firing up
                     switchGlowResponder.run(self.key,state='On',avatar=triggerer)
             else:
-                print"gear switch now off"
+                print("gear switch now off")
                 mainPowerOffResponder.run(self.key,state='GearOff',avatar=triggerer)
                 gearStopping = True
                 gearStartingDown=True
@@ -690,50 +690,50 @@ class grsnPowerOn(ptResponder):
             return
             
         if (id == gearBrake01.id):
-            print"brake01"
+            print("brake01")
             if (gearOn):
                 gearBrake01Resp.run(self.key,state='Trip',avatar=triggerer)
                 return
             elif not mainOn:
-                print"main off"
+                print("main off")
                 gearBrake01Resp.run(self.key,state='Trip',avatar=triggerer)
             else: #main on
-                print"main on"
+                print("main on")
                 if (generatorPrimed):
                     if (brake01On):
-                        print"unlock"
+                        print("unlock")
                         gearBrake01Resp.run(self.key,state='Unlock',avatar=triggerer)
                         ageSDL[gearBrake01SDL.value]=(0,)
                     else:
-                        print"lock"
+                        print("lock")
                         gearBrake01Resp.run(self.key,state='Lock',avatar=triggerer)
                         ageSDL[gearBrake01SDL.value]=(1,)
                 else: #generator not primed
-                    print"trip"
+                    print("trip")
                     gearBrake01Resp.run(self.key,state='Trip',avatar=triggerer)
             return
         
         if (id == gearBrake02.id):
-            print"brake02"
+            print("brake02")
             if (gearOn):
                 gearBrake02Resp.run(self.key,state='Trip',avatar=triggerer)
                 return
             elif not mainOn:
-                print"main off"
+                print("main off")
                 gearBrake02Resp.run(self.key,state='Trip',avatar=triggerer)
             else: #main on
-                print"main on"
+                print("main on")
                 if (generatorPrimed):
                     if (brake02On):
-                        print"unlock"
+                        print("unlock")
                         gearBrake02Resp.run(self.key,state='Unlock',avatar=triggerer)
                         ageSDL[gearBrake02SDL.value]=(0,)
                     else:
-                        print"lock"
+                        print("lock")
                         gearBrake02Resp.run(self.key,state='Lock',avatar=triggerer)
                         ageSDL[gearBrake02SDL.value]=(1,)
                 else: #generator not primed
-                    print"trip"
+                    print("trip")
                     gearBrake02Resp.run(self.key,state='Trip',avatar=triggerer)
             return
         

--- a/Python/grsnPrisonRandomSDLItems.py
+++ b/Python/grsnPrisonRandomSDLItems.py
@@ -83,7 +83,7 @@ class grsnPrisonRandomSDLItems(ptResponder):
 
         version = 2
         self.version = version
-        print "__init__grsnPrisonRandomItems v.", version
+        print("__init__grsnPrisonRandomItems v.", version)
         random.seed()
 
     def OnServerInitComplete(self):

--- a/Python/grsnPrisonRandomSDLItems.py
+++ b/Python/grsnPrisonRandomSDLItems.py
@@ -83,7 +83,7 @@ class grsnPrisonRandomSDLItems(ptResponder):
 
         version = 2
         self.version = version
-        print("__init__grsnPrisonRandomItems v.", version)
+        PtDebugPrint("__init__grsnPrisonRandomItems v.", version)
         random.seed()
 
     def OnServerInitComplete(self):

--- a/Python/grsnTrnCtrBridgeSafety.py
+++ b/Python/grsnTrnCtrBridgeSafety.py
@@ -75,7 +75,7 @@ class grsnTrnCtrBridgeSafety(ptResponder):
         if (id == triggerRgn1.id):
             for event in events:
                 if (event[0]==1):
-                    print "in region 1 ",event[1]
+                    print("in region 1 ",event[1])
                     inRegion1 = event[1]
                     return
         
@@ -83,7 +83,7 @@ class grsnTrnCtrBridgeSafety(ptResponder):
             if (inRegion1):
                 for event in events:
                     if (event[0]==1 and event[1]==1):
-                        print"in both regions - warp up"
+                        print("in both regions - warp up")
                         PtGetLocalAvatar().physics.warpObj(arrivePt.value.getKey())
                         return
  

--- a/Python/grsnTrnCtrBridgeSafety.py
+++ b/Python/grsnTrnCtrBridgeSafety.py
@@ -75,7 +75,7 @@ class grsnTrnCtrBridgeSafety(ptResponder):
         if (id == triggerRgn1.id):
             for event in events:
                 if (event[0]==1):
-                    print("in region 1 ",event[1])
+                    PtDebugPrint("in region 1 ",event[1])
                     inRegion1 = event[1]
                     return
         
@@ -83,7 +83,7 @@ class grsnTrnCtrBridgeSafety(ptResponder):
             if (inRegion1):
                 for event in events:
                     if (event[0]==1 and event[1]==1):
-                        print("in both regions - warp up")
+                        PtDebugPrint("in both regions - warp up")
                         PtGetLocalAvatar().physics.warpObj(arrivePt.value.getKey())
                         return
  

--- a/Python/grsnTrnCtrDoorEnter.py
+++ b/Python/grsnTrnCtrDoorEnter.py
@@ -73,25 +73,25 @@ class grsnTrnCtrDoorEnter(ptResponder):
         if (id == triggerRgn1.id):
             if (PtFindAvatar(events) != PtGetLocalAvatar()):
                 return
-            print" must have ki"
+            print(" must have ki")
             kiLevel = PtGetLocalKILevel()
             if (kiLevel < 2):
                 return
             for event in events:
                 if (event[0]==1 and event[1]==1):
                     avatarEntering = PtFindAvatar(events)
-                    print"entered the region, disable this one and the other door's triggers"
+                    print("entered the region, disable this one and the other door's triggers")
                     triggerRgn1.disable()
                     triggerRgn2.disable()
                     if (avatarEntering == PtGetLocalAvatar()):
-                        print"stop this avatar"
+                        print("stop this avatar")
                         PtDisableMovementKeys()
-                        print"take away first person"
+                        print("take away first person")
                         cam = ptCamera()
                         cam.disableFirstPersonOverride()
                         cam.undoFirstPerson()
                         PtSendKIMessage(kDisableEntireYeeshaBook,0)
-                    print"open the door"
+                    print("open the door")
                     door1OpenResponder.run(self.key,avatar=avatarEntering)
                     return
         
@@ -99,7 +99,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print" door is open, walk in"
+            print(" door is open, walk in")
             avatarEntering.avatar.runBehaviorSetNotify(behaviorWalkIn.value,self.key,behaviorWalkIn.netForce)
             return
         
@@ -109,7 +109,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print" Smart seek completed. Exit multistage, close exterior door"
+                    print(" Smart seek completed. Exit multistage, close exterior door")
                     behaviorWalkIn.gotoStage(avatarEntering,-1)
                     door1CloseResponder.run(self.key,avatar=avatarEntering)
                     return
@@ -118,7 +118,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print"door closed, teleport and open other door"
+            print("door closed, teleport and open other door")
             if (avatarEntering == PtGetLocalAvatar()):
                 camera.value.pushCameraCut(avatarEntering.getKey())
             avatarEntering.avatar.exitSubWorld()
@@ -130,7 +130,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print"interior door open, walk out"
+            print("interior door open, walk out")
             avatarEntering.avatar.runBehaviorSetNotify(behaviorWalkOut.value,self.key,behaviorWalkOut.netForce)
             return
             
@@ -140,7 +140,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print" Smart seek completed. Exit multistage, close interior door"
+                    print(" Smart seek completed. Exit multistage, close interior door")
                     door2CloseResponder.run(self.key,avatar=avatarEntering)
                     behaviorWalkOut.gotoStage(avatarEntering,-1)
                     return
@@ -149,7 +149,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print" process complete, re-enable detectors and free avatar "
+            print(" process complete, re-enable detectors and free avatar ")
             triggerRgn1.enable()
             triggerRgn2.enable()
             if (avatarEntering == PtGetLocalAvatar()):

--- a/Python/grsnTrnCtrDoorEnter.py
+++ b/Python/grsnTrnCtrDoorEnter.py
@@ -73,25 +73,25 @@ class grsnTrnCtrDoorEnter(ptResponder):
         if (id == triggerRgn1.id):
             if (PtFindAvatar(events) != PtGetLocalAvatar()):
                 return
-            print(" must have ki")
+            PtDebugPrint(" must have ki")
             kiLevel = PtGetLocalKILevel()
             if (kiLevel < 2):
                 return
             for event in events:
                 if (event[0]==1 and event[1]==1):
                     avatarEntering = PtFindAvatar(events)
-                    print("entered the region, disable this one and the other door's triggers")
+                    PtDebugPrint("entered the region, disable this one and the other door's triggers")
                     triggerRgn1.disable()
                     triggerRgn2.disable()
                     if (avatarEntering == PtGetLocalAvatar()):
-                        print("stop this avatar")
+                        PtDebugPrint("stop this avatar")
                         PtDisableMovementKeys()
-                        print("take away first person")
+                        PtDebugPrint("take away first person")
                         cam = ptCamera()
                         cam.disableFirstPersonOverride()
                         cam.undoFirstPerson()
                         PtSendKIMessage(kDisableEntireYeeshaBook,0)
-                    print("open the door")
+                    PtDebugPrint("open the door")
                     door1OpenResponder.run(self.key,avatar=avatarEntering)
                     return
         
@@ -99,7 +99,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print(" door is open, walk in")
+            PtDebugPrint(" door is open, walk in")
             avatarEntering.avatar.runBehaviorSetNotify(behaviorWalkIn.value,self.key,behaviorWalkIn.netForce)
             return
         
@@ -109,7 +109,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print(" Smart seek completed. Exit multistage, close exterior door")
+                    PtDebugPrint(" Smart seek completed. Exit multistage, close exterior door")
                     behaviorWalkIn.gotoStage(avatarEntering,-1)
                     door1CloseResponder.run(self.key,avatar=avatarEntering)
                     return
@@ -118,7 +118,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print("door closed, teleport and open other door")
+            PtDebugPrint("door closed, teleport and open other door")
             if (avatarEntering == PtGetLocalAvatar()):
                 camera.value.pushCameraCut(avatarEntering.getKey())
             avatarEntering.avatar.exitSubWorld()
@@ -130,7 +130,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print("interior door open, walk out")
+            PtDebugPrint("interior door open, walk out")
             avatarEntering.avatar.runBehaviorSetNotify(behaviorWalkOut.value,self.key,behaviorWalkOut.netForce)
             return
             
@@ -140,7 +140,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print(" Smart seek completed. Exit multistage, close interior door")
+                    PtDebugPrint(" Smart seek completed. Exit multistage, close interior door")
                     door2CloseResponder.run(self.key,avatar=avatarEntering)
                     behaviorWalkOut.gotoStage(avatarEntering,-1)
                     return
@@ -149,7 +149,7 @@ class grsnTrnCtrDoorEnter(ptResponder):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
             
-            print(" process complete, re-enable detectors and free avatar ")
+            PtDebugPrint(" process complete, re-enable detectors and free avatar ")
             triggerRgn1.enable()
             triggerRgn2.enable()
             if (avatarEntering == PtGetLocalAvatar()):

--- a/Python/grsnTrnCtrDoorExit.py
+++ b/Python/grsnTrnCtrDoorExit.py
@@ -80,33 +80,33 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == triggerRgn1.id):
             if (PtFindAvatar(events) != PtGetLocalAvatar()):
                 return
-            print" must have ki"
+            print(" must have ki")
             kiLevel = PtGetLocalKILevel()
             if (kiLevel < 2):
                 return
             for event in events:
                 if (event[0]==1 and event[1]==1):
                     avatarEntering = PtFindAvatar(events)
-                    print"entered the region, disable this one and the other door's triggers"
+                    print("entered the region, disable this one and the other door's triggers")
                     triggerRgn1.disable()
                     triggerRgn2.disable()
-                    print"stop this avatar"
+                    print("stop this avatar")
                     PtDisableMovementKeys()
-                    print"take away first person"
+                    print("take away first person")
                     cam = ptCamera()
                     cam.disableFirstPersonOverride()
                     cam.undoFirstPerson()
                     PtSendKIMessage(kDisableEntireYeeshaBook,0)
-                    print"open the door"
+                    print("open the door")
                     door1OpenResponder.run(self.key,avatar=PtGetLocalAvatar())
-                    print"switch to the initial camera"
+                    print("switch to the initial camera")
                     startCamera.value.pushCameraCut(PtGetLocalAvatar().getKey())
                     return
         
         if (id == door1OpenResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print" door is open, walk in"
+            print(" door is open, walk in")
             PtGetLocalAvatar().avatar.runBehaviorSetNotify(behaviorWalkIn.value,self.key,behaviorWalkIn.netForce)
             return
         
@@ -115,7 +115,7 @@ class grsnTrnCtrDoorExit(ptResponder):
                 return
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print" Smart seek completed. Exit multistage, close exterior door"
+                    print(" Smart seek completed. Exit multistage, close exterior door")
                     behaviorWalkIn.gotoStage(PtGetLocalAvatar(),-1)
                     door1CloseResponder.run(self.key,avatar=PtGetLocalAvatar())
                     return
@@ -123,7 +123,7 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == door1CloseResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print"door closed, teleport and open other door"
+            print("door closed, teleport and open other door")
             endCamera.value.pushCameraCut(PtGetLocalAvatar().getKey())
             PtGetLocalAvatar().avatar.enterSubWorld(subWorld.value)
             PtGetLocalAvatar().physics.warpObj(arrivePt.value.getKey())
@@ -133,7 +133,7 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == door2OpenResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print"interior door open, walk out"
+            print("interior door open, walk out")
             PtGetLocalAvatar().avatar.runBehaviorSetNotify(behaviorWalkOut.value,self.key,behaviorWalkOut.netForce)
             return
             
@@ -142,7 +142,7 @@ class grsnTrnCtrDoorExit(ptResponder):
                 return
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print" Smart seek completed. Exit multistage, close interior door"
+                    print(" Smart seek completed. Exit multistage, close interior door")
                     door2CloseResponder.run(self.key,avatar=PtGetLocalAvatar())
                     behaviorWalkOut.gotoStage(PtGetLocalAvatar(),-1)
                     return
@@ -150,7 +150,7 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == door2CloseResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print" process complete, re-enable detectors and free avatar "
+            print(" process complete, re-enable detectors and free avatar ")
             triggerRgn1.enable()
             triggerRgn2.enable()
             PtEnableMovementKeys()

--- a/Python/grsnTrnCtrDoorExit.py
+++ b/Python/grsnTrnCtrDoorExit.py
@@ -80,33 +80,33 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == triggerRgn1.id):
             if (PtFindAvatar(events) != PtGetLocalAvatar()):
                 return
-            print(" must have ki")
+            PtDebugPrint(" must have ki")
             kiLevel = PtGetLocalKILevel()
             if (kiLevel < 2):
                 return
             for event in events:
                 if (event[0]==1 and event[1]==1):
                     avatarEntering = PtFindAvatar(events)
-                    print("entered the region, disable this one and the other door's triggers")
+                    PtDebugPrint("entered the region, disable this one and the other door's triggers")
                     triggerRgn1.disable()
                     triggerRgn2.disable()
-                    print("stop this avatar")
+                    PtDebugPrint("stop this avatar")
                     PtDisableMovementKeys()
-                    print("take away first person")
+                    PtDebugPrint("take away first person")
                     cam = ptCamera()
                     cam.disableFirstPersonOverride()
                     cam.undoFirstPerson()
                     PtSendKIMessage(kDisableEntireYeeshaBook,0)
-                    print("open the door")
+                    PtDebugPrint("open the door")
                     door1OpenResponder.run(self.key,avatar=PtGetLocalAvatar())
-                    print("switch to the initial camera")
+                    PtDebugPrint("switch to the initial camera")
                     startCamera.value.pushCameraCut(PtGetLocalAvatar().getKey())
                     return
         
         if (id == door1OpenResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print(" door is open, walk in")
+            PtDebugPrint(" door is open, walk in")
             PtGetLocalAvatar().avatar.runBehaviorSetNotify(behaviorWalkIn.value,self.key,behaviorWalkIn.netForce)
             return
         
@@ -115,7 +115,7 @@ class grsnTrnCtrDoorExit(ptResponder):
                 return
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print(" Smart seek completed. Exit multistage, close exterior door")
+                    PtDebugPrint(" Smart seek completed. Exit multistage, close exterior door")
                     behaviorWalkIn.gotoStage(PtGetLocalAvatar(),-1)
                     door1CloseResponder.run(self.key,avatar=PtGetLocalAvatar())
                     return
@@ -123,7 +123,7 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == door1CloseResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print("door closed, teleport and open other door")
+            PtDebugPrint("door closed, teleport and open other door")
             endCamera.value.pushCameraCut(PtGetLocalAvatar().getKey())
             PtGetLocalAvatar().avatar.enterSubWorld(subWorld.value)
             PtGetLocalAvatar().physics.warpObj(arrivePt.value.getKey())
@@ -133,7 +133,7 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == door2OpenResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print("interior door open, walk out")
+            PtDebugPrint("interior door open, walk out")
             PtGetLocalAvatar().avatar.runBehaviorSetNotify(behaviorWalkOut.value,self.key,behaviorWalkOut.netForce)
             return
             
@@ -142,7 +142,7 @@ class grsnTrnCtrDoorExit(ptResponder):
                 return
             for event in events:
                 if event[0] == kMultiStageEvent and event[2] == kAdvanceNextStage: 
-                    print(" Smart seek completed. Exit multistage, close interior door")
+                    PtDebugPrint(" Smart seek completed. Exit multistage, close interior door")
                     door2CloseResponder.run(self.key,avatar=PtGetLocalAvatar())
                     behaviorWalkOut.gotoStage(PtGetLocalAvatar(),-1)
                     return
@@ -150,7 +150,7 @@ class grsnTrnCtrDoorExit(ptResponder):
         if (id == door2CloseResponder.id):
             if (avatarEntering != PtGetLocalAvatar()):
                 return
-            print(" process complete, re-enable detectors and free avatar ")
+            PtDebugPrint(" process complete, re-enable detectors and free avatar ")
             triggerRgn1.enable()
             triggerRgn2.enable()
             PtEnableMovementKeys()

--- a/Python/grsnTrnCtrDoors.py
+++ b/Python/grsnTrnCtrDoors.py
@@ -84,31 +84,31 @@ class grsnTrnCtrDoors(ptResponder):
             self.SDL['grsnDoorState'] = (0,)
             self.grsnDoorState = self.SDL['grsnDoorState'][0]
          
-        print "grsnTrnCtrDoors: self.SDL = %d" % self.grsnDoorState
-        print "grsnTrnCtrDoors: Player List = %d" % len(PtGetPlayerList())
+        print("grsnTrnCtrDoors: self.SDL = %d" % self.grsnDoorState)
+        print("grsnTrnCtrDoors: Player List = %d" % len(PtGetPlayerList()))
 
         if len(PtGetPlayerList()) > 0:
             
-            print "grsnTrnCtrDoors: Somebody is already in the age. Attempting to sync states."
+            print("grsnTrnCtrDoors: Somebody is already in the age. Attempting to sync states.")
 
             if self.grsnDoorState == doorSDLstates['open'] or self.grsnDoorState == doorSDLstates['opening']:
                  doorOpenResponder.run(self.key,fastforward=1)
-                 print "grsnTrnCtrDoors: Door is open."
-                 print "grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState
+                 print("grsnTrnCtrDoors: Door is open.")
+                 print("grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState)
             
             elif self.grsnDoorState == doorSDLstates['closing']:
                 doorCloseResponder.run(self.key,fastforward=1)
-                print "grsnTrnCtrDoors: Door is closed."
-                print "grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState
+                print("grsnTrnCtrDoors: Door is closed.")
+                print("grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState)
 
             else:
-                print "grsnTrnCtrDoors: Exception. Door State = %d" % self.grsnDoorState
+                print("grsnTrnCtrDoors: Exception. Door State = %d" % self.grsnDoorState)
 
         elif len(PtGetPlayerList()) < 1:
             # the door is really shut, someone left it open
             self.SDL['grsnDoorState'] = (doorSDLstates['closed'],)
             self.grsnDoorState = self.SDL['grsnDoorState'][0]
-            print "grsnTrnCtrDoors: Nobody is here, setting door states to closed."
+            print("grsnTrnCtrDoors: Nobody is here, setting door states to closed.")
             
         self.init = 1
     ##########################################
@@ -119,100 +119,100 @@ class grsnTrnCtrDoors(ptResponder):
         ageSDL = PtGetAgeSDL()
         #Notify Section
         if id == (-1):            
-            print "grsnTrnCtrDoors: Recieved Notify... Contents Are %s" % str(events[0][1])
+            print("grsnTrnCtrDoors: Recieved Notify... Contents Are %s" % str(events[0][1]))
             if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
                 if self.grsnDoorState == doorSDLstates['closed']:            
                     self.UpdateDoorState(doorSDLstates['opening'])
-                    print "grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opening."
+                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opening.")
 
                 elif self.grsnDoorState == doorSDLstates['movingclosed'] or self.grsnDoorState == doorSDLstates['closing']:
                     self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    print "grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closetoopen."
+                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closetoopen.")
 
                 elif self.grsnDoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['movingopen'])
-                    print "grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingopen."
+                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingopen.")
 
             elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():            
                 if self.grsnDoorState == doorSDLstates['open']:
                     self.UpdateDoorState(doorSDLstates['closing'])
-                    print "grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closing."
+                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closing.")
 
                 elif self.grsnDoorState == doorSDLstates['movingopen'] or self.grsnDoorState == doorSDLstates['opening']:
                     self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    print "grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opentoclose."
+                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opentoclose.")
 
                 elif self.grsnDoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    print "grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingclosed."
+                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingclosed.")
 
             
             elif events[0][1].find('Responder') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1:
                 self.grsnDoorStack.append(events[0][1])
-                print "grsnTrnCtrDoors: New list is: %s" % (str(self.grsnDoorStack))
+                print("grsnTrnCtrDoors: New list is: %s" % (str(self.grsnDoorStack)))
                 
                 if len(self.grsnDoorStack) == 1:
-                    print "grsnTrnCtrDoors: List is only one command long, so I'm playing it"
+                    print("grsnTrnCtrDoors: List is only one command long, so I'm playing it")
                     code = self.grsnDoorStack[0]
-                    print "grsnTrnCtrDoors: Playing command: %s" % (code)
+                    print("grsnTrnCtrDoors: Playing command: %s" % (code))
                     self.ExecCode(code)
 
             ############################################################################################################
             elif events[0][1].find('DoorState') != 1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1:
                 
                 curState = int(events[0][1].lstrip('DoorState='))
-                print "grsnTrnCtrDoors: Door State Updated to %d" % curState
-                print "grsnTrnCtrDoors: Door State SDL Set to %d" % self.SDL['grsnDoorState'][0]
+                print("grsnTrnCtrDoors: Door State Updated to %d" % curState)
+                print("grsnTrnCtrDoors: Door State SDL Set to %d" % self.SDL['grsnDoorState'][0])
 
                 if curState == doorSDLstates['closed']:
-                    print "grsnTrnCtrDoors: Door is closed and nobody is in the region."
+                    print("grsnTrnCtrDoors: Door is closed and nobody is in the region.")
                     self.grsnDoorState = doorSDLstates['closed']
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['opening']:
 
-                    print "grsnTrnCtrDoors: Someone entered the region with a KI. Opening up the door."
+                    print("grsnTrnCtrDoors: Someone entered the region with a KI. Opening up the door.")
                     
                     self.grsnDoorState = doorSDLstates['opening']
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
           
                     if self.sceneobject.isLocallyOwned():
                         self.SendNote("doorOpenResponder")
                      
                 elif curState == doorSDLstates['open']:
                     self.grsnDoorState = doorSDLstates['open']
-                    print "grsnTrnCtrDoors: Door is open and region is still occupied."
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Door is open and region is still occupied.")
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['closing']:
                     
-                    print "grsnTrnCtrDoors: Door is now going to close."
+                    print("grsnTrnCtrDoors: Door is now going to close.")
                     
                     self.grsnDoorState = doorSDLstates['closing']
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                     if self.sceneobject.isLocallyOwned():
                         self.SendNote("doorCloseResponder")
 
                 elif curState == doorSDLstates['opentoclose']:
                     self.grsnDoorState = doorSDLstates['opentoclose']
-                    print "grsnTrnCtrDoors: Everyone exited the region while the door was opening."
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Everyone exited the region while the door was opening.")
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['closetoopen']:
                     self.grsnDoorState = doorSDLstates['closetoopen']
-                    print "grsnTrnCtrDoors: Someone with a good KI entered the region while the door was closing."
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Someone with a good KI entered the region while the door was closing.")
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['movingopen']:
                     self.grsnDoorState = doorSDLstates['movingopen']
-                    print "grsnTrnCtrDoors: Going back to staying open."
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Going back to staying open.")
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['movingclosed']:
                     self.grsnDoorState = doorSDLstates['movingclosed']
-                    print "grsnTrnCtrDoors: Going back to staying closed."
-                    print "grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState
+                    print("grsnTrnCtrDoors: Going back to staying closed.")
+                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                     
             #####################################################################################                
@@ -234,10 +234,10 @@ class grsnTrnCtrDoors(ptResponder):
                             self.SendNote("rgnTriggerEnter")
                             return
 
-                        print "grsnTrnCtrDoors: I triggered the region"
+                        print("grsnTrnCtrDoors: I triggered the region")
                         
                         if PtGetLocalKILevel() < 2:
-                            print "grsnTrnCtrDoors: KiLevel too low, cannot open door"
+                            print("grsnTrnCtrDoors: KiLevel too low, cannot open door")
                             return
                         else:                        
                             self.SendNote("rgnTriggerEnter")
@@ -253,7 +253,7 @@ class grsnTrnCtrDoors(ptResponder):
             
             self.UpdateRespStack()
             
-            print "grsnTrnCtrDoors: Door is now open."
+            print("grsnTrnCtrDoors: Door is now open.")
             if self.sceneobject.isLocallyOwned():
                 if self.grsnDoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['closing'])
@@ -265,7 +265,7 @@ class grsnTrnCtrDoors(ptResponder):
 
             self.UpdateRespStack()
 
-            print "grsnTrnCtrDoors: Door is now closed."
+            print("grsnTrnCtrDoors: Door is now closed.")
             if self.sceneobject.isLocallyOwned():
                 if self.grsnDoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['opening'])
@@ -274,7 +274,7 @@ class grsnTrnCtrDoors(ptResponder):
                     self.UpdateDoorState(doorSDLstates['closed'])
 
         else:
-            print "grsnTrnCtrDoors: Events that came through:\t", events
+            print("grsnTrnCtrDoors: Events that came through:\t", events)
 ###############################################################
     def SendNote(self, ExtraInfo):
         #Thanks Derek
@@ -293,11 +293,11 @@ class grsnTrnCtrDoors(ptResponder):
     def UpdateRespStack (self):
         #Updates the Responder List
         old = self.grsnDoorStack.pop(0)
-        print "grsnTrnCtrDoors: Getting rid of Resp: %s" % (old)
+        print("grsnTrnCtrDoors: Getting rid of Resp: %s" % (old))
         if len(self.grsnDoorStack):            
-            print "grsnTrnCtrDoors: There's at lest one more Resp to play."
+            print("grsnTrnCtrDoors: There's at lest one more Resp to play.")
             code = self.grsnDoorStack[0]            
-            print "Playing command: %s" % (code)
+            print("Playing command: %s" % (code))
             self.ExecCode(code)
 
     def UpdateDoorState (self, StateNum):
@@ -310,5 +310,5 @@ class grsnTrnCtrDoors(ptResponder):
         elif code == "doorCloseResponder":
             doorCloseResponder.run(self.key,netPropagate=0)
         else:
-            print "grsnTrnCtrDoors.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("grsnTrnCtrDoors.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.grsnDoorStack.pop(0)

--- a/Python/grsnTrnCtrDoors.py
+++ b/Python/grsnTrnCtrDoors.py
@@ -84,31 +84,31 @@ class grsnTrnCtrDoors(ptResponder):
             self.SDL['grsnDoorState'] = (0,)
             self.grsnDoorState = self.SDL['grsnDoorState'][0]
          
-        print("grsnTrnCtrDoors: self.SDL = %d" % self.grsnDoorState)
-        print("grsnTrnCtrDoors: Player List = %d" % len(PtGetPlayerList()))
+        PtDebugPrint("grsnTrnCtrDoors: self.SDL = %d" % self.grsnDoorState)
+        PtDebugPrint("grsnTrnCtrDoors: Player List = %d" % len(PtGetPlayerList()))
 
         if len(PtGetPlayerList()) > 0:
             
-            print("grsnTrnCtrDoors: Somebody is already in the age. Attempting to sync states.")
+            PtDebugPrint("grsnTrnCtrDoors: Somebody is already in the age. Attempting to sync states.")
 
             if self.grsnDoorState == doorSDLstates['open'] or self.grsnDoorState == doorSDLstates['opening']:
                  doorOpenResponder.run(self.key,fastforward=1)
-                 print("grsnTrnCtrDoors: Door is open.")
-                 print("grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState)
+                 PtDebugPrint("grsnTrnCtrDoors: Door is open.")
+                 PtDebugPrint("grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState)
             
             elif self.grsnDoorState == doorSDLstates['closing']:
                 doorCloseResponder.run(self.key,fastforward=1)
-                print("grsnTrnCtrDoors: Door is closed.")
-                print("grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState)
+                PtDebugPrint("grsnTrnCtrDoors: Door is closed.")
+                PtDebugPrint("grsnTrnCtrDoors: Door State = %d" % self.grsnDoorState)
 
             else:
-                print("grsnTrnCtrDoors: Exception. Door State = %d" % self.grsnDoorState)
+                PtDebugPrint("grsnTrnCtrDoors: Exception. Door State = %d" % self.grsnDoorState)
 
         elif len(PtGetPlayerList()) < 1:
             # the door is really shut, someone left it open
             self.SDL['grsnDoorState'] = (doorSDLstates['closed'],)
             self.grsnDoorState = self.SDL['grsnDoorState'][0]
-            print("grsnTrnCtrDoors: Nobody is here, setting door states to closed.")
+            PtDebugPrint("grsnTrnCtrDoors: Nobody is here, setting door states to closed.")
             
         self.init = 1
     ##########################################
@@ -119,100 +119,100 @@ class grsnTrnCtrDoors(ptResponder):
         ageSDL = PtGetAgeSDL()
         #Notify Section
         if id == (-1):            
-            print("grsnTrnCtrDoors: Recieved Notify... Contents Are %s" % str(events[0][1]))
+            PtDebugPrint("grsnTrnCtrDoors: Recieved Notify... Contents Are %s" % str(events[0][1]))
             if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
                 if self.grsnDoorState == doorSDLstates['closed']:            
                     self.UpdateDoorState(doorSDLstates['opening'])
-                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opening.")
+                    PtDebugPrint("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opening.")
 
                 elif self.grsnDoorState == doorSDLstates['movingclosed'] or self.grsnDoorState == doorSDLstates['closing']:
                     self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closetoopen.")
+                    PtDebugPrint("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closetoopen.")
 
                 elif self.grsnDoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['movingopen'])
-                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingopen.")
+                    PtDebugPrint("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingopen.")
 
             elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():            
                 if self.grsnDoorState == doorSDLstates['open']:
                     self.UpdateDoorState(doorSDLstates['closing'])
-                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closing.")
+                    PtDebugPrint("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to closing.")
 
                 elif self.grsnDoorState == doorSDLstates['movingopen'] or self.grsnDoorState == doorSDLstates['opening']:
                     self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opentoclose.")
+                    PtDebugPrint("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to opentoclose.")
 
                 elif self.grsnDoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    print("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingclosed.")
+                    PtDebugPrint("grsnTrnCtrDoors: I triggered the region and I'm changing the sdl to movingclosed.")
 
             
             elif events[0][1].find('Responder') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1:
                 self.grsnDoorStack.append(events[0][1])
-                print("grsnTrnCtrDoors: New list is: %s" % (str(self.grsnDoorStack)))
+                PtDebugPrint("grsnTrnCtrDoors: New list is: %s" % (str(self.grsnDoorStack)))
                 
                 if len(self.grsnDoorStack) == 1:
-                    print("grsnTrnCtrDoors: List is only one command long, so I'm playing it")
+                    PtDebugPrint("grsnTrnCtrDoors: List is only one command long, so I'm playing it")
                     code = self.grsnDoorStack[0]
-                    print("grsnTrnCtrDoors: Playing command: %s" % (code))
+                    PtDebugPrint("grsnTrnCtrDoors: Playing command: %s" % (code))
                     self.ExecCode(code)
 
             ############################################################################################################
             elif events[0][1].find('DoorState') != 1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1:
                 
                 curState = int(events[0][1].lstrip('DoorState='))
-                print("grsnTrnCtrDoors: Door State Updated to %d" % curState)
-                print("grsnTrnCtrDoors: Door State SDL Set to %d" % self.SDL['grsnDoorState'][0])
+                PtDebugPrint("grsnTrnCtrDoors: Door State Updated to %d" % curState)
+                PtDebugPrint("grsnTrnCtrDoors: Door State SDL Set to %d" % self.SDL['grsnDoorState'][0])
 
                 if curState == doorSDLstates['closed']:
-                    print("grsnTrnCtrDoors: Door is closed and nobody is in the region.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door is closed and nobody is in the region.")
                     self.grsnDoorState = doorSDLstates['closed']
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['opening']:
 
-                    print("grsnTrnCtrDoors: Someone entered the region with a KI. Opening up the door.")
+                    PtDebugPrint("grsnTrnCtrDoors: Someone entered the region with a KI. Opening up the door.")
                     
                     self.grsnDoorState = doorSDLstates['opening']
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
           
                     if self.sceneobject.isLocallyOwned():
                         self.SendNote("doorOpenResponder")
                      
                 elif curState == doorSDLstates['open']:
                     self.grsnDoorState = doorSDLstates['open']
-                    print("grsnTrnCtrDoors: Door is open and region is still occupied.")
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Door is open and region is still occupied.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['closing']:
                     
-                    print("grsnTrnCtrDoors: Door is now going to close.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door is now going to close.")
                     
                     self.grsnDoorState = doorSDLstates['closing']
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                     if self.sceneobject.isLocallyOwned():
                         self.SendNote("doorCloseResponder")
 
                 elif curState == doorSDLstates['opentoclose']:
                     self.grsnDoorState = doorSDLstates['opentoclose']
-                    print("grsnTrnCtrDoors: Everyone exited the region while the door was opening.")
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Everyone exited the region while the door was opening.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['closetoopen']:
                     self.grsnDoorState = doorSDLstates['closetoopen']
-                    print("grsnTrnCtrDoors: Someone with a good KI entered the region while the door was closing.")
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Someone with a good KI entered the region while the door was closing.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['movingopen']:
                     self.grsnDoorState = doorSDLstates['movingopen']
-                    print("grsnTrnCtrDoors: Going back to staying open.")
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Going back to staying open.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                 elif curState == doorSDLstates['movingclosed']:
                     self.grsnDoorState = doorSDLstates['movingclosed']
-                    print("grsnTrnCtrDoors: Going back to staying closed.")
-                    print("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
+                    PtDebugPrint("grsnTrnCtrDoors: Going back to staying closed.")
+                    PtDebugPrint("grsnTrnCtrDoors: Door state is now %d" % self.grsnDoorState)
 
                     
             #####################################################################################                
@@ -234,10 +234,10 @@ class grsnTrnCtrDoors(ptResponder):
                             self.SendNote("rgnTriggerEnter")
                             return
 
-                        print("grsnTrnCtrDoors: I triggered the region")
+                        PtDebugPrint("grsnTrnCtrDoors: I triggered the region")
                         
                         if PtGetLocalKILevel() < 2:
-                            print("grsnTrnCtrDoors: KiLevel too low, cannot open door")
+                            PtDebugPrint("grsnTrnCtrDoors: KiLevel too low, cannot open door")
                             return
                         else:                        
                             self.SendNote("rgnTriggerEnter")
@@ -253,7 +253,7 @@ class grsnTrnCtrDoors(ptResponder):
             
             self.UpdateRespStack()
             
-            print("grsnTrnCtrDoors: Door is now open.")
+            PtDebugPrint("grsnTrnCtrDoors: Door is now open.")
             if self.sceneobject.isLocallyOwned():
                 if self.grsnDoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['closing'])
@@ -265,7 +265,7 @@ class grsnTrnCtrDoors(ptResponder):
 
             self.UpdateRespStack()
 
-            print("grsnTrnCtrDoors: Door is now closed.")
+            PtDebugPrint("grsnTrnCtrDoors: Door is now closed.")
             if self.sceneobject.isLocallyOwned():
                 if self.grsnDoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['opening'])
@@ -274,7 +274,7 @@ class grsnTrnCtrDoors(ptResponder):
                     self.UpdateDoorState(doorSDLstates['closed'])
 
         else:
-            print("grsnTrnCtrDoors: Events that came through:\t", events)
+            PtDebugPrint("grsnTrnCtrDoors: Events that came through:\t", events)
 ###############################################################
     def SendNote(self, ExtraInfo):
         #Thanks Derek
@@ -293,11 +293,11 @@ class grsnTrnCtrDoors(ptResponder):
     def UpdateRespStack (self):
         #Updates the Responder List
         old = self.grsnDoorStack.pop(0)
-        print("grsnTrnCtrDoors: Getting rid of Resp: %s" % (old))
+        PtDebugPrint("grsnTrnCtrDoors: Getting rid of Resp: %s" % (old))
         if len(self.grsnDoorStack):            
-            print("grsnTrnCtrDoors: There's at lest one more Resp to play.")
+            PtDebugPrint("grsnTrnCtrDoors: There's at lest one more Resp to play.")
             code = self.grsnDoorStack[0]            
-            print("Playing command: %s" % (code))
+            PtDebugPrint("Playing command: %s" % (code))
             self.ExecCode(code)
 
     def UpdateDoorState (self, StateNum):
@@ -310,5 +310,5 @@ class grsnTrnCtrDoors(ptResponder):
         elif code == "doorCloseResponder":
             doorCloseResponder.run(self.key,netPropagate=0)
         else:
-            print("grsnTrnCtrDoors.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("grsnTrnCtrDoors.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.grsnDoorStack.pop(0)

--- a/Python/grsnWallImagerDisplayN.py
+++ b/Python/grsnWallImagerDisplayN.py
@@ -99,22 +99,22 @@ class grsnWallImagerDisplayN(ptResponder):
         if PtGetPlayerList():
             ReceiveInit = True
         else:
-            print"solo in climbing wall"
+            PtDebugPrint("solo in climbing wall")
             
         
     def OnClimbingWallInit(self,type,state,value):
         global ReceiveInit
         
-        print"grsnClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value
+        PtDebugPrint("grsnClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value)
         if not ReceiveInit:
-            print"failed to receive init"
+            PtDebugPrint("failed to receive init")
             return
         if (type == ptClimbingWallMsgType.kEndGameState):
             ReceiveInit = False
-            print "finished receiving total game state"
+            PtDebugPrint("finished receiving total game state")
         
         if (type == ptClimbingWallMsgType.kTotalGameState):
-            print "begin receiving total game state"
+            PtDebugPrint("begin receiving total game state")
         
         elif (type == ptClimbingWallMsgType.kAddBlocker and state > 0 and value):
             northWall.value[state].runAttachedResponder(kTeamLightsOn)
@@ -123,11 +123,11 @@ class grsnWallImagerDisplayN(ptResponder):
         
         if (type == ptClimbingWallMsgType.kAddBlocker and value):            #display wall settings
             northWall.value[state].runAttachedResponder(kTeamLightsOn)
-            print"Imager display N drawing n wall index",state
+            PtDebugPrint("Imager display N drawing n wall index",state)
                     
         elif (type == ptClimbingWallMsgType.kRemoveBlocker and value):
             northWall.value[state].runAttachedResponder(kTeamLightsOff)
-            print"Imager display N clearing n wall index",state
+            PtDebugPrint("Imager display N clearing n wall index",state)
         
         elif (type == ptClimbingWallMsgType.kNewState):
             if (state == ptClimbingWallMsgState.kSouthSit or state == ptClimbingWallMsgState.kNorthSit ):

--- a/Python/grsnWallImagerDisplayS.py
+++ b/Python/grsnWallImagerDisplayS.py
@@ -100,22 +100,22 @@ class grsnWallImagerDisplayS(ptResponder):
         if PtGetPlayerList():
             ReceiveInit = True
         else:
-            print"solo in climbing wall"
+            PtDebugPrint("solo in climbing wall")
             
         
     def OnClimbingWallInit(self,type,state,value):
         global ReceiveInit
         
-        print"grsnClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value
+        PtDebugPrint("grsnClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value)
         if not ReceiveInit:
-            print"failed to receive init"
+            PtDebugPrint("failed to receive init")
             return
         if (type == ptClimbingWallMsgType.kEndGameState):
             ReceiveInit = False
-            print "finished receiving total game state"
+            PtDebugPrint("finished receiving total game state")
         
         if (type == ptClimbingWallMsgType.kTotalGameState):
-            print "begin receiving total game state"
+            PtDebugPrint("begin receiving total game state")
         
         elif (type == ptClimbingWallMsgType.kAddBlocker and state > 0 and value == 0):
             southWall.value[state].runAttachedResponder(kTeamLightsOn)
@@ -124,11 +124,11 @@ class grsnWallImagerDisplayS(ptResponder):
         
         if (type == ptClimbingWallMsgType.kAddBlocker and not value):            #display wall settings
             southWall.value[state].runAttachedResponder(kTeamLightsOn)
-            print"Imager display S drawing wall index",state
+            PtDebugPrint("Imager display S drawing wall index",state)
                     
         elif (type == ptClimbingWallMsgType.kRemoveBlocker and not value):
             southWall.value[state].runAttachedResponder(kTeamLightsOff)
-            print"Imager display S clearing wall index",state
+            PtDebugPrint("Imager display S clearing wall index",state)
         
         elif (type == ptClimbingWallMsgType.kNewState):
             if (state == ptClimbingWallMsgState.kSouthSit or state == ptClimbingWallMsgState.kNorthSit ):

--- a/Python/grsnWallPython.py
+++ b/Python/grsnWallPython.py
@@ -205,23 +205,23 @@ class grsnWallPython(ptResponder):
         global BlockerCountLimit
         
         i = 0
-        print"looking north ",north
+        PtDebugPrint("looking north ",north)
         if (north):
             while (i < BlockerCountLimit):
                 if (NorthWall[i] == index):
-                    print"index found in north list in slot ",i
+                    PtDebugPrint("index found in north list in slot ",i)
                     return True
-                print "north wall [",i,"] = ",NorthWall[i]
+                PtDebugPrint("north wall [",i,"] = ",NorthWall[i])
                 i = i + 1
         else:
             while (i < BlockerCountLimit):
                 if (SouthWall[i] == index):
-                    print"index found in south list in slot ",i
+                    PtDebugPrint("index found in south list in slot ",i)
                     return True
-                print "south wall [",i,"] = ",SouthWall[i]
+                PtDebugPrint("south wall [",i,"] = ",SouthWall[i])
                 i = i + 1
         
-        print"index not found"
+        PtDebugPrint("index not found")
         return False
         
     def SetWallIndex(self,index,value,north):
@@ -236,39 +236,39 @@ class grsnWallPython(ptResponder):
                 while (NorthWall[i] >= 0):
                     i = i + 1
                     if (i == 20):
-                        print"yikes - somehow overran the array!"
+                        PtDebugPrint("yikes - somehow overran the array!")
                         return
                 NorthWall[i] = index
                 NorthCount = NorthCount + 1
-                print"set north wall index ",index," in slot ",i," to true"
+                PtDebugPrint("set north wall index ",index," in slot ",i," to true")
             else:
                 while (SouthWall[i] >= 0):
                     i = i + 1
                     if (i == 20):
-                        print"yikes - somehow overran the array!"
+                        PtDebugPrint("yikes - somehow overran the array!")
                         return
                 SouthWall[i] = index
                 SouthCount = SouthCount + 1
-                print"set south wall index ",index," in slot ",i," to true"
+                PtDebugPrint("set south wall index ",index," in slot ",i," to true")
         else:
             if (north):
                 while (NorthWall[i] != index):
                     i = i + 1
                     if (i == 20):
-                        print"this should not get hit - looked for non-existent NorthWall entry!"
+                        PtDebugPrint("this should not get hit - looked for non-existent NorthWall entry!")
                         return
                 NorthWall[i] = -1
                 NorthCount = NorthCount - 1
-                print"removed index ",index," from list slot ",i
+                PtDebugPrint("removed index ",index," from list slot ",i)
             else:
                 while (SouthWall[i] != index):
                     i = i + 1
                     if (i == 20):
-                        print"this should not get hit - looked for non-existent SouthWall entry!"
+                        PtDebugPrint("this should not get hit - looked for non-existent SouthWall entry!")
                         return
                 SouthWall[i] = -1
                 SouthCount = SouthCount - 1
-                print"removed index ",index," from list slot ",i
+                PtDebugPrint("removed index ",index," from list slot ",i)
     
     def ClearIndices(self,north):
         global NorthWall
@@ -354,7 +354,7 @@ class grsnWallPython(ptResponder):
                 goBtnSObject.value.runAttachedResponder(kBright)
                 nTubeOpen.run(self.key,avatar=PtGetLocalAvatar())
                 goBtnNObject.value.runAttachedResponder(kBright)
-                print"tubes open"
+                PtDebugPrint("tubes open")
             
 
     def SetNPanelMode(self,state):
@@ -366,7 +366,7 @@ class grsnWallPython(ptResponder):
         global NorthWall
         global SouthWall
         
-        print"set N Panel Mode called with state ",state
+        PtDebugPrint("set N Panel Mode called with state ",state)
         if (state == ptClimbingWallMsgState.kWaiting):
             #turn everything off
             self.ResetNorthPanel(False)
@@ -383,7 +383,7 @@ class grsnWallPython(ptResponder):
             i = 0
             while i<20:
                 northCountLights.value[i].runAttachedResponder(kRedFlash)
-                print"run red flash ",i
+                PtDebugPrint("run red flash ",i)
                 i = i + 1
             #enable up / down buttons
             upButtonN.enable()
@@ -393,7 +393,7 @@ class grsnWallPython(ptResponder):
             tenBtnN.enable()
             fifteenBtnN.enable()
             goBtnNObject.value.runAttachedResponder(kDim)
-            print"enabled all n switches"
+            PtDebugPrint("enabled all n switches")
         elif (state == ptClimbingWallMsgState.kNorthReady):
             # turn unselected count lights solid, and turn off the other lights
             i = 0
@@ -421,7 +421,7 @@ class grsnWallPython(ptResponder):
                 goBtnSObject.value.runAttachedResponder(kBright)
                 nTubeOpen.run(self.key,avatar=PtGetLocalAvatar())
                 goBtnNObject.value.runAttachedResponder(kBright)
-                print"tubes open"
+                PtDebugPrint("tubes open")
 
     def IAmMaster(self):
         return (self.sceneobject.isLocallyOwned())
@@ -429,13 +429,13 @@ class grsnWallPython(ptResponder):
 
     def ChangeGameState(self,newState):
         
-        print"sending change game state message with state ",newState
+        PtDebugPrint("sending change game state message with state ",newState)
         msg = ptClimbingWallMsg(self.key)
         msg.init(ptClimbingWallMsgType.kNewState, newState, 0)
         msg.send()
         
     def ChangeBlockerCount(self, newCount):
-        print"sending change blocker count message with new count ",newCount
+        PtDebugPrint("sending change blocker count message with new count ",newCount)
         msg = ptClimbingWallMsg(self.key)
         msg.init(ptClimbingWallMsgType.kSetBlockerNum, 1, newCount)
         msg.send()
@@ -463,13 +463,13 @@ class grsnWallPython(ptResponder):
         global SouthWall
         
         
-        print"grsnClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value
+        PtDebugPrint("grsnClimbingWall::OnClimbingWallInit type ",type," state ",state," value ",value)
         if not ReceiveInit:
-            print"failed to receive init"
+            PtDebugPrint("failed to receive init")
             return
         if (type == ptClimbingWallMsgType.kEndGameState):
             ReceiveInit = False
-            print "finished receiving total game state"
+            PtDebugPrint("finished receiving total game state")
             # update lights display 
             i = 0
             while i < BlockerCountLimit:
@@ -501,7 +501,7 @@ class grsnWallPython(ptResponder):
         if (type == ptClimbingWallMsgType.kTotalGameState):
             SouthState = state
             NorthState = value
-            print "begin receiving total game state"
+            PtDebugPrint("begin receiving total game state")
         
         elif (type == ptClimbingWallMsgType.kAddBlocker and state > 0):
             self.SetWallIndex(state,True,value)
@@ -525,7 +525,7 @@ class grsnWallPython(ptResponder):
         if (ReceiveInit):
             return
         
-        print"grsnClimbingWall::OnClimbingWallMsg type ",type," state ",state," value ",value
+        PtDebugPrint("grsnClimbingWall::OnClimbingWallMsg type ",type," state ",state," value ",value)
         if (type == ptClimbingWallMsgType.kNewState):
             if (value == 1):
                 NorthState = state
@@ -580,13 +580,13 @@ class grsnWallPython(ptResponder):
                 i = i + 1
             sTubeClose.run(self.key,fastforward=True,netForce=0)
             nTubeClose.run(self.key,fastforward=True,netForce=0)
-            print"requesting game state message from master client"
+            PtDebugPrint("requesting game state message from master client")
             msg = ptClimbingWallMsg(self.key)
             msg.init(ptClimbingWallMsgType.kRequestGameState,0,0)
             msg.send()
             return
         else:
-            print"solo in climbing wall"
+            PtDebugPrint("solo in climbing wall")
             
         ageSDL = PtGetAgeSDL()
         # these need to send immediate
@@ -674,7 +674,7 @@ class grsnWallPython(ptResponder):
         global BlockerCountLimit
         
         # we clicked or un-clicked on a control panel button corresponding to a wall blocker
-        print"found South index ",index
+        PtDebugPrint("found South index ",index)
         wallPicked = southWall.value[index]
         animPicked = southLights.value[index]
         if (self.LookupIndex(index,False)):
@@ -696,7 +696,7 @@ class grsnWallPython(ptResponder):
         global BlockerCountLimit
         
         # we clicked or un-clicked on a control panel button corresponding to a wall blocker
-        print"found North index ",index
+        PtDebugPrint("found North index ",index)
         wallPicked = northWall.value[index]
         animPicked = northLights.value[index]
         if (self.LookupIndex(index,True)):
@@ -777,7 +777,7 @@ class grsnWallPython(ptResponder):
             
             if (enable == 0):
                 southWall.value[i].physics.suppress(True)
-                #print"disabled south wall ",i
+                #PtDebugPrint("disabled south wall ",i)
             i = i + 1
         
         self.ZeroBlockerCount()
@@ -798,11 +798,11 @@ class grsnWallPython(ptResponder):
                 northCountLights.value[i].runAttachedResponder(kTeamLightsOff)
             if (enable):
             #    ageSDL.setIndex("northWall",i,1)
-                print"enabled north wall - this should not happen  "
+                PtDebugPrint("enabled north wall - this should not happen  ")
             else:
                 #ageSDL.setIndex("northWall",i,0)
                 northWall.value[i].physics.suppress(True)
-                #print"disabled north wall ",i
+                #PtDebugPrint("disabled north wall ",i)
             i = i + 1
         self.ZeroBlockerCount()
         NorthCount = 0
@@ -832,21 +832,21 @@ class grsnWallPython(ptResponder):
         global NorthWall
         global SouthWall
         
-        #print "grsnWall - Notify ",state,id,events
+        #PtDebugPrint("grsnWall - Notify ",state,id,events)
         ageSDL = PtGetAgeSDL()
         avatar = PtFindAvatar(events)
 
         southState = SouthState
         northState = NorthState
-        print"southState = ",southState
-        print"northState = ",northState
+        PtDebugPrint("southState = ",southState)
+        PtDebugPrint("northState = ",northState)
             
         # responder / behavior notifications
         
         if (id == sQuitBehavior.id):
             for event in events:
                 if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
-                    print"start touching quit jewel, warp out"
+                    PtDebugPrint("start touching quit jewel, warp out")
                     if (avatar == PtGetLocalAvatar()):
                         PtAtTimeCallback(self.key ,0.8 ,kSouthQuit)
                     return
@@ -854,38 +854,38 @@ class grsnWallPython(ptResponder):
         if (id == nQuitBehavior.id):
             for event in events:
                 if (event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage):
-                    print"start touching quit jewel, warp out"
+                    PtDebugPrint("start touching quit jewel, warp out")
                     if (avatar == PtGetLocalAvatar()):
                         PtAtTimeCallback(self.key ,0.8 ,kNorthQuit)
                     return
                     
         if (id == nTubeOpen.id):
-            print"tube finished opening"
+            PtDebugPrint("tube finished opening")
             nTubeExclude.release(self.key)
         
         if (id == nTubeMulti.id):
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage: 
-                    print"Smart seek completed. close tube"
+                    PtDebugPrint("Smart seek completed. close tube")
                     nTubeClose.run(self.key,avatar=avatar)
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
-                    print"multistage complete, warp to wall south room with suit"
+                    PtDebugPrint("multistage complete, warp to wall south room with suit")
                     if (avatar == PtGetLocalAvatar()):
                         PtWearMaintainerSuit(PtGetLocalAvatar().getKey(),True)
                         PtSendKIMessage(kDisableEntireYeeshaBook,0)
                     avatar.physics.warpObj(sTeamWarpPt.value.getKey())
                     
         if (id == sTubeOpen.id):
-            print"tube finished opening"
+            PtDebugPrint("tube finished opening")
             sTubeExclude.release(self.key)
         
         if (id == sTubeMulti.id):
             for event in events:
                 if event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kEnterStage: 
-                    print"Smart seek completed. close tube"
+                    PtDebugPrint("Smart seek completed. close tube")
                     sTubeClose.run(self.key,avatar=avatar)
                 elif event[0] == kMultiStageEvent and event[1] == 0 and event[2] == kAdvanceNextStage:
-                    print"multistage complete, warp to wall north room with suit"
+                    PtDebugPrint("multistage complete, warp to wall north room with suit")
                     if (avatar == PtGetLocalAvatar()):
                         PtWearMaintainerSuit(PtGetLocalAvatar().getKey(),True)
                         PtSendKIMessage(kDisableEntireYeeshaBook,0)
@@ -895,7 +895,7 @@ class grsnWallPython(ptResponder):
         
         # activator notifications
         if (id == sTeamWin.id and state):
-            print"you win"
+            PtDebugPrint("you win")
             PtFakeLinkAvatarToObject(avatar.getKey(),sTeamWinTeleport.value.getKey())
             #avatar.physics.warpObj(sTeamWinTeleport.value.getKey())
             self.ChangeGameState(ptClimbingWallMsgState.kSouthWin)
@@ -904,7 +904,7 @@ class grsnWallPython(ptResponder):
             #ageSDL.setIndex("nChairState",0,kNorthQuit)
             
         if (id == nTeamWin.id and state):
-            print"you win"
+            PtDebugPrint("you win")
             PtFakeLinkAvatarToObject(avatar.getKey(),nTeamWinTeleport.value.getKey())
             #avatar.physics.warpObj(nTeamWinTeleport.value.getKey())
             self.ChangeGameState(ptClimbingWallMsgState.kNorthWin)
@@ -929,13 +929,13 @@ class grsnWallPython(ptResponder):
             return
             
         if (id == southChair.id):
-            print"clicked south chair"
+            PtDebugPrint("clicked south chair")
             avID = PtGetClientIDFromAvatarKey(avatar.getKey())
             if state:
                 occupant = ageSDL["sChairOccupant"][0]
-                print"occupant ",occupant
+                PtDebugPrint("occupant ",occupant)
                 if (1):
-                    print"sitting down in south chair"
+                    PtDebugPrint("sitting down in south chair")
                     southChair.disable()
                     ageSDL.setIndex("sChairOccupant",0,avID)
                     if (southState == ptClimbingWallMsgState.kWaiting or southState == ptClimbingWallMsgState.kSouthWin or southState == ptClimbingWallMsgState.kSouthQuit):
@@ -949,20 +949,20 @@ class grsnWallPython(ptResponder):
             for event in events:
                 if event[0]==6 and event[1]==1 and state == 0:
                     if (1):
-                        print"standing up from south chair"
+                        PtDebugPrint("standing up from south chair")
                         southChair.enable()
                         ageSDL.setIndex("sChairOccupant",0,-1)
                             
                     return            
                             
         if (id == northChair.id):
-            print"clicked north chair"
+            PtDebugPrint("clicked north chair")
             avID = PtGetClientIDFromAvatarKey(avatar.getKey())
             if state:
                 occupant = ageSDL["nChairOccupant"][0]
-                print"occupant ",occupant
+                PtDebugPrint("occupant ",occupant)
                 if (1):
-                    print"sitting down in south chair"
+                    PtDebugPrint("sitting down in south chair")
                     northChair.disable()
                     ageSDL.setIndex("nChairOccupant",0,avID)
                     if (northState == ptClimbingWallMsgState.kWaiting or northState == ptClimbingWallMsgState.kNorthWin or northState == ptClimbingWallMsgState.kNorthQuit):
@@ -975,7 +975,7 @@ class grsnWallPython(ptResponder):
             for event in events:
                 if event[0]==6 and event[1]==1 and state == 0:
                     if (1):
-                        print"standing up from north chair"
+                        PtDebugPrint("standing up from north chair")
                         northChair.enable()
                         ageSDL.setIndex("nChairOccupant",0,-1)
                             
@@ -985,33 +985,33 @@ class grsnWallPython(ptResponder):
         elif not state:
             return
         if (avatar != PtGetLocalAvatar()):
-            print"not activated by me"
+            PtDebugPrint("not activated by me")
             return
         
         if (id == nTubeEntry.id):
             trigger = PtFindAvatar(events)
-            print"entered team 1 tube, run behavior"
+            PtDebugPrint("entered team 1 tube, run behavior")
             ageSDL.setIndex("nWallPlayer",0,PtGetClientIDFromAvatarKey(trigger.getKey()))
             trigger.avatar.runBehaviorSetNotify(nTubeMulti.value,self.key,0)
         
         if (id == sTubeEntry.id):
             trigger = PtFindAvatar(events)
-            print"entered team 2 tube, run behavior"
+            PtDebugPrint("entered team 2 tube, run behavior")
             ageSDL.setIndex("sWallPlayer",0,PtGetClientIDFromAvatarKey(trigger.getKey()))
             trigger.avatar.runBehaviorSetNotify(sTubeMulti.value,self.key,0)
         
         if id == upButtonS.id:
-            print "up button south"
+            PtDebugPrint("up button south")
             if (southState == ptClimbingWallMsgState.kSouthSelect):
-                print"correct state, blocker count limit ",BlockerCountLimit
+                PtDebugPrint("correct state, blocker count limit ",BlockerCountLimit)
                 if (BlockerCountLimit < 20):
                     self.ChangeBlockerCount(BlockerCountLimit + 1)                    
                     sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='up')
                 else:
-                    print"somehow think blocker count limit greater than 20?"
+                    PtDebugPrint("somehow think blocker count limit greater than 20?")
             return
         elif id == dnButtonS.id:
-            print "down button south"
+            PtDebugPrint("down button south")
             if (southState == ptClimbingWallMsgState.kSouthSelect):
                 if (BlockerCountLimit > 0):
                     self.ChangeBlockerCount(BlockerCountLimit - 1)
@@ -1019,26 +1019,26 @@ class grsnWallPython(ptResponder):
                     
             return
         elif id == fiveBtnS.id:
-            print"five button south"
+            PtDebugPrint("five button south")
             if (southState == ptClimbingWallMsgState.kSouthSelect):
                 self.ChangeBlockerCount(5)
                 sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='up')
             return
         elif id == tenBtnS.id:
-            print"ten button south"
+            PtDebugPrint("ten button south")
             if (southState == ptClimbingWallMsgState.kSouthSelect):
                 self.ChangeBlockerCount(10)
                 sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='up')
             return
         elif id == fifteenBtnS.id:
-            print"fifteen button south"
+            PtDebugPrint("fifteen button south")
             if (southState == ptClimbingWallMsgState.kSouthSelect):
                 self.ChangeBlockerCount(15)
                 sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='up')
             return
             
         elif id == readyButtonS.id:
-            print "ready button south"
+            PtDebugPrint("ready button south")
             if (southState == ptClimbingWallMsgState.kSouthSelect):
                 self.ChangeGameState(ptClimbingWallMsgState.kSouthReady)
                 sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='select')
@@ -1049,18 +1049,18 @@ class grsnWallPython(ptResponder):
              
             return
         elif id == goButtonS.id:
-            print"picked s go button"
+            PtDebugPrint("picked s go button")
             if (southState == ptClimbingWallMsgState.kSouthSit):
-                print"set index to kSouthSelect"
+                PtDebugPrint("set index to kSouthSelect")
                 self.ClearIndices(False)
                 self.ChangeGameState(ptClimbingWallMsgState.kSouthSelect)
                 sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='main')
                 if (northState == ptClimbingWallMsgState.kWaiting or northState == ptClimbingWallMsgState.kNorthSit or \
                     northState == ptClimbingWallMsgState.kNorthWin or northState == ptClimbingWallMsgState.kNorthQuit ):
-                    print"force north chair to keep up"
+                    PtDebugPrint("force north chair to keep up")
                     self.ChangeGameState(ptClimbingWallMsgState.kNorthSelect)
             elif(southState == ptClimbingWallMsgState.kSouthReady):
-                print"check to see if you've used all your wall blockers"
+                PtDebugPrint("check to see if you've used all your wall blockers")
                 #numSelected = ageSDL["southCount"][0]
                 #maxSelections = ageSDL["southCountLimit"][0]
                 numSelected = SouthCount
@@ -1074,7 +1074,7 @@ class grsnWallPython(ptResponder):
             return
         
         if id == upButtonN.id:
-            print "up button north"
+            PtDebugPrint("up button north")
             if (northState == ptClimbingWallMsgState.kNorthSelect):
                 #numSelected = ageSDL["northCountLimit"][0]
                 numSelected = BlockerCountLimit
@@ -1088,7 +1088,7 @@ class grsnWallPython(ptResponder):
                     
             return
         elif id == dnButtonN.id:
-            print "down button north"
+            PtDebugPrint("down button north")
             if (northState == ptClimbingWallMsgState.kNorthSelect):
                 #numSelected = ageSDL["northCountLimit"][0]
                 numSelected = BlockerCountLimit
@@ -1102,7 +1102,7 @@ class grsnWallPython(ptResponder):
                     
             return
         elif id == fiveBtnN.id:
-            print"five button north"
+            PtDebugPrint("five button north")
             if (northState == ptClimbingWallMsgState.kNorthSelect):
                 self.ChangeBlockerCount(5)
                 #ageSDL.setIndex("northCountLimit",0,5)
@@ -1111,7 +1111,7 @@ class grsnWallPython(ptResponder):
                 #    ageSDL.setIndex("southCountLimit",0,5)
             return
         elif id == tenBtnN.id:
-            print"ten button north"
+            PtDebugPrint("ten button north")
             if (northState == ptClimbingWallMsgState.kNorthSelect):
                 self.ChangeBlockerCount(10)
                 #ageSDL.setIndex("northCountLimit",0,10)
@@ -1120,7 +1120,7 @@ class grsnWallPython(ptResponder):
                 #    ageSDL.setIndex("southCountLimit",0,10)
             return
         elif id == fifteenBtnN.id:
-            print"fifteen button north"
+            PtDebugPrint("fifteen button north")
             if (northState == ptClimbingWallMsgState.kNorthSelect):
                 self.ChangeBlockerCount(15)
                 #ageSDL.setIndex("northCountLimit",0,15)
@@ -1130,7 +1130,7 @@ class grsnWallPython(ptResponder):
             return
             
         elif id == readyButtonN.id:
-            print "ready button north"
+            PtDebugPrint("ready button north")
             if (northState == ptClimbingWallMsgState.kNorthSelect):
                 self.ChangeGameState(ptClimbingWallMsgState.kNorthReady)
                 #ageSDL.setIndex("nChairState",0,kNorthReady)
@@ -1138,14 +1138,14 @@ class grsnWallPython(ptResponder):
                 if (southState == ptClimbingWallMsgState.kSouthSelect):
                     self.ChangeGameState(ptClimbingWallMsgState.kSouthReady)
                     #ageSDL.setIndex("sChairState",0,kSouthReady)
-                    print"force south chair to keep up"
+                    PtDebugPrint("force south chair to keep up")
             else:
                 nPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='denied')
             return
         elif id == goButtonN.id:
-            print"picked n go button"
+            PtDebugPrint("picked n go button")
             if (northState == ptClimbingWallMsgState.kNorthSit):
-                print"set index to kNorthSelect"
+                PtDebugPrint("set index to kNorthSelect")
                 self.ChangeGameState(ptClimbingWallMsgState.kNorthSelect)
                 self.ClearIndices(True)
                 #ageSDL.setIndex("nChairState",0,kNorthSelect)
@@ -1154,9 +1154,9 @@ class grsnWallPython(ptResponder):
                     southState == ptClimbingWallMsgState.kSouthWin or southState == ptClimbingWallMsgState.kSouthWin):
                     self.ChangeGameState(ptClimbingWallMsgState.kSouthSelect)
                     #ageSDL.setIndex("sChairState",0,kSouthSelect)
-                    print"force south chair to keep up"
+                    PtDebugPrint("force south chair to keep up")
             elif(northState == ptClimbingWallMsgState.kNorthReady):
-                print"check to see if you've used all your wall blockers"
+                PtDebugPrint("check to see if you've used all your wall blockers")
                 #numSelected = ageSDL["northCount"][0]
                 #maxSelections = ageSDL["northCountLimit"][0]
                 numSelected = NorthCount
@@ -1173,7 +1173,7 @@ class grsnWallPython(ptResponder):
             if event[0]==kPickedEvent and event[1] == 1:
                 panelPicked = event[3]
                 objName = panelPicked.getName()
-                print "player picked blocker named ", objName
+                PtDebugPrint("player picked blocker named ", objName)
                 north = 0
                 try:
                     index = northPanel.value.index(panelPicked)
@@ -1182,23 +1182,23 @@ class grsnWallPython(ptResponder):
                     try:
                         index = southPanel.value.index(panelPicked)
                     except:
-                        print"no wall blocker found"
+                        PtDebugPrint("no wall blocker found")
                         return;
                 if (north): #you picked something on the north panel
                     if (northState != ptClimbingWallMsgState.kNorthReady):
-                        print"no blocker picking for you!"
+                        PtDebugPrint("no blocker picking for you!")
                         nPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='denied')
                         return
                     #numSelected = ageSDL["northCount"][0]
                     numSelected = NorthCount
                     #ageSDL.setIndex("lastChangedIndexN",0,index)
-                    print"numSelected = ",numSelected
+                    PtDebugPrint("numSelected = ",numSelected)
                     #maxSelections = ageSDL["northCountLimit"][0]
                     maxSelections = BlockerCountLimit
                     #if (ageSDL["northWall"][index]==0):
                     if (self.LookupIndex(index,True) == 0):
                         if (numSelected == maxSelections):
-                            print"you've picked all you can"
+                            PtDebugPrint("you've picked all you can")
                             nPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='denied')
                             return
                         #numSelected = numSelected + 1
@@ -1209,7 +1209,7 @@ class grsnWallPython(ptResponder):
                     else:
                         numSelected = numSelected - 1
                         if (numSelected == -1):
-                            print"what?!?"
+                            PtDebugPrint("what?!?")
                             return
                         #ageSDL.setIndex("northCount",0,numSelected)
                         #NorthCount = numSelected
@@ -1217,19 +1217,19 @@ class grsnWallPython(ptResponder):
                         self.ChangeBlockerState(False,index,True)
                 else: #you picked one on the south panel
                     if (southState != ptClimbingWallMsgState.kSouthReady):
-                        print"no blocker picking for you!"
+                        PtDebugPrint("no blocker picking for you!")
                         sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='denied')
                         return
                     #numSelected = ageSDL["southCount"][0]
                     numSelected = SouthCount
                     #ageSDL.setIndex("lastChangedIndexS",0,index)
-                    print"numSelected = ",numSelected
+                    PtDebugPrint("numSelected = ",numSelected)
                     #maxSelections = ageSDL["southCountLimit"][0]
                     maxSelections = BlockerCountLimit
                     #if (ageSDL["southWall"][index]==0):
                     if (self.LookupIndex(index,False) == 0):
                         if (numSelected == maxSelections):
-                            print"you've picked all you can"
+                            PtDebugPrint("you've picked all you can")
                             sPanelSound.run(self.key,avatar=PtGetLocalAvatar(),state='denied')
                             return
                         #numSelected = numSelected + 1
@@ -1240,7 +1240,7 @@ class grsnWallPython(ptResponder):
                     else:
                         numSelected = numSelected - 1
                         if (numSelected == -1):
-                            print"what?!?"
+                            PtDebugPrint("what?!?")
                             return
                         #ageSDL.setIndex("southCount",0,numSelected)
                         #SouthCount = numSelected

--- a/Python/grtzAccessDoors.py
+++ b/Python/grtzAccessDoors.py
@@ -84,25 +84,25 @@ class grtzAccessDoors(ptResponder):
             self.SDL['DoorOpen'] = (0,)
             self.grtzDoorState = self.SDL['DoorOpen'][0]
          
-        print "grtzAccessDoors: self.SDL = %d" % self.grtzDoorState
-        print "grtzAccessDoors: Player List = %d" % len(PtGetPlayerList())
+        print("grtzAccessDoors: self.SDL = %d" % self.grtzDoorState)
+        print("grtzAccessDoors: Player List = %d" % len(PtGetPlayerList()))
 
         if len(PtGetPlayerList()) > 0:
             
-            print "grtzAccessDoors: Somebody is already in the age. Attempting to sync states."
+            print("grtzAccessDoors: Somebody is already in the age. Attempting to sync states.")
 
             if self.grtzDoorState == doorSDLstates['open'] or self.grtzDoorState == doorSDLstates['opening']:
                  doorResponder.run(self.key,state='OpenTheDoor',fastforward=1,netPropagate=0)
-                 print "grtzAccessDoors: Door is open."
-                 print "grtzAccessDoors: Door State = %d" % self.grtzDoorState
+                 print("grtzAccessDoors: Door is open.")
+                 print("grtzAccessDoors: Door State = %d" % self.grtzDoorState)
             
             elif self.grtzDoorState == doorSDLstates['closing']:
                 doorResponder.run(self.key,state='CloseTheDoor',fastforward=1,netPropagate=0)
-                print "grtzAccessDoors: Door is closed."
-                print "grtzAccessDoors: Door State = %d" % self.grtzDoorState
+                print("grtzAccessDoors: Door is closed.")
+                print("grtzAccessDoors: Door State = %d" % self.grtzDoorState)
 
             else:
-                print "grtzAccessDoors: Exception. Door State = %d" % self.grtzDoorState
+                print("grtzAccessDoors: Exception. Door State = %d" % self.grtzDoorState)
 
             if self.grtzDoorState == doorSDLstates['opening'] or self.grtzDoorState == doorSDLstates['movingopen'] or self.grtzDoorState == doorSDLstates['opentoclose']:
                 doorResponder.run(self.key,state='OpenTheDoor',netPropagate=0)
@@ -127,7 +127,7 @@ class grtzAccessDoors(ptResponder):
             # the door is really shut, someone left it open
             self.SDL['DoorOpen'] = (doorSDLstates['closed'],)
             self.grtzDoorState = self.SDL['DoorOpen'][0]
-            print "grtzAccessDoors: Nobody is here, setting door states to closed."
+            print("grtzAccessDoors: Nobody is here, setting door states to closed.")
             
         self.init = 1
     ##########################################
@@ -138,32 +138,32 @@ class grtzAccessDoors(ptResponder):
         ageSDL = PtGetAgeSDL()
         #Notify Section
         if id == (-1):            
-            print "grtzAccessDoors: Recieved Notify... Contents Are %s" % str(events[0][1])
+            print("grtzAccessDoors: Recieved Notify... Contents Are %s" % str(events[0][1]))
             if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
                 if self.grtzDoorState == doorSDLstates['closed']:            
                     self.UpdateDoorState(doorSDLstates['opening'])
-                    print "grtzAccessDoors: I triggered the region and I'm changing the sdl to opening."
+                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to opening.")
 
                 elif self.grtzDoorState == doorSDLstates['movingclosed'] or self.grtzDoorState == doorSDLstates['closing'] or self.grtzDoorState == doorSDLstates['closedfail']:
                     self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    print "grtzAccessDoors: I triggered the region and I'm changing the sdl to closetoopen."
+                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to closetoopen.")
 
                 elif self.grtzDoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['movingopen'])
-                    print "grtzAccessDoors: I triggered the region and I'm changing the sdl to movingopen."
+                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to movingopen.")
 
             elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():            
                 if self.grtzDoorState == doorSDLstates['open']:
                     self.UpdateDoorState(doorSDLstates['closing'])
-                    print "grtzAccessDoors: I triggered the region and I'm changing the sdl to closing."
+                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to closing.")
 
                 elif self.grtzDoorState == doorSDLstates['movingopen'] or self.grtzDoorState == doorSDLstates['opening']:
                     self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    print "grtzAccessDoors: I triggered the region and I'm changing the sdl to opentoclose."
+                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to opentoclose.")
 
                 elif self.grtzDoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    print "grtzAccessDoors: I triggered the region and I'm changing the sdl to movingclosed."
+                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to movingclosed.")
 
             elif events[0][1].find('rgnTriggerFail') != -1 and self.sceneobject.isLocallyOwned():
                 if self.grtzDoorState == doorSDLstates['closed']:
@@ -173,24 +173,24 @@ class grtzAccessDoors(ptResponder):
             
             elif events[0][1].find('Responder') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1:
                 self.grtzDoorStack.append(events[0][1])
-                print "grtzAccessDoors: New list is: %s" % (str(self.grtzDoorStack))
+                print("grtzAccessDoors: New list is: %s" % (str(self.grtzDoorStack)))
                 
                 if len(self.grtzDoorStack) == 1:
-                    print "grtzAccessDoors: List is only one command long, so I'm playing it"
+                    print("grtzAccessDoors: List is only one command long, so I'm playing it")
                     code = self.grtzDoorStack[0]
-                    print "grtzAccessDoors: Playing command: %s" % (code)
+                    print("grtzAccessDoors: Playing command: %s" % (code))
                     self.ExecCode(code)
 
             ############################################################################################################
             elif events[0][1].find('DoorState') != 1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1 and events[0][1].find('rgnTriggerFail') == -1:
                 
                 curState = int(events[0][1].lstrip('DoorState='))
-                print "grtzAccessDoors: Door State Updated to %d" % curState
-                print "grtzAccessDoors: Door State SDL Set to %d" % self.SDL['DoorOpen'][0]
+                print("grtzAccessDoors: Door State Updated to %d" % curState)
+                print("grtzAccessDoors: Door State SDL Set to %d" % self.SDL['DoorOpen'][0])
 
                 if curState != self.grtzDoorState:
                     self.grtzDoorState = curState
-                    print "grtzAccessDoors: Door state is now %d" % self.grtzDoorState
+                    print("grtzAccessDoors: Door state is now %d" % self.grtzDoorState)
                 return
 
                 
@@ -215,10 +215,10 @@ class grtzAccessDoors(ptResponder):
                             self.SendNote("rgnTriggerEnter")
                             return
 
-                        print "grtzAccessDoors: I triggered the region"
+                        print("grtzAccessDoors: I triggered the region")
                         
                         if PtDetermineKIMarkerLevel() < kKIMarkerNormalLevel:                     
-                            print "grtzAccessDoors: KiLevel too low, cannot open door"
+                            print("grtzAccessDoors: KiLevel too low, cannot open door")
                             self.SendNote("rgnTriggerFail")
                             return
                         else:                        
@@ -252,7 +252,7 @@ class grtzAccessDoors(ptResponder):
                     self.UpdateDoorState(doorSDLstates['closed'])
                     
         else:
-            print "grtzAccessDoors: Events that came through:\t", events
+            print("grtzAccessDoors: Events that came through:\t", events)
 ###############################################################
     def SendNote(self, ExtraInfo):
         notify = ptNotify(self.key)
@@ -268,11 +268,11 @@ class grtzAccessDoors(ptResponder):
     def UpdateRespStack (self):
         #Updates the Responder List
         old = self.grtzDoorStack.pop(0)
-        print "grtzAccessDoors: Getting rid of Resp: %s" % (old)
+        print("grtzAccessDoors: Getting rid of Resp: %s" % (old))
         if len(self.grtzDoorStack):            
-            print "grtzAccessDoors: There's at lest one more Resp to play."
+            print("grtzAccessDoors: There's at lest one more Resp to play.")
             code = self.grtzDoorStack[0]            
-            print "Playing command: %s" % (code)
+            print("Playing command: %s" % (code))
             self.ExecCode(code)
 
     def UpdateDoorState (self, StateNum):
@@ -283,15 +283,15 @@ class grtzAccessDoors(ptResponder):
 
             if self.grtzDoorState == doorSDLstates['opening']:
                 self.SendNote("doorResponderOpen")
-                print "grtzAccessDoors: Notifying Clients to play Open Door Responder"
+                print("grtzAccessDoors: Notifying Clients to play Open Door Responder")
 
             elif self.grtzDoorState == doorSDLstates['closing']:
                 self.SendNote("doorResponderClose")
-                print "grtzAccessDoors: Notifying Clients to play Close Door Responder"
+                print("grtzAccessDoors: Notifying Clients to play Close Door Responder")
 
             elif self.grtzDoorState == doorSDLstates['closedfail']:                                        
                 self.SendNote("doorResponderNoAccess")
-                print "grtzAccessDoors: Notifying Clients to play Failed Door Responder"
+                print("grtzAccessDoors: Notifying Clients to play Failed Door Responder")
 
     def ExecCode(self, code):
         if code == "doorResponderOpen":
@@ -301,5 +301,5 @@ class grtzAccessDoors(ptResponder):
         elif code == "doorResponderNoAccess":
             doorResponder.run(self.key,state='NoAccess',netPropagate=0)
         else:
-            print "grtzAccessDoors.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("grtzAccessDoors.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.grtzDoorStack.pop(0)

--- a/Python/grtzAccessDoors.py
+++ b/Python/grtzAccessDoors.py
@@ -84,25 +84,25 @@ class grtzAccessDoors(ptResponder):
             self.SDL['DoorOpen'] = (0,)
             self.grtzDoorState = self.SDL['DoorOpen'][0]
          
-        print("grtzAccessDoors: self.SDL = %d" % self.grtzDoorState)
-        print("grtzAccessDoors: Player List = %d" % len(PtGetPlayerList()))
+        PtDebugPrint("grtzAccessDoors: self.SDL = %d" % self.grtzDoorState)
+        PtDebugPrint("grtzAccessDoors: Player List = %d" % len(PtGetPlayerList()))
 
         if len(PtGetPlayerList()) > 0:
             
-            print("grtzAccessDoors: Somebody is already in the age. Attempting to sync states.")
+            PtDebugPrint("grtzAccessDoors: Somebody is already in the age. Attempting to sync states.")
 
             if self.grtzDoorState == doorSDLstates['open'] or self.grtzDoorState == doorSDLstates['opening']:
                  doorResponder.run(self.key,state='OpenTheDoor',fastforward=1,netPropagate=0)
-                 print("grtzAccessDoors: Door is open.")
-                 print("grtzAccessDoors: Door State = %d" % self.grtzDoorState)
+                 PtDebugPrint("grtzAccessDoors: Door is open.")
+                 PtDebugPrint("grtzAccessDoors: Door State = %d" % self.grtzDoorState)
             
             elif self.grtzDoorState == doorSDLstates['closing']:
                 doorResponder.run(self.key,state='CloseTheDoor',fastforward=1,netPropagate=0)
-                print("grtzAccessDoors: Door is closed.")
-                print("grtzAccessDoors: Door State = %d" % self.grtzDoorState)
+                PtDebugPrint("grtzAccessDoors: Door is closed.")
+                PtDebugPrint("grtzAccessDoors: Door State = %d" % self.grtzDoorState)
 
             else:
-                print("grtzAccessDoors: Exception. Door State = %d" % self.grtzDoorState)
+                PtDebugPrint("grtzAccessDoors: Exception. Door State = %d" % self.grtzDoorState)
 
             if self.grtzDoorState == doorSDLstates['opening'] or self.grtzDoorState == doorSDLstates['movingopen'] or self.grtzDoorState == doorSDLstates['opentoclose']:
                 doorResponder.run(self.key,state='OpenTheDoor',netPropagate=0)
@@ -127,7 +127,7 @@ class grtzAccessDoors(ptResponder):
             # the door is really shut, someone left it open
             self.SDL['DoorOpen'] = (doorSDLstates['closed'],)
             self.grtzDoorState = self.SDL['DoorOpen'][0]
-            print("grtzAccessDoors: Nobody is here, setting door states to closed.")
+            PtDebugPrint("grtzAccessDoors: Nobody is here, setting door states to closed.")
             
         self.init = 1
     ##########################################
@@ -138,32 +138,32 @@ class grtzAccessDoors(ptResponder):
         ageSDL = PtGetAgeSDL()
         #Notify Section
         if id == (-1):            
-            print("grtzAccessDoors: Recieved Notify... Contents Are %s" % str(events[0][1]))
+            PtDebugPrint("grtzAccessDoors: Recieved Notify... Contents Are %s" % str(events[0][1]))
             if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
                 if self.grtzDoorState == doorSDLstates['closed']:            
                     self.UpdateDoorState(doorSDLstates['opening'])
-                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to opening.")
+                    PtDebugPrint("grtzAccessDoors: I triggered the region and I'm changing the sdl to opening.")
 
                 elif self.grtzDoorState == doorSDLstates['movingclosed'] or self.grtzDoorState == doorSDLstates['closing'] or self.grtzDoorState == doorSDLstates['closedfail']:
                     self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to closetoopen.")
+                    PtDebugPrint("grtzAccessDoors: I triggered the region and I'm changing the sdl to closetoopen.")
 
                 elif self.grtzDoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['movingopen'])
-                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to movingopen.")
+                    PtDebugPrint("grtzAccessDoors: I triggered the region and I'm changing the sdl to movingopen.")
 
             elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():            
                 if self.grtzDoorState == doorSDLstates['open']:
                     self.UpdateDoorState(doorSDLstates['closing'])
-                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to closing.")
+                    PtDebugPrint("grtzAccessDoors: I triggered the region and I'm changing the sdl to closing.")
 
                 elif self.grtzDoorState == doorSDLstates['movingopen'] or self.grtzDoorState == doorSDLstates['opening']:
                     self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to opentoclose.")
+                    PtDebugPrint("grtzAccessDoors: I triggered the region and I'm changing the sdl to opentoclose.")
 
                 elif self.grtzDoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    print("grtzAccessDoors: I triggered the region and I'm changing the sdl to movingclosed.")
+                    PtDebugPrint("grtzAccessDoors: I triggered the region and I'm changing the sdl to movingclosed.")
 
             elif events[0][1].find('rgnTriggerFail') != -1 and self.sceneobject.isLocallyOwned():
                 if self.grtzDoorState == doorSDLstates['closed']:
@@ -173,24 +173,24 @@ class grtzAccessDoors(ptResponder):
             
             elif events[0][1].find('Responder') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1:
                 self.grtzDoorStack.append(events[0][1])
-                print("grtzAccessDoors: New list is: %s" % (str(self.grtzDoorStack)))
+                PtDebugPrint("grtzAccessDoors: New list is: %s" % (str(self.grtzDoorStack)))
                 
                 if len(self.grtzDoorStack) == 1:
-                    print("grtzAccessDoors: List is only one command long, so I'm playing it")
+                    PtDebugPrint("grtzAccessDoors: List is only one command long, so I'm playing it")
                     code = self.grtzDoorStack[0]
-                    print("grtzAccessDoors: Playing command: %s" % (code))
+                    PtDebugPrint("grtzAccessDoors: Playing command: %s" % (code))
                     self.ExecCode(code)
 
             ############################################################################################################
             elif events[0][1].find('DoorState') != 1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1 and events[0][1].find('rgnTriggerFail') == -1:
                 
                 curState = int(events[0][1].lstrip('DoorState='))
-                print("grtzAccessDoors: Door State Updated to %d" % curState)
-                print("grtzAccessDoors: Door State SDL Set to %d" % self.SDL['DoorOpen'][0])
+                PtDebugPrint("grtzAccessDoors: Door State Updated to %d" % curState)
+                PtDebugPrint("grtzAccessDoors: Door State SDL Set to %d" % self.SDL['DoorOpen'][0])
 
                 if curState != self.grtzDoorState:
                     self.grtzDoorState = curState
-                    print("grtzAccessDoors: Door state is now %d" % self.grtzDoorState)
+                    PtDebugPrint("grtzAccessDoors: Door state is now %d" % self.grtzDoorState)
                 return
 
                 
@@ -215,10 +215,10 @@ class grtzAccessDoors(ptResponder):
                             self.SendNote("rgnTriggerEnter")
                             return
 
-                        print("grtzAccessDoors: I triggered the region")
+                        PtDebugPrint("grtzAccessDoors: I triggered the region")
                         
                         if PtDetermineKIMarkerLevel() < kKIMarkerNormalLevel:                     
-                            print("grtzAccessDoors: KiLevel too low, cannot open door")
+                            PtDebugPrint("grtzAccessDoors: KiLevel too low, cannot open door")
                             self.SendNote("rgnTriggerFail")
                             return
                         else:                        
@@ -252,7 +252,7 @@ class grtzAccessDoors(ptResponder):
                     self.UpdateDoorState(doorSDLstates['closed'])
                     
         else:
-            print("grtzAccessDoors: Events that came through:\t", events)
+            PtDebugPrint("grtzAccessDoors: Events that came through:\t", events)
 ###############################################################
     def SendNote(self, ExtraInfo):
         notify = ptNotify(self.key)
@@ -268,11 +268,11 @@ class grtzAccessDoors(ptResponder):
     def UpdateRespStack (self):
         #Updates the Responder List
         old = self.grtzDoorStack.pop(0)
-        print("grtzAccessDoors: Getting rid of Resp: %s" % (old))
+        PtDebugPrint("grtzAccessDoors: Getting rid of Resp: %s" % (old))
         if len(self.grtzDoorStack):            
-            print("grtzAccessDoors: There's at lest one more Resp to play.")
+            PtDebugPrint("grtzAccessDoors: There's at lest one more Resp to play.")
             code = self.grtzDoorStack[0]            
-            print("Playing command: %s" % (code))
+            PtDebugPrint("Playing command: %s" % (code))
             self.ExecCode(code)
 
     def UpdateDoorState (self, StateNum):
@@ -283,15 +283,15 @@ class grtzAccessDoors(ptResponder):
 
             if self.grtzDoorState == doorSDLstates['opening']:
                 self.SendNote("doorResponderOpen")
-                print("grtzAccessDoors: Notifying Clients to play Open Door Responder")
+                PtDebugPrint("grtzAccessDoors: Notifying Clients to play Open Door Responder")
 
             elif self.grtzDoorState == doorSDLstates['closing']:
                 self.SendNote("doorResponderClose")
-                print("grtzAccessDoors: Notifying Clients to play Close Door Responder")
+                PtDebugPrint("grtzAccessDoors: Notifying Clients to play Close Door Responder")
 
             elif self.grtzDoorState == doorSDLstates['closedfail']:                                        
                 self.SendNote("doorResponderNoAccess")
-                print("grtzAccessDoors: Notifying Clients to play Failed Door Responder")
+                PtDebugPrint("grtzAccessDoors: Notifying Clients to play Failed Door Responder")
 
     def ExecCode(self, code):
         if code == "doorResponderOpen":
@@ -301,5 +301,5 @@ class grtzAccessDoors(ptResponder):
         elif code == "doorResponderNoAccess":
             doorResponder.run(self.key,state='NoAccess',netPropagate=0)
         else:
-            print("grtzAccessDoors.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("grtzAccessDoors.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.grtzDoorStack.pop(0)

--- a/Python/grtzGZMaster.py
+++ b/Python/grtzGZMaster.py
@@ -129,7 +129,7 @@ class grtzGZMaster(ptResponder):
   
         if id == respGZActive.id:
             pass
-            #print "grtzGZMaster:OnNotify(): got callback from resp"
+            #PtDebugPrint("grtzGZMaster:OnNotify(): got callback from resp")
             #PtEnableMovementKeys()
             #PtSendKIMessage(kEnableKIandBB,0)
 

--- a/Python/grtzKIMarkerMachine.py
+++ b/Python/grtzKIMarkerMachine.py
@@ -202,7 +202,7 @@ class grtzKIMarkerMachine(ptModifier):
                 markerKILevel = PtDetermineKIMarkerLevel()
 
                 if markerKILevel > kKIMarkerFirstLevel:
-                    print "Making Sure Nexus Link Exists."
+                    print("Making Sure Nexus Link Exists.")
                     self.IUpdateNexusLink()
 
                 #Don't try and get the game if we've got a normal KI marker level (i.e. finished with first two marker games)
@@ -490,14 +490,14 @@ class grtzKIMarkerMachine(ptModifier):
                     name = SpawnPoint.getName().lower()
                     #print "Title: %s\nName: %s" % (title,name)
                     if title == "great zero" and name == "bigroomlinkinpoint":
-                        print "grtzKIMarkerMachine: Nexus link already exists."
+                        print("grtzKIMarkerMachine: Nexus link already exists.")
                         return
                 #self.IDoCityLinksChron("BigRoomLinkInPoint")   # this will be used if we want to add this to the city book
                 outerRoomSP = ptSpawnPointInfo("Great Zero","BigRoomLinkInPoint")
                 #print "NewSpawnPointInfo\nName: %s\nTitle: %s" % (outerRoomSP.getName(), outerRoomSP.getTitle())
                 link.addSpawnPoint(outerRoomSP)
                 link.save()
-                print "grtzKIMarkerMachine: Nexus link added."
+                print("grtzKIMarkerMachine: Nexus link added.")
                 PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NexusLinkAdded"))
                 PtDebugPrint("grtzKIMarkerMachine - setting new spawn point for GZ",level=kDebugDumpLevel)
                 return
@@ -527,25 +527,25 @@ class grtzKIMarkerMachine(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print "valCityLinks = ",valCityLinks
+            print("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print "CityLinks = ",CityLinks
+            print("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
                 entryCityLinks.chronicleSetValue(NewLinks)
                 entryCityLinks.save()
-                print "grtzKIMarkerMachine.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel
+                print("grtzKIMarkerMachine.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
                 valCityLinks = entryCityLinks.chronicleGetValue()
                 CityLinks = valCityLinks.split(",")
-                print "grtzKIMarkerMachine.IDoCityLinksChron():  citylinks now = ",CityLinks
+                print("grtzKIMarkerMachine.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
-                print "grtzKIMarkerMachine.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel
+                print("grtzKIMarkerMachine.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
         else:
             vault.addChronicleEntry("CityBookLinks",0,agePanel)
-            print "grtzKIMarkerMachine.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel
+            print("grtzKIMarkerMachine.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
         
         psnlSDL = xPsnlVaultSDL()
         GotBook = psnlSDL["psnlGotCityBook"][0]
         if not GotBook:
             psnlSDL["psnlGotCityBook"] = (1,)
-            print "grtzKIMarkerMachine.IDoCityLinksChron():  setting SDL for city book to 1"
+            print("grtzKIMarkerMachine.IDoCityLinksChron():  setting SDL for city book to 1")

--- a/Python/grtzKIMarkerMachine.py
+++ b/Python/grtzKIMarkerMachine.py
@@ -202,7 +202,7 @@ class grtzKIMarkerMachine(ptModifier):
                 markerKILevel = PtDetermineKIMarkerLevel()
 
                 if markerKILevel > kKIMarkerFirstLevel:
-                    print("Making Sure Nexus Link Exists.")
+                    PtDebugPrint("Making Sure Nexus Link Exists.")
                     self.IUpdateNexusLink()
 
                 #Don't try and get the game if we've got a normal KI marker level (i.e. finished with first two marker games)
@@ -488,16 +488,16 @@ class grtzKIMarkerMachine(ptModifier):
                 for SpawnPoint in GZSpawnPoints:
                     title = SpawnPoint.getTitle().lower()
                     name = SpawnPoint.getName().lower()
-                    #print "Title: %s\nName: %s" % (title,name)
+                    #PtDebugPrint("Title: %s\nName: %s" % (title,name))
                     if title == "great zero" and name == "bigroomlinkinpoint":
-                        print("grtzKIMarkerMachine: Nexus link already exists.")
+                        PtDebugPrint("grtzKIMarkerMachine: Nexus link already exists.")
                         return
                 #self.IDoCityLinksChron("BigRoomLinkInPoint")   # this will be used if we want to add this to the city book
                 outerRoomSP = ptSpawnPointInfo("Great Zero","BigRoomLinkInPoint")
-                #print "NewSpawnPointInfo\nName: %s\nTitle: %s" % (outerRoomSP.getName(), outerRoomSP.getTitle())
+                #PtDebugPrint("NewSpawnPointInfo\nName: %s\nTitle: %s" % (outerRoomSP.getName(), outerRoomSP.getTitle()))
                 link.addSpawnPoint(outerRoomSP)
                 link.save()
-                print("grtzKIMarkerMachine: Nexus link added.")
+                PtDebugPrint("grtzKIMarkerMachine: Nexus link added.")
                 PtSendKIMessage(kKILocalChatStatusMsg,PtGetLocalizedString("KI.Messages.NexusLinkAdded"))
                 PtDebugPrint("grtzKIMarkerMachine - setting new spawn point for GZ",level=kDebugDumpLevel)
                 return
@@ -527,25 +527,25 @@ class grtzKIMarkerMachine(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print("valCityLinks = ",valCityLinks)
+            PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print("CityLinks = ",CityLinks)
+            PtDebugPrint("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
                 entryCityLinks.chronicleSetValue(NewLinks)
                 entryCityLinks.save()
-                print("grtzKIMarkerMachine.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
+                PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
                 valCityLinks = entryCityLinks.chronicleGetValue()
                 CityLinks = valCityLinks.split(",")
-                print("grtzKIMarkerMachine.IDoCityLinksChron():  citylinks now = ",CityLinks)
+                PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
-                print("grtzKIMarkerMachine.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
+                PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
         else:
             vault.addChronicleEntry("CityBookLinks",0,agePanel)
-            print("grtzKIMarkerMachine.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
+            PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
         
         psnlSDL = xPsnlVaultSDL()
         GotBook = psnlSDL["psnlGotCityBook"][0]
         if not GotBook:
             psnlSDL["psnlGotCityBook"] = (1,)
-            print("grtzKIMarkerMachine.IDoCityLinksChron():  setting SDL for city book to 1")
+            PtDebugPrint("grtzKIMarkerMachine.IDoCityLinksChron():  setting SDL for city book to 1")

--- a/Python/islmEmgrPhase0.py
+++ b/Python/islmEmgrPhase0.py
@@ -108,7 +108,7 @@ class islmEmgrPhase0(ptResponder):
         
         version = 2
         self.version = version
-        print("__init__islmEmgrPhase0 v.", version)
+        PtDebugPrint("__init__islmEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -119,7 +119,7 @@ class islmEmgrPhase0(ptResponder):
             ageSDL = PtGetAgeSDL()
             
             for variable in BooleanVARs:
-                print("tying together", variable)
+                PtDebugPrint("tying together", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
                 
@@ -137,7 +137,7 @@ class islmEmgrPhase0(ptResponder):
             PtDebugPrint("islmEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
             
             if VARname in BooleanVARs:
-                print("islmEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
+                PtDebugPrint("islmEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
                 self.IManageBOOLs(VARname,SDLname)
                 
             elif VARname in StateVARs.viewkeys():
@@ -159,7 +159,7 @@ class islmEmgrPhase0(ptResponder):
                 PtDebugPrint("islmEmgrPhase0.OnSDLNotify:\tPaging in room ", VARname)
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print("variable = ", VARname)
+                PtDebugPrint("variable = ", VARname)
                 PtDebugPrint("islmEmgrPhase0.OnSDLNotify:\tPaging out room ", VARname)
                 PtPageOutNode(VARname)
             else:

--- a/Python/islmEmgrPhase0.py
+++ b/Python/islmEmgrPhase0.py
@@ -108,7 +108,7 @@ class islmEmgrPhase0(ptResponder):
         
         version = 2
         self.version = version
-        print "__init__islmEmgrPhase0 v.", version
+        print("__init__islmEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -119,7 +119,7 @@ class islmEmgrPhase0(ptResponder):
             ageSDL = PtGetAgeSDL()
             
             for variable in BooleanVARs:
-                print "tying together", variable
+                print("tying together", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
                 
@@ -137,7 +137,7 @@ class islmEmgrPhase0(ptResponder):
             PtDebugPrint("islmEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
             
             if VARname in BooleanVARs:
-                print "islmEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname)
+                print("islmEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
                 self.IManageBOOLs(VARname,SDLname)
                 
             elif VARname in StateVARs.viewkeys():
@@ -159,7 +159,7 @@ class islmEmgrPhase0(ptResponder):
                 PtDebugPrint("islmEmgrPhase0.OnSDLNotify:\tPaging in room ", VARname)
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print "variable = ", VARname
+                print("variable = ", VARname)
                 PtDebugPrint("islmEmgrPhase0.OnSDLNotify:\tPaging out room ", VARname)
                 PtPageOutNode(VARname)
             else:

--- a/Python/islmGZBeamBrain.py
+++ b/Python/islmGZBeamBrain.py
@@ -71,7 +71,7 @@ class islmGZBeamBrain(ptResponder):
 
         version = 2
         self.version = version
-        print "__init__islmGZBeamBrain v.", version,".3"
+        print("__init__islmGZBeamBrain v.", version,".3")
 
 
     def OnServerInitComplete(self):
@@ -84,25 +84,25 @@ class islmGZBeamBrain(ptResponder):
             ageSDL.setNotify(self.key,"islmGZBeamVis",0.0)
             boolGZBeamVis = ageSDL["islmGZBeamVis"][0]
         except:
-            print "islmGZBeamBrain.OnServerInitComplete:  ERROR!  Can't find the boolGZBeamVis sdl, doing nothing."
+            print("islmGZBeamBrain.OnServerInitComplete:  ERROR!  Can't find the boolGZBeamVis sdl, doing nothing.")
             return
 
         if boolGZBeamVis:
-            print "islmGZBeamBrain.OnServerInitComplete: The Great Zero beam IS active."
+            print("islmGZBeamBrain.OnServerInitComplete: The Great Zero beam IS active.")
             self.TurnBeamOn()
         else:
-            print "islmGZBeamBrain.OnServerInitComplete: The Great Zero beam is NOT active."
+            print("islmGZBeamBrain.OnServerInitComplete: The Great Zero beam is NOT active.")
             self.TurnBeamOff()
 
     
     def TurnBeamOn(self):
-        print "islmGZBeamBrain.RotateBeam: Trying to turn the beam ON."
+        print("islmGZBeamBrain.RotateBeam: Trying to turn the beam ON.")
         Beamlight.sceneobject.draw.enable()
         respRotateBeam.run(self.key)
 
 
     def TurnBeamOff(self):
-        print "islmGZBeamBrain.RotateBeam: Trying to turn the beam OFF."
+        print("islmGZBeamBrain.RotateBeam: Trying to turn the beam OFF.")
         Beamlight.sceneobject.draw.disable()
         #~ respRotateBeam.animation.stop()
 
@@ -123,7 +123,7 @@ class islmGZBeamBrain(ptResponder):
             
                     
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
-        print "islmGZBeamBrain.OnSDLNotify(): VARname = ", VARname
+        print("islmGZBeamBrain.OnSDLNotify(): VARname = ", VARname)
         global boolGZBeamVis
 
         if VARname == "islmGZBeamVis":

--- a/Python/islmGZBeamBrain.py
+++ b/Python/islmGZBeamBrain.py
@@ -71,7 +71,7 @@ class islmGZBeamBrain(ptResponder):
 
         version = 2
         self.version = version
-        print("__init__islmGZBeamBrain v.", version,".3")
+        PtDebugPrint("__init__islmGZBeamBrain v.", version,".3")
 
 
     def OnServerInitComplete(self):
@@ -84,25 +84,25 @@ class islmGZBeamBrain(ptResponder):
             ageSDL.setNotify(self.key,"islmGZBeamVis",0.0)
             boolGZBeamVis = ageSDL["islmGZBeamVis"][0]
         except:
-            print("islmGZBeamBrain.OnServerInitComplete:  ERROR!  Can't find the boolGZBeamVis sdl, doing nothing.")
+            PtDebugPrint("islmGZBeamBrain.OnServerInitComplete:  ERROR!  Can't find the boolGZBeamVis sdl, doing nothing.")
             return
 
         if boolGZBeamVis:
-            print("islmGZBeamBrain.OnServerInitComplete: The Great Zero beam IS active.")
+            PtDebugPrint("islmGZBeamBrain.OnServerInitComplete: The Great Zero beam IS active.")
             self.TurnBeamOn()
         else:
-            print("islmGZBeamBrain.OnServerInitComplete: The Great Zero beam is NOT active.")
+            PtDebugPrint("islmGZBeamBrain.OnServerInitComplete: The Great Zero beam is NOT active.")
             self.TurnBeamOff()
 
     
     def TurnBeamOn(self):
-        print("islmGZBeamBrain.RotateBeam: Trying to turn the beam ON.")
+        PtDebugPrint("islmGZBeamBrain.RotateBeam: Trying to turn the beam ON.")
         Beamlight.sceneobject.draw.enable()
         respRotateBeam.run(self.key)
 
 
     def TurnBeamOff(self):
-        print("islmGZBeamBrain.RotateBeam: Trying to turn the beam OFF.")
+        PtDebugPrint("islmGZBeamBrain.RotateBeam: Trying to turn the beam OFF.")
         Beamlight.sceneobject.draw.disable()
         #~ respRotateBeam.animation.stop()
 
@@ -113,17 +113,17 @@ class islmGZBeamBrain(ptResponder):
         
 #        if id == actBeamAlign.id:
 #            shellseen = shellseen + 1
-#            #print "islmGZBeamBrain: The Shell has been seen", shellseen," times."
+#            #PtDebugPrint("islmGZBeamBrain: The Shell has been seen", shellseen," times.")
 #            respShowShell.run(self.key)
 #        
 #        elif id == actShellJump.id:
-#            print "islmGZBeamBrain: The avatar has jumped into the Shell. Stopping the fall."
+#            PtDebugPrint("islmGZBeamBrain: The avatar has jumped into the Shell. Stopping the fall.")
 #            avatar = PtGetLocalAvatar()
 #            avatar.physics.suppress(1)
             
                     
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
-        print("islmGZBeamBrain.OnSDLNotify(): VARname = ", VARname)
+        PtDebugPrint("islmGZBeamBrain.OnSDLNotify(): VARname = ", VARname)
         global boolGZBeamVis
 
         if VARname == "islmGZBeamVis":

--- a/Python/islmMemorialImager.py
+++ b/Python/islmMemorialImager.py
@@ -98,7 +98,7 @@ class islmMemorialImager(ptModifier):
         Instance = self
         self.id = 5105
         self.version = 1
-        print "islmMemorialImager: init  version=%d.%d"%(self.version,3)
+        print("islmMemorialImager: init  version=%d.%d"%(self.version,3))
     ############################
     def OnServerInitComplete(self):
         
@@ -347,7 +347,7 @@ class islmMemorialImager(ptModifier):
             i = i - 1
             
             if not len(testmessage):
-                print "islmMemorialImager: Message Length = 0"
+                print("islmMemorialImager: Message Length = 0")
                 kMessage = ""
                 return
             testmessage = testmessage[0:len(testmessage) - 1]

--- a/Python/islmMemorialImager.py
+++ b/Python/islmMemorialImager.py
@@ -98,7 +98,7 @@ class islmMemorialImager(ptModifier):
         Instance = self
         self.id = 5105
         self.version = 1
-        print("islmMemorialImager: init  version=%d.%d"%(self.version,3))
+        PtDebugPrint("islmMemorialImager: init  version=%d.%d"%(self.version,3))
     ############################
     def OnServerInitComplete(self):
         
@@ -131,7 +131,7 @@ class islmMemorialImager(ptModifier):
         kIncAmount = IncAmount.value
 
         kFontColor = FontColor.value.split(",")
-        #print "islmMemorialImager: Font Color: R:%s,G:%s,B:%s,A:%s" % (float(kFontColor[0]),float(kFontColor[1]),float(kFontColor[2]),float(kFontColor[3]))
+        #PtDebugPrint("islmMemorialImager: Font Color: R:%s,G:%s,B:%s,A:%s" % (float(kFontColor[0]),float(kFontColor[1]),float(kFontColor[2]),float(kFontColor[3])))
         kFontColor = ptColor(red=float(kFontColor[0]),green=float(kFontColor[1]),blue=float(kFontColor[2]),alpha=float(kFontColor[3]))
         self.UpdateMarqueeMessage()
         kLastUpdate = PtGetDniTime()
@@ -155,7 +155,7 @@ class islmMemorialImager(ptModifier):
     ############################
     def UpdateMarquee(self, ImagerMap, x):
         imagertext = CurrentMessage[x]
-        #print "islmMemorialImager: kTextXPos:%s \t kTextYStart:%s \n imagertext:%s" % (str(kTextXPos[x]),str(kTextYStart),str(imagertext)) 
+        #PtDebugPrint("islmMemorialImager: kTextXPos:%s \t kTextYStart:%s \n imagertext:%s" % (str(kTextXPos[x]),str(kTextYStart),str(imagertext)))
         ImagerMap.textmap.clearToColor(ptColor(0,0,0,0))
         ImagerMap.textmap.drawText(kTextXPos[x],kTextYStart,imagertext)
         ImagerMap.textmap.flush()
@@ -168,14 +168,14 @@ class islmMemorialImager(ptModifier):
         global kNextChar
         global kFirstChar
         global kLastUpdate
-        #print "islmMemorialImager: PtGetDniTime: " + str(PtGetDniTime()) + "kLastUpdate: " + str(kLastUpdate) 
+        #PtDebugPrint("islmMemorialImager: PtGetDniTime: " + str(PtGetDniTime()) + "kLastUpdate: " + str(kLastUpdate))
         movedSince = int(((long(PtGetDniTime()) - long(kLastUpdate)) / kUpdateTime) * kIncAmount)
-        #print "islmMemorialImager: Distance to move:" , movedSince
+        #PtDebugPrint("islmMemorialImager: Distance to move:" , movedSince)
         kLastUpdate = PtGetDniTime()
         for x in range(4):
-            #print "islmMemorialImager: Imager%d \n kcursorstart:%d \t kcursorend:%d" % (x,kCursorStart[x],kCursorEnd[x])
+            #PtDebugPrint("islmMemorialImager: Imager%d \n kcursorstart:%d \t kcursorend:%d" % (x,kCursorStart[x],kCursorEnd[x]))
             self.UpdateMarqueeOffset(x,movedSince)
-            #print "islmMemorialImager: kTextXPos[%d]: %d" % (x, kTextXPos[x])
+            #PtDebugPrint("islmMemorialImager: kTextXPos[%d]: %d" % (x, kTextXPos[x]))
             self.UpdateStartCursor(x,imgMessage)
             self.UpdateEndCursor(x,imgMessage)
             
@@ -210,7 +210,7 @@ class islmMemorialImager(ptModifier):
             (kTextWidth[x],z) = ImagerMap1.textmap.calcTextExtents(CurrentMessage[x])
             if (((kTextXPos[x] - kTextXStart) + kTextWidth[x]) + kNextChar[x]) > ImagerMap1.textmap.getWidth(): break
             
-            #print "islmMemorialImager: Value of offset plus the nextChar width", ((kTextXPos[x] - kTextXStart[x]) + kTextWidth[x])
+            #PtDebugPrint("islmMemorialImager: Value of offset plus the nextChar width", ((kTextXPos[x] - kTextXStart[x]) + kTextWidth[x]))
             if kCursorEnd[x] > len(imgMessage) - 1:
                 kCursorEnd[x] = 0
             else:
@@ -236,7 +236,7 @@ class islmMemorialImager(ptModifier):
             kNewChar = 1
         else:
             kTextXPos[x] = kTextXPos[x] - movedSince
-        #print "islmMemorialImager: Updating Offset to:",kTextXPos[x]
+        #PtDebugPrint("islmMemorialImager: Updating Offset to:",kTextXPos[x])
     ############################
     def UpdateMarqueeMessage(self):
         global kMessage
@@ -263,7 +263,7 @@ class islmMemorialImager(ptModifier):
                                 if textNode.getText() == "":
                                     if kMessage == "":
                                         self.setTimerCallback(30)
-                                    #print "islmMemorialImager: No message was found."
+                                    #PtDebugPrint("islmMemorialImager: No message was found.")
                                 
                                 elif kMessage != textNode.getText():
                                     oldmessage = kMessage
@@ -279,14 +279,14 @@ class islmMemorialImager(ptModifier):
                                 PtDebugPrint("islmMemorialImager: Marquee contents are '%s'" % (kMessage),level=kDebugDumpLevel)
                                 return
         self.setTimerCallback(30)
-        #print "islmMemorialImager: Message Node not found."
+        #PtDebugPrint("islmMemorialImager: Message Node not found.")
         
-        #print "islmMemorialImager: Message Updated"
-        #print "islmMemorialImager: Message Length:", len(kMessage)
+        #PtDebugPrint("islmMemorialImager: Message Updated")
+        #PtDebugPrint("islmMemorialImager: Message Length:", len(kMessage))
     ############################
     
     #def SetMemorialSDL(self):
-    #    #print "islmMemorialImager: Updating SDL with the new time value."
+    #    #PtDebugPrint("islmMemorialImager: Updating SDL with the new time value.")
     #    ageSDL = PtGetAgeSDL()
     #    ageSDL["MemorialImagerStartTime"] = (PtGetDniTime(),)
     
@@ -297,14 +297,14 @@ class islmMemorialImager(ptModifier):
 #        if kMessage == "":
 #            self.UpdateMarqueeMessage()
 #            return
-#        #print "islmMemorialImager: Synching my imager to the age owners."
+#        #PtDebugPrint("islmMemorialImager: Synching my imager to the age owners.")
 #        ageSDL = PtGetAgeSDL()
 #        updatetime = long(PtGetDniTime()) - long(ageSDL["MemorialImagerStartTime"][0])
 #        movedsince = int((updatetime / kUpdateTime) * kIncAmount)
-#        #print "islmMemorialImager: UpdateTime: " + str(updatetime) + " \t MovedSince: " + str(movedsince)
+#        #PtDebugPrint("islmMemorialImager: UpdateTime: " + str(updatetime) + " \t MovedSince: " + str(movedsince))
 #        textWidth = 0
 #        cursor = len(kMessage)
-#        #print "islmMemorialImager: Cursor: ", cursor
+#        #PtDebugPrint("islmMemorialImager: Cursor: ", cursor)
 #        for i in range(len(kMessage)):
 #            (textWidth,z) = ImagerMap1.textmap.calcTextExtents(kMessage[0:cursor])
 #            if textWidth < movedsince: break
@@ -347,7 +347,7 @@ class islmMemorialImager(ptModifier):
             i = i - 1
             
             if not len(testmessage):
-                print("islmMemorialImager: Message Length = 0")
+                PtDebugPrint("islmMemorialImager: Message Length = 0")
                 kMessage = ""
                 return
             testmessage = testmessage[0:len(testmessage) - 1]

--- a/Python/islmPassable.py
+++ b/Python/islmPassable.py
@@ -64,10 +64,10 @@ class islmPassable(ptResponder):
 
     def OnServerInitComplete(self):
         if PtDetermineKIMarkerLevel() >= kKIMarkerFirstLevel:
-            print "islmPassable: The Player has started the GZ marker game."
-            print "islmPassable: Disabling baracades at the bottom of the Great Stair."
+            print("islmPassable: The Player has started the GZ marker game.")
+            print("islmPassable: Disabling baracades at the bottom of the Great Stair.")
             respBoolTrue.run(self.key,fastforward=1)
         else:
-            print "islmPassable: The player has NOT started the GZ marker game."
-            print "islmPassable: Enabling baracades at the bottom of the Great Stair."
+            print("islmPassable: The player has NOT started the GZ marker game.")
+            print("islmPassable: Enabling baracades at the bottom of the Great Stair.")
             respBoolFalse.run(self.key,fastforward=1)

--- a/Python/islmPassable.py
+++ b/Python/islmPassable.py
@@ -64,10 +64,10 @@ class islmPassable(ptResponder):
 
     def OnServerInitComplete(self):
         if PtDetermineKIMarkerLevel() >= kKIMarkerFirstLevel:
-            print("islmPassable: The Player has started the GZ marker game.")
-            print("islmPassable: Disabling baracades at the bottom of the Great Stair.")
+            PtDebugPrint("islmPassable: The Player has started the GZ marker game.")
+            PtDebugPrint("islmPassable: Disabling baracades at the bottom of the Great Stair.")
             respBoolTrue.run(self.key,fastforward=1)
         else:
-            print("islmPassable: The player has NOT started the GZ marker game.")
-            print("islmPassable: Enabling baracades at the bottom of the Great Stair.")
+            PtDebugPrint("islmPassable: The player has NOT started the GZ marker game.")
+            PtDebugPrint("islmPassable: Enabling baracades at the bottom of the Great Stair.")
             respBoolFalse.run(self.key,fastforward=1)

--- a/Python/islmPodMap.py
+++ b/Python/islmPodMap.py
@@ -75,7 +75,7 @@ class islmPodMap(ptResponder):
         ptResponder.__init__(self)
         self.id = 221
         self.version = 1
-        print "islmPodMap: init  version = %d" % self.version
+        print("islmPodMap: init  version = %d" % self.version)
 
     ###########################
     def IGetAgeFilename(self):
@@ -136,7 +136,7 @@ class islmPodMap(ptResponder):
             PtSendKIMessage(kDisableKIandBB,0)
             respZoom.run(self.key, state="out", netForce=0, netPropagate=0)
             PtShowDialog(Vignette.value)
-            print "dialog: %s goes up" % Vignette.value
+            print("dialog: %s goes up" % Vignette.value)
         # get control key events
         PtGetControlEvents(True,self.key)
 
@@ -148,9 +148,9 @@ class islmPodMap(ptResponder):
         if Vignette.value:
             PtSendKIMessage(kEnableKIandBB,0)
             PtHideDialog(Vignette.value)
-            print "Dialog: %s goes down" % Vignette.value
+            print("Dialog: %s goes down" % Vignette.value)
         else:
-            print "WTH!!!"
+            print("WTH!!!")
         #disable the Control key events
         PtGetControlEvents(False,self.key)
 

--- a/Python/islmPodMap.py
+++ b/Python/islmPodMap.py
@@ -75,7 +75,7 @@ class islmPodMap(ptResponder):
         ptResponder.__init__(self)
         self.id = 221
         self.version = 1
-        print("islmPodMap: init  version = %d" % self.version)
+        PtDebugPrint("islmPodMap: init  version = %d" % self.version)
 
     ###########################
     def IGetAgeFilename(self):
@@ -107,7 +107,7 @@ class islmPodMap(ptResponder):
     def OnGUINotify(self,id,control,event):
         "Notifications from the vignette"
         global gToggle
-        #print "GUI Notify id=%d, event=%d control=" % (id,event),control
+        #PtDebugPrint("GUI Notify id=%d, event=%d control=" % (id,event),control)
         if event == kAction:
             if control.getTagID() == kExit: #off
                 self.IQuitDialog()
@@ -136,7 +136,7 @@ class islmPodMap(ptResponder):
             PtSendKIMessage(kDisableKIandBB,0)
             respZoom.run(self.key, state="out", netForce=0, netPropagate=0)
             PtShowDialog(Vignette.value)
-            print("dialog: %s goes up" % Vignette.value)
+            PtDebugPrint("dialog: %s goes up" % Vignette.value)
         # get control key events
         PtGetControlEvents(True,self.key)
 
@@ -148,9 +148,9 @@ class islmPodMap(ptResponder):
         if Vignette.value:
             PtSendKIMessage(kEnableKIandBB,0)
             PtHideDialog(Vignette.value)
-            print("Dialog: %s goes down" % Vignette.value)
+            PtDebugPrint("Dialog: %s goes down" % Vignette.value)
         else:
-            print("WTH!!!")
+            PtDebugPrint("WTH!!!")
         #disable the Control key events
         PtGetControlEvents(False,self.key)
 

--- a/Python/islmRandomBahroScream.py
+++ b/Python/islmRandomBahroScream.py
@@ -67,7 +67,7 @@ class islmRandomBahroScream(ptModifier):
         self.id = 5320
         
         self.version = 2
-        print "__init__islmRandomBahroScream v.", self.version
+        print("__init__islmRandomBahroScream v.", self.version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -89,12 +89,12 @@ class islmRandomBahroScream(ptModifier):
             try:
                 chanceval = ageSDL[ScreamChanceVar][0]
                 cur_chance = xRandom.randint(0, 100)
-                print "RandomBahroScream: Chance val - %d, Cur Chance - %d" % (chanceval, cur_chance)
+                print("RandomBahroScream: Chance val - %d, Cur Chance - %d" % (chanceval, cur_chance))
                 if cur_chance <= chanceval:
                     # turn on
-                    print "RandomBahroScream: turning on"
+                    print("RandomBahroScream: turning on")
                     respScream.run(self.key)
             except:
-                print "RandomBahroScream: could not find SDL for %s in %s" % (ScreamChanceVar,AgeStartedIn)
+                print("RandomBahroScream: could not find SDL for %s in %s" % (ScreamChanceVar,AgeStartedIn))
             PtAtTimeCallback(self.key, 600, TimerID.TurnOn)
         

--- a/Python/islmRandomBahroScream.py
+++ b/Python/islmRandomBahroScream.py
@@ -67,7 +67,7 @@ class islmRandomBahroScream(ptModifier):
         self.id = 5320
         
         self.version = 2
-        print("__init__islmRandomBahroScream v.", self.version)
+        PtDebugPrint("__init__islmRandomBahroScream v.", self.version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -89,12 +89,12 @@ class islmRandomBahroScream(ptModifier):
             try:
                 chanceval = ageSDL[ScreamChanceVar][0]
                 cur_chance = xRandom.randint(0, 100)
-                print("RandomBahroScream: Chance val - %d, Cur Chance - %d" % (chanceval, cur_chance))
+                PtDebugPrint("RandomBahroScream: Chance val - %d, Cur Chance - %d" % (chanceval, cur_chance))
                 if cur_chance <= chanceval:
                     # turn on
-                    print("RandomBahroScream: turning on")
+                    PtDebugPrint("RandomBahroScream: turning on")
                     respScream.run(self.key)
             except:
-                print("RandomBahroScream: could not find SDL for %s in %s" % (ScreamChanceVar,AgeStartedIn))
+                PtDebugPrint("RandomBahroScream: could not find SDL for %s in %s" % (ScreamChanceVar,AgeStartedIn))
             PtAtTimeCallback(self.key, 600, TimerID.TurnOn)
         

--- a/Python/jlakField.py
+++ b/Python/jlakField.py
@@ -197,33 +197,33 @@ class jlakField(ptResponder):
         else:
             boolGUILock = ageSDL[sdlGUILock][0]
 
-        print "jlakField.OnServerInitComplete():  byteStartPt = ",byteStartPt
-        print "jlakField.OnServerInitComplete():  boolWall = ",boolWall
-        print "jlakField.OnServerInitComplete():  byteSphere = ",byteSphere
-        print "jlakField.OnServerInitComplete():  byteLilBox = ",byteLilBox
-        print "jlakField.OnServerInitComplete():  byteBigBox = ",byteBigBox
-        print "jlakField.OnServerInitComplete():  byteRamp = ",byteRamp
-        print "jlakField.OnServerInitComplete():  byteRect = ",byteRect
-        print "jlakField.OnServerInitComplete():  boolGUILock = ",boolGUILock
+        print("jlakField.OnServerInitComplete():  byteStartPt = ",byteStartPt)
+        print("jlakField.OnServerInitComplete():  boolWall = ",boolWall)
+        print("jlakField.OnServerInitComplete():  byteSphere = ",byteSphere)
+        print("jlakField.OnServerInitComplete():  byteLilBox = ",byteLilBox)
+        print("jlakField.OnServerInitComplete():  byteBigBox = ",byteBigBox)
+        print("jlakField.OnServerInitComplete():  byteRamp = ",byteRamp)
+        print("jlakField.OnServerInitComplete():  byteRect = ",byteRect)
+        print("jlakField.OnServerInitComplete():  boolGUILock = ",boolGUILock)
         for sdl in sdlColumns:
             ageSDL.setFlags(sdl,1,1)
             ageSDL.sendToClients(sdl)
             ageSDL.setNotify(self.key,sdl,0.0)
             val = ageSDL[sdl][0]
             byteColumns.append(val)
-        print "jlakField.OnServerInitComplete():  byteColumns = ",byteColumns
+        print("jlakField.OnServerInitComplete():  byteColumns = ",byteColumns)
 
         kZeroed = ptVector3(0,0,0)
         
         for objCol in objColumns.value:
             obj = objCol.getName()
             listObjCols.append(obj)
-        print "listObjCols = ",listObjCols
+        print("listObjCols = ",listObjCols)
 
         if len(clkColumnUp.value) != len(listObjCols):
-            print "error!  not enough up clickables"
+            print("error!  not enough up clickables")
         elif len(clkColumnDn.value) != len(listObjCols):
-            print "error!  not enough down clickables"
+            print("error!  not enough down clickables")
         
         for resp in respSfxColumn.value:
             aResp = resp.getName()
@@ -236,7 +236,7 @@ class jlakField(ptResponder):
         #print "listWarpPlayers = ",listWarpPlayers
 
         if not len(PtGetPlayerList()):
-            print "jlakField.OnServerInitComplete(): on link-in, am only player here.  Will reset player start point"
+            print("jlakField.OnServerInitComplete(): on link-in, am only player here.  Will reset player start point")
             newPoint = byteStartPt
             while newPoint == byteStartPt:
                 newPoint = xRandom.randint(0,len(listWarpPlayers)-1)
@@ -253,14 +253,14 @@ class jlakField(ptResponder):
             if byteRect == len(objRects.value):
                 self.WarpWidgetsHome(4)
         elif len(PtGetPlayerList()) == 1:
-            print "jlakField.OnServerInitComplete(): on link-in, 1 player already here.  Will warp 2 points away (across from previous point)"
+            print("jlakField.OnServerInitComplete(): on link-in, 1 player already here.  Will warp 2 points away (across from previous point)")
             byteStartPt = byteStartPt+2
             if byteStartPt == 4:
                 byteStartPt = 0
             elif byteStartPt >= 5:      # greater than 5 shouldn't be possible, but as a safety...
                 byteStartPt = 1
         else:
-            print "jlakField.OnServerInitComplete(): on link-in, 2 or more players already here.  Will warp to next point"
+            print("jlakField.OnServerInitComplete(): on link-in, 2 or more players already here.  Will warp to next point")
             if byteStartPt == 0:
                 byteStartPt = 2
             elif byteStartPt == 1:
@@ -269,7 +269,7 @@ class jlakField(ptResponder):
                 byteStartPt = 3
             elif byteStartPt == 3:
                 byteStartPt = 1
-        print "jlakField.OnServerInitComplete(): player start point = ",byteStartPt
+        print("jlakField.OnServerInitComplete(): player start point = ",byteStartPt)
         
         onInit = 1
         i = 0
@@ -296,7 +296,7 @@ class jlakField(ptResponder):
             self.DoWallSensors(0)
         
         if PtGetLocalKILevel() < 2:
-            print "jlakField.OnServerInitComplete(): KI level too low, columns will not be clickable"
+            print("jlakField.OnServerInitComplete(): KI level too low, columns will not be clickable")
             for up in clkColumnUp.value:
                 up.disable()
             for dn in clkColumnDn.value:
@@ -319,10 +319,10 @@ class jlakField(ptResponder):
         
         if VARname == sdlStartPt:
             byteStartPt = ageSDL[sdlStartPt][0]
-            print "jlakField.OnSDLNotify(): byteStartPt = ",byteStartPt
+            print("jlakField.OnSDLNotify(): byteStartPt = ",byteStartPt)
         if VARname == sdlWall:
             boolWall = ageSDL[sdlWall][0]
-            print "jlakField.OnSDLNotify(): boolWall = ",boolWall
+            print("jlakField.OnSDLNotify(): boolWall = ",boolWall)
             if boolWall:
                 respWallToggle.run(self.key,state="on",fastforward=0,netPropagate=0)
                 self.DoWallSensors(1)
@@ -342,7 +342,7 @@ class jlakField(ptResponder):
             clkColumnDn.value[id].disable()
             animColumn.byObject[col].playToTime(newPos)
             byteColumns[id] = newPos
-            print "jlakField.OnSDLNotify(): byteColumns[%d] = %d" % (id,newPos)
+            print("jlakField.OnSDLNotify(): byteColumns[%d] = %d" % (id,newPos))
             if newPos > oldPos:
                 dir = "up"
             else:
@@ -352,7 +352,7 @@ class jlakField(ptResponder):
             PtAtTimeCallback(self.key,diffPos,id)
         if VARname == sdlGUILock:
             boolGUILock = ageSDL[sdlGUILock][0]
-            print "jlakField.OnSDLNotify(): boolGUILock = ",boolGUILock
+            print("jlakField.OnSDLNotify(): boolGUILock = ",boolGUILock)
         if VARname == sdlSphere:
             byteSphere = ageSDL[sdlSphere][0]
             if byteSphere == len(objSpheres.value):
@@ -366,8 +366,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print "jlakField.OnSDLNotify(): dropping: ",widgetName
-            print "jlakField.OnSDLNotify(): byteSphere = ",byteSphere
+                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
+            print("jlakField.OnSDLNotify(): byteSphere = ",byteSphere)
         if VARname == sdlLilBox:
             byteLilBox = ageSDL[sdlLilBox][0]
             if byteLilBox == len(objLilBoxes.value):
@@ -381,8 +381,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print "jlakField.OnSDLNotify(): dropping: ",widgetName
-            print "jlakField.OnSDLNotify(): byteLilBox = ",byteLilBox
+                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
+            print("jlakField.OnSDLNotify(): byteLilBox = ",byteLilBox)
         if VARname == sdlBigBox:
             byteBigBox = ageSDL[sdlBigBox][0]
             if byteBigBox == len(objBigBoxes.value):
@@ -395,9 +395,9 @@ class jlakField(ptResponder):
                 warpPt = warpWidgets
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
-                print "jlakField.OnSDLNotify(): dropping: ",widgetName
+                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
                 respCreateWidgetSFX.run(self.key)
-            print "jlakField.OnSDLNotify(): byteBigBox = ",byteBigBox
+            print("jlakField.OnSDLNotify(): byteBigBox = ",byteBigBox)
         if VARname == sdlRamp:
             byteRamp = ageSDL[sdlRamp][0]
             if byteRamp == len(objRamps.value):
@@ -411,8 +411,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print "jlakField.OnSDLNotify(): dropping: ",widgetName                
-            print "jlakField.OnSDLNotify(): byteRamp = ",byteRamp
+                print("jlakField.OnSDLNotify(): dropping: ",widgetName)                
+            print("jlakField.OnSDLNotify(): byteRamp = ",byteRamp)
         if VARname == sdlRect:
             byteRect = ageSDL[sdlRect][0]
             if byteRect == len(objRects.value):
@@ -426,8 +426,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print "jlakField.OnSDLNotify(): dropping: ",widgetName
-            print "jlakField.OnSDLNotify(): byteRect = ",byteRect
+                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
+            print("jlakField.OnSDLNotify(): byteRect = ",byteRect)
 
 
     def OnNotify(self,state,id,events):
@@ -441,7 +441,7 @@ class jlakField(ptResponder):
                 if event[0] == kPickedEvent:
                     xEvent = event[3]
                     theClk = xEvent.getName()
-                    print "jlakField.OnNotify(): pressed: ",theClk
+                    print("jlakField.OnNotify(): pressed: ",theClk)
                     if id == clkColumnUp.id:
                         direction = 1
                         numClk = string.atoi(theClk[6:])
@@ -466,14 +466,14 @@ class jlakField(ptResponder):
                 if events[0][3] > 0: #We'll only enable bulk SFX if we've got a good reason to!
                     self.bulkMove = 1 #Disable individual Pillar SFX
                     if self.sceneobject.isLocallyOwned() and not boolGUILock:
-                        print "jlakField.OnNotify(): bulk-move requested, will ignore GUI bulk-move buttons until done"
+                        print("jlakField.OnNotify(): bulk-move requested, will ignore GUI bulk-move buttons until done")
                         ageSDL[sdlGUILock] = (1,)
                     respBulkMoveSFX.run(self.key, state='on', netPropagate=0)
                     PtAtTimeCallback(self.key,events[0][3],kSFXCompleteID)
             else:
-                print "incoming event: %s" % (events[0][1])
+                print("incoming event: %s" % (events[0][1]))
                 code = events[0][1]
-                print "playing command: %s" % (code)
+                print("playing command: %s" % (code))
                 self.ExecCode(code)
 
 
@@ -494,7 +494,7 @@ class jlakField(ptResponder):
             if oldPos < kMaxPos:
                 newPos = oldPos + 1
             else:
-                print "but already at max"
+                print("but already at max")
                 return
         else:
             op = "down"
@@ -502,7 +502,7 @@ class jlakField(ptResponder):
             if oldPos > kMinPos:
                 newPos = oldPos - 1
             else:
-                print "but already at min"
+                print("but already at min")
                 return
 
         PendingCol = id
@@ -512,9 +512,9 @@ class jlakField(ptResponder):
 
 
     def AutoColumns(self,mode,preset=None):
-        print "jlakField.AutoColumns(): requested all columns move using mode: ",mode
+        print("jlakField.AutoColumns(): requested all columns move using mode: ",mode)
         if boolGUILock:
-            print "jlakField.AutoColumns():  but a previous move is currently in-progress... so it's DENIED!"
+            print("jlakField.AutoColumns():  but a previous move is currently in-progress... so it's DENIED!")
             return
         anythingMoved = 0
         if mode == 0:           #lowest
@@ -534,10 +534,10 @@ class jlakField(ptResponder):
         elif mode == 5:
             # experimental 'preset' mode
             if preset == None:
-                print "no preset, ignoring"
+                print("no preset, ignoring")
                 return
             else:
-                print "running preset..."
+                print("running preset...")
                 pass
 
         #Tye's Note: had to make this code work in two phases for SFX.
@@ -606,7 +606,7 @@ class jlakField(ptResponder):
         col = listObjCols[id]
         #animColumn.byObject[col].speed(spd)    #ensure animation plays at normal speed
         if onInit:
-            print "jlakField.MoveColumn(): on init, fastforwarding column ",id," from position ",oldPos," to ",pos
+            print("jlakField.MoveColumn(): on init, fastforwarding column ",id," from position ",oldPos," to ",pos)
             animColumn.byObject[col].skipToTime(pos)
         else:
             ageSDL[sdlColumns[id]] = (pos,)
@@ -673,7 +673,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpSpheres.value[a].getKey()
                 widget.physics.warpObj(warpPt)
-                print "jlakField.WarpWidgetsHome(): resetting: ",widgetName
+                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 a += 1
         elif widgetType == 1:
             b = 0
@@ -683,7 +683,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpLilBoxes.value[b].getKey()
                 widget.physics.warpObj(warpPt)
-                print "jlakField.WarpWidgetsHome(): resetting: ",widgetName
+                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 b += 1
         elif widgetType == 2:
             c = 0
@@ -693,7 +693,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpBigBoxes.value[c].getKey()
                 widget.physics.warpObj(warpPt)
-                print "jlakField.WarpWidgetsHome(): resetting: ",widgetName
+                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 c += 1
         elif widgetType == 3:
             d = 0
@@ -703,7 +703,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpRamps.value[d].getKey()
                 widget.physics.warpObj(warpPt)
-                print "jlakField.WarpWidgetsHome(): resetting: ",widgetName
+                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 d += 1
         elif widgetType == 4:
             e = 0
@@ -713,12 +713,12 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpRects.value[e].getKey()
                 widget.physics.warpObj(warpPt)
-                print "jlakField.WarpWidgetsHome(): resetting: ",widgetName
+                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 e += 1
 
 
     def ToggleWall(self):
-        print "jlakField.ToggleWall()"
+        print("jlakField.ToggleWall()")
         ageSDL = PtGetAgeSDL()
         if boolWall:
             ageSDL[sdlWall] = (0,)
@@ -727,7 +727,7 @@ class jlakField(ptResponder):
 
 
     def DoWallSensors(self,state):
-        print "jlakField.DoWallSensors()"
+        print("jlakField.DoWallSensors()")
         for rgn in rgnWallSensors.value:
             if state:
                 #print "jlakField.DoWallSensors(): ",rgn.getName()," enabled"
@@ -755,7 +755,7 @@ class jlakField(ptResponder):
                 PendingPos = -1
                 PendingDir = ""
             else:
-                print "timer callback to do pending column move, but vars are bad...?"
+                print("timer callback to do pending column move, but vars are bad...?")
         elif id == kEmoteTimerID:
             PtForceCursorShown()
         elif id == kSFXCompleteID:
@@ -765,11 +765,11 @@ class jlakField(ptResponder):
 
     def SaveColumns(self,fName):
         fWrite = file(fName,'w')
-        print "jlakField.SaveColumns(): writing to presets file '%s'" % (fName)
+        print("jlakField.SaveColumns(): writing to presets file '%s'" % (fName))
         i = 0
         for pos in byteColumns:
             fWrite.write(str(pos)+"\n")
-            print "jlakField.SaveColumns():  column: %d at position: %d" % (i,pos)
+            print("jlakField.SaveColumns():  column: %d at position: %d" % (i,pos))
             i += 1
         fWrite.close()
 
@@ -778,7 +778,7 @@ class jlakField(ptResponder):
         try:
             fRead = file(fName,'r')
         except:
-            print "jlakField.LoadColumns():  ERROR!  File '%s' not found, load canceled." % (fName)
+            print("jlakField.LoadColumns():  ERROR!  File '%s' not found, load canceled." % (fName))
             #templist = [PtGetLocalPlayer()]
             #PtSendRTChat(PtGetLocalPlayer(),templist,"doh!",1)
             return
@@ -787,27 +787,27 @@ class jlakField(ptResponder):
         for line in fRead:
             pos = string.atoi(line)
             if pos < 0 or pos > 19:
-                print "jlakField.LoadColumns():  ERROR!  Column %d has an invalid position of %d, must be an integer between 0 and 19.  Load canceled." % (i,pos)
+                print("jlakField.LoadColumns():  ERROR!  Column %d has an invalid position of %d, must be an integer between 0 and 19.  Load canceled." % (i,pos))
                 fRead.close()
                 return
             else:
                 preset.append(pos)
             i += 1
         if len(preset) != 25:
-            print "jlakField.LoadColumns():  ERROR!  File contains %d positions, must contain positions for 25 columns, only.  Load canceled." % (len(preset))
+            print("jlakField.LoadColumns():  ERROR!  File contains %d positions, must contain positions for 25 columns, only.  Load canceled." % (len(preset)))
         else:
-            print "jlakField.LoadColumns(): reading preset file '%s'" % (fName)
-            print "this preset's columns = ",preset
+            print("jlakField.LoadColumns(): reading preset file '%s'" % (fName))
+            print("this preset's columns = ",preset)
             self.AutoColumns(5,preset)    	
         fRead.close()
 
 
     def OnBackdoorMsg(self, target, param):
-        print "jlakField.OnBackdoorMsg()"
+        print("jlakField.OnBackdoorMsg()")
         if target == "height":
             param = string.atoi(param)
             if param < kMinPos or param > kMaxPos:
-                print "invalid height parameter, must be a # between ",kMinPos," and ",kMaxPos
+                print("invalid height parameter, must be a # between ",kMinPos," and ",kMaxPos)
                 return
             newPos = param
             anythingMoved = 0
@@ -824,7 +824,7 @@ class jlakField(ptResponder):
             if param == "widgets":
                 self.ResetWidgets()
             else:
-                print "invalid reset parameter, can only use 'widgets' for now"
+                print("invalid reset parameter, can only use 'widgets' for now")
 
     def ExecCode(self, code):
         try:
@@ -854,11 +854,11 @@ class jlakField(ptResponder):
             elif btnID == kJalakDestroyBtn:
                 self.ResetWidgets()
             else:
-                print "jlakField.ExecCode(): ERROR! Invalid btnID %d." % (btnID)
+                print("jlakField.ExecCode(): ERROR! Invalid btnID %d." % (btnID))
         except:
             cmd = code.split(';',1)
             if len(cmd) != 2:
-                print "jlakField.ExecCode(): ERROR! Malformed Command '%s'." % (code)
+                print("jlakField.ExecCode(): ERROR! Malformed Command '%s'." % (code))
                 return
             
             if cmd[0] == "SaveColumns":
@@ -866,7 +866,7 @@ class jlakField(ptResponder):
             elif cmd[0] == "LoadColumns":
                 self.LoadColumns(cmd[1])
             else:
-                print "jlakField.ExecCode(): ERROR! Invalid code '%s'." % (code)
+                print("jlakField.ExecCode(): ERROR! Invalid code '%s'." % (code))
 
 #ColumnPos  AnimStart
 #   19      570

--- a/Python/jlakField.py
+++ b/Python/jlakField.py
@@ -197,46 +197,46 @@ class jlakField(ptResponder):
         else:
             boolGUILock = ageSDL[sdlGUILock][0]
 
-        print("jlakField.OnServerInitComplete():  byteStartPt = ",byteStartPt)
-        print("jlakField.OnServerInitComplete():  boolWall = ",boolWall)
-        print("jlakField.OnServerInitComplete():  byteSphere = ",byteSphere)
-        print("jlakField.OnServerInitComplete():  byteLilBox = ",byteLilBox)
-        print("jlakField.OnServerInitComplete():  byteBigBox = ",byteBigBox)
-        print("jlakField.OnServerInitComplete():  byteRamp = ",byteRamp)
-        print("jlakField.OnServerInitComplete():  byteRect = ",byteRect)
-        print("jlakField.OnServerInitComplete():  boolGUILock = ",boolGUILock)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteStartPt = ",byteStartPt)
+        PtDebugPrint("jlakField.OnServerInitComplete():  boolWall = ",boolWall)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteSphere = ",byteSphere)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteLilBox = ",byteLilBox)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteBigBox = ",byteBigBox)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteRamp = ",byteRamp)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteRect = ",byteRect)
+        PtDebugPrint("jlakField.OnServerInitComplete():  boolGUILock = ",boolGUILock)
         for sdl in sdlColumns:
             ageSDL.setFlags(sdl,1,1)
             ageSDL.sendToClients(sdl)
             ageSDL.setNotify(self.key,sdl,0.0)
             val = ageSDL[sdl][0]
             byteColumns.append(val)
-        print("jlakField.OnServerInitComplete():  byteColumns = ",byteColumns)
+        PtDebugPrint("jlakField.OnServerInitComplete():  byteColumns = ",byteColumns)
 
         kZeroed = ptVector3(0,0,0)
         
         for objCol in objColumns.value:
             obj = objCol.getName()
             listObjCols.append(obj)
-        print("listObjCols = ",listObjCols)
+        PtDebugPrint("listObjCols = ",listObjCols)
 
         if len(clkColumnUp.value) != len(listObjCols):
-            print("error!  not enough up clickables")
+            PtDebugPrint("error!  not enough up clickables")
         elif len(clkColumnDn.value) != len(listObjCols):
-            print("error!  not enough down clickables")
+            PtDebugPrint("error!  not enough down clickables")
         
         for resp in respSfxColumn.value:
             aResp = resp.getName()
             listSfxCols.append(aResp)
-        #print "listSfxCols = ",listSfxCols
+        #PtDebugPrint("listSfxCols = ",listSfxCols)
 
         for warp in warpPlayers.value:
             pt = warp.getName()
             listWarpPlayers.append(pt)
-        #print "listWarpPlayers = ",listWarpPlayers
+        #PtDebugPrint("listWarpPlayers = ",listWarpPlayers)
 
         if not len(PtGetPlayerList()):
-            print("jlakField.OnServerInitComplete(): on link-in, am only player here.  Will reset player start point")
+            PtDebugPrint("jlakField.OnServerInitComplete(): on link-in, am only player here.  Will reset player start point")
             newPoint = byteStartPt
             while newPoint == byteStartPt:
                 newPoint = xRandom.randint(0,len(listWarpPlayers)-1)
@@ -253,14 +253,14 @@ class jlakField(ptResponder):
             if byteRect == len(objRects.value):
                 self.WarpWidgetsHome(4)
         elif len(PtGetPlayerList()) == 1:
-            print("jlakField.OnServerInitComplete(): on link-in, 1 player already here.  Will warp 2 points away (across from previous point)")
+            PtDebugPrint("jlakField.OnServerInitComplete(): on link-in, 1 player already here.  Will warp 2 points away (across from previous point)")
             byteStartPt = byteStartPt+2
             if byteStartPt == 4:
                 byteStartPt = 0
             elif byteStartPt >= 5:      # greater than 5 shouldn't be possible, but as a safety...
                 byteStartPt = 1
         else:
-            print("jlakField.OnServerInitComplete(): on link-in, 2 or more players already here.  Will warp to next point")
+            PtDebugPrint("jlakField.OnServerInitComplete(): on link-in, 2 or more players already here.  Will warp to next point")
             if byteStartPt == 0:
                 byteStartPt = 2
             elif byteStartPt == 1:
@@ -269,7 +269,7 @@ class jlakField(ptResponder):
                 byteStartPt = 3
             elif byteStartPt == 3:
                 byteStartPt = 1
-        print("jlakField.OnServerInitComplete(): player start point = ",byteStartPt)
+        PtDebugPrint("jlakField.OnServerInitComplete(): player start point = ",byteStartPt)
         
         onInit = 1
         i = 0
@@ -296,7 +296,7 @@ class jlakField(ptResponder):
             self.DoWallSensors(0)
         
         if PtGetLocalKILevel() < 2:
-            print("jlakField.OnServerInitComplete(): KI level too low, columns will not be clickable")
+            PtDebugPrint("jlakField.OnServerInitComplete(): KI level too low, columns will not be clickable")
             for up in clkColumnUp.value:
                 up.disable()
             for dn in clkColumnDn.value:
@@ -319,10 +319,10 @@ class jlakField(ptResponder):
         
         if VARname == sdlStartPt:
             byteStartPt = ageSDL[sdlStartPt][0]
-            print("jlakField.OnSDLNotify(): byteStartPt = ",byteStartPt)
+            PtDebugPrint("jlakField.OnSDLNotify(): byteStartPt = ",byteStartPt)
         if VARname == sdlWall:
             boolWall = ageSDL[sdlWall][0]
-            print("jlakField.OnSDLNotify(): boolWall = ",boolWall)
+            PtDebugPrint("jlakField.OnSDLNotify(): boolWall = ",boolWall)
             if boolWall:
                 respWallToggle.run(self.key,state="on",fastforward=0,netPropagate=0)
                 self.DoWallSensors(1)
@@ -335,14 +335,14 @@ class jlakField(ptResponder):
             oldPos = byteColumns[id]
             newPos = ageSDL[sdlColumns[id]][0]
             diffPos = abs(newPos-oldPos)
-            #print "oldPos = ",oldPos
-            #print "newPos = ",newPos
-            #print "diffPos = ",diffPos
+            #PtDebugPrint("oldPos = ",oldPos)
+            #PtDebugPrint("newPos = ",newPos)
+            #PtDebugPrint("diffPos = ",diffPos)
             clkColumnUp.value[id].disable()
             clkColumnDn.value[id].disable()
             animColumn.byObject[col].playToTime(newPos)
             byteColumns[id] = newPos
-            print("jlakField.OnSDLNotify(): byteColumns[%d] = %d" % (id,newPos))
+            PtDebugPrint("jlakField.OnSDLNotify(): byteColumns[%d] = %d" % (id,newPos))
             if newPos > oldPos:
                 dir = "up"
             else:
@@ -352,7 +352,7 @@ class jlakField(ptResponder):
             PtAtTimeCallback(self.key,diffPos,id)
         if VARname == sdlGUILock:
             boolGUILock = ageSDL[sdlGUILock][0]
-            print("jlakField.OnSDLNotify(): boolGUILock = ",boolGUILock)
+            PtDebugPrint("jlakField.OnSDLNotify(): boolGUILock = ",boolGUILock)
         if VARname == sdlSphere:
             byteSphere = ageSDL[sdlSphere][0]
             if byteSphere == len(objSpheres.value):
@@ -366,8 +366,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
-            print("jlakField.OnSDLNotify(): byteSphere = ",byteSphere)
+                PtDebugPrint("jlakField.OnSDLNotify(): dropping: ",widgetName)
+            PtDebugPrint("jlakField.OnSDLNotify(): byteSphere = ",byteSphere)
         if VARname == sdlLilBox:
             byteLilBox = ageSDL[sdlLilBox][0]
             if byteLilBox == len(objLilBoxes.value):
@@ -381,8 +381,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
-            print("jlakField.OnSDLNotify(): byteLilBox = ",byteLilBox)
+                PtDebugPrint("jlakField.OnSDLNotify(): dropping: ",widgetName)
+            PtDebugPrint("jlakField.OnSDLNotify(): byteLilBox = ",byteLilBox)
         if VARname == sdlBigBox:
             byteBigBox = ageSDL[sdlBigBox][0]
             if byteBigBox == len(objBigBoxes.value):
@@ -395,9 +395,9 @@ class jlakField(ptResponder):
                 warpPt = warpWidgets
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
-                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
+                PtDebugPrint("jlakField.OnSDLNotify(): dropping: ",widgetName)
                 respCreateWidgetSFX.run(self.key)
-            print("jlakField.OnSDLNotify(): byteBigBox = ",byteBigBox)
+            PtDebugPrint("jlakField.OnSDLNotify(): byteBigBox = ",byteBigBox)
         if VARname == sdlRamp:
             byteRamp = ageSDL[sdlRamp][0]
             if byteRamp == len(objRamps.value):
@@ -411,8 +411,8 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print("jlakField.OnSDLNotify(): dropping: ",widgetName)                
-            print("jlakField.OnSDLNotify(): byteRamp = ",byteRamp)
+                PtDebugPrint("jlakField.OnSDLNotify(): dropping: ",widgetName)                
+            PtDebugPrint("jlakField.OnSDLNotify(): byteRamp = ",byteRamp)
         if VARname == sdlRect:
             byteRect = ageSDL[sdlRect][0]
             if byteRect == len(objRects.value):
@@ -426,13 +426,13 @@ class jlakField(ptResponder):
                 widget.physics.enable(1)
                 widget.physics.warpObj(warpPt)
                 respCreateWidgetSFX.run(self.key)
-                print("jlakField.OnSDLNotify(): dropping: ",widgetName)
-            print("jlakField.OnSDLNotify(): byteRect = ",byteRect)
+                PtDebugPrint("jlakField.OnSDLNotify(): dropping: ",widgetName)
+            PtDebugPrint("jlakField.OnSDLNotify(): byteRect = ",byteRect)
 
 
     def OnNotify(self,state,id,events):
         ageSDL = PtGetAgeSDL()
-        #print "jlakField.OnNotify(): id = ",id
+        #PtDebugPrint("jlakField.OnNotify(): id = ",id)
         #if not state:
             #return
 
@@ -441,22 +441,22 @@ class jlakField(ptResponder):
                 if event[0] == kPickedEvent:
                     xEvent = event[3]
                     theClk = xEvent.getName()
-                    print("jlakField.OnNotify(): pressed: ",theClk)
+                    PtDebugPrint("jlakField.OnNotify(): pressed: ",theClk)
                     if id == clkColumnUp.id:
                         direction = 1
                         numClk = string.atoi(theClk[6:])
                     else:
                         direction = 0
                         numClk = string.atoi(theClk[6:])
-                    #print "numClk = ",numClk
+                    #PtDebugPrint("numClk = ",numClk)
                     self.CalcPos(numClk,direction)
 
 #        elif id == rgnZeroPhysicals.id:
-#            print "rgnZeroPhysicals"
-#            print state
+#            PtDebugPrint("rgnZeroPhysicals")
+#            PtDebugPrint(state)
 #            for event in events:
 #                if event[0] == kCollisionEvent:
-#                    print "collision event"
+#                    PtDebugPrint("collision event")
 #                    hitter = event[2]
         elif id == respBulkMoveSFX.id:
             if self.sceneobject.isLocallyOwned() and boolGUILock:
@@ -466,19 +466,19 @@ class jlakField(ptResponder):
                 if events[0][3] > 0: #We'll only enable bulk SFX if we've got a good reason to!
                     self.bulkMove = 1 #Disable individual Pillar SFX
                     if self.sceneobject.isLocallyOwned() and not boolGUILock:
-                        print("jlakField.OnNotify(): bulk-move requested, will ignore GUI bulk-move buttons until done")
+                        PtDebugPrint("jlakField.OnNotify(): bulk-move requested, will ignore GUI bulk-move buttons until done")
                         ageSDL[sdlGUILock] = (1,)
                     respBulkMoveSFX.run(self.key, state='on', netPropagate=0)
                     PtAtTimeCallback(self.key,events[0][3],kSFXCompleteID)
             else:
-                print("incoming event: %s" % (events[0][1]))
+                PtDebugPrint("incoming event: %s" % (events[0][1]))
                 code = events[0][1]
-                print("playing command: %s" % (code))
+                PtDebugPrint("playing command: %s" % (code))
                 self.ExecCode(code)
 
 
     def CalcPos(self,id,dir):
-        #print "jlakField.CalcPos()"
+        #PtDebugPrint("jlakField.CalcPos()")
         global PendingCol
         global PendingPos
         global PendingDir
@@ -490,19 +490,19 @@ class jlakField(ptResponder):
         oldPos = byteColumns[id]
         if dir:
             op = "up"
-            #print "jlakField.CalcPos(): request for column: ",id,", to go: ",op
+            #PtDebugPrint("jlakField.CalcPos(): request for column: ",id,", to go: ",op)
             if oldPos < kMaxPos:
                 newPos = oldPos + 1
             else:
-                print("but already at max")
+                PtDebugPrint("but already at max")
                 return
         else:
             op = "down"
-            #print "jlakField.CalcPos(): request for column: ",id,", to go: ",op
+            #PtDebugPrint("jlakField.CalcPos(): request for column: ",id,", to go: ",op)
             if oldPos > kMinPos:
                 newPos = oldPos - 1
             else:
-                print("but already at min")
+                PtDebugPrint("but already at min")
                 return
 
         PendingCol = id
@@ -512,9 +512,9 @@ class jlakField(ptResponder):
 
 
     def AutoColumns(self,mode,preset=None):
-        print("jlakField.AutoColumns(): requested all columns move using mode: ",mode)
+        PtDebugPrint("jlakField.AutoColumns(): requested all columns move using mode: ",mode)
         if boolGUILock:
-            print("jlakField.AutoColumns():  but a previous move is currently in-progress... so it's DENIED!")
+            PtDebugPrint("jlakField.AutoColumns():  but a previous move is currently in-progress... so it's DENIED!")
             return
         anythingMoved = 0
         if mode == 0:           #lowest
@@ -534,10 +534,10 @@ class jlakField(ptResponder):
         elif mode == 5:
             # experimental 'preset' mode
             if preset == None:
-                print("no preset, ignoring")
+                PtDebugPrint("no preset, ignoring")
                 return
             else:
-                print("running preset...")
+                PtDebugPrint("running preset...")
                 pass
 
         #Tye's Note: had to make this code work in two phases for SFX.
@@ -606,7 +606,7 @@ class jlakField(ptResponder):
         col = listObjCols[id]
         #animColumn.byObject[col].speed(spd)    #ensure animation plays at normal speed
         if onInit:
-            print("jlakField.MoveColumn(): on init, fastforwarding column ",id," from position ",oldPos," to ",pos)
+            PtDebugPrint("jlakField.MoveColumn(): on init, fastforwarding column ",id," from position ",oldPos," to ",pos)
             animColumn.byObject[col].skipToTime(pos)
         else:
             ageSDL[sdlColumns[id]] = (pos,)
@@ -650,11 +650,11 @@ class jlakField(ptResponder):
             else:
                 RectCur = 0
             ageSDL[sdlRect] = (RectCur,)
-        #print "jlakField.DropWidget(): dropping widget: ",widgetName
+        #PtDebugPrint("jlakField.DropWidget(): dropping widget: ",widgetName)
 
 
     def ResetWidgets(self):
-        #print "jlakField.ResetWidgets()"
+        #PtDebugPrint("jlakField.ResetWidgets()")
         ageSDL = PtGetAgeSDL()
 
         ageSDL[sdlSphere] = (len(objSpheres.value),)
@@ -673,7 +673,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpSpheres.value[a].getKey()
                 widget.physics.warpObj(warpPt)
-                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
+                PtDebugPrint("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 a += 1
         elif widgetType == 1:
             b = 0
@@ -683,7 +683,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpLilBoxes.value[b].getKey()
                 widget.physics.warpObj(warpPt)
-                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
+                PtDebugPrint("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 b += 1
         elif widgetType == 2:
             c = 0
@@ -693,7 +693,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpBigBoxes.value[c].getKey()
                 widget.physics.warpObj(warpPt)
-                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
+                PtDebugPrint("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 c += 1
         elif widgetType == 3:
             d = 0
@@ -703,7 +703,7 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpRamps.value[d].getKey()
                 widget.physics.warpObj(warpPt)
-                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
+                PtDebugPrint("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 d += 1
         elif widgetType == 4:
             e = 0
@@ -713,12 +713,12 @@ class jlakField(ptResponder):
                 widgetName = widget.getName()
                 warpPt = warpRects.value[e].getKey()
                 widget.physics.warpObj(warpPt)
-                print("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
+                PtDebugPrint("jlakField.WarpWidgetsHome(): resetting: ",widgetName)
                 e += 1
 
 
     def ToggleWall(self):
-        print("jlakField.ToggleWall()")
+        PtDebugPrint("jlakField.ToggleWall()")
         ageSDL = PtGetAgeSDL()
         if boolWall:
             ageSDL[sdlWall] = (0,)
@@ -727,13 +727,13 @@ class jlakField(ptResponder):
 
 
     def DoWallSensors(self,state):
-        print("jlakField.DoWallSensors()")
+        PtDebugPrint("jlakField.DoWallSensors()")
         for rgn in rgnWallSensors.value:
             if state:
-                #print "jlakField.DoWallSensors(): ",rgn.getName()," enabled"
+                #PtDebugPrint("jlakField.DoWallSensors(): ",rgn.getName()," enabled")
                 rgn.enable()
             else:
-                #print "jlakField.DoWallSensors(): ",rgn.getName()," disabled"
+                #PtDebugPrint("jlakField.DoWallSensors(): ",rgn.getName()," disabled")
                 rgn.disable()
 
 
@@ -744,7 +744,7 @@ class jlakField(ptResponder):
         ageSDL = PtGetAgeSDL()
 
         if id >= 0 and id <= 99:
-            #print "jlakField.OnTimer(): reenabling up/down clickables for column: ",id
+            #PtDebugPrint("jlakField.OnTimer(): reenabling up/down clickables for column: ",id)
             respSfxColumn.run(self.key,state="off",objectName=listSfxCols[id])
             clkColumnUp.value[id].enable()
             clkColumnDn.value[id].enable()
@@ -755,7 +755,7 @@ class jlakField(ptResponder):
                 PendingPos = -1
                 PendingDir = ""
             else:
-                print("timer callback to do pending column move, but vars are bad...?")
+                PtDebugPrint("timer callback to do pending column move, but vars are bad...?")
         elif id == kEmoteTimerID:
             PtForceCursorShown()
         elif id == kSFXCompleteID:
@@ -765,11 +765,11 @@ class jlakField(ptResponder):
 
     def SaveColumns(self,fName):
         fWrite = file(fName,'w')
-        print("jlakField.SaveColumns(): writing to presets file '%s'" % (fName))
+        PtDebugPrint("jlakField.SaveColumns(): writing to presets file '%s'" % (fName))
         i = 0
         for pos in byteColumns:
             fWrite.write(str(pos)+"\n")
-            print("jlakField.SaveColumns():  column: %d at position: %d" % (i,pos))
+            PtDebugPrint("jlakField.SaveColumns():  column: %d at position: %d" % (i,pos))
             i += 1
         fWrite.close()
 
@@ -778,7 +778,7 @@ class jlakField(ptResponder):
         try:
             fRead = file(fName,'r')
         except:
-            print("jlakField.LoadColumns():  ERROR!  File '%s' not found, load canceled." % (fName))
+            PtDebugPrint("jlakField.LoadColumns():  ERROR!  File '%s' not found, load canceled." % (fName))
             #templist = [PtGetLocalPlayer()]
             #PtSendRTChat(PtGetLocalPlayer(),templist,"doh!",1)
             return
@@ -787,27 +787,27 @@ class jlakField(ptResponder):
         for line in fRead:
             pos = string.atoi(line)
             if pos < 0 or pos > 19:
-                print("jlakField.LoadColumns():  ERROR!  Column %d has an invalid position of %d, must be an integer between 0 and 19.  Load canceled." % (i,pos))
+                PtDebugPrint("jlakField.LoadColumns():  ERROR!  Column %d has an invalid position of %d, must be an integer between 0 and 19.  Load canceled." % (i,pos))
                 fRead.close()
                 return
             else:
                 preset.append(pos)
             i += 1
         if len(preset) != 25:
-            print("jlakField.LoadColumns():  ERROR!  File contains %d positions, must contain positions for 25 columns, only.  Load canceled." % (len(preset)))
+            PtDebugPrint("jlakField.LoadColumns():  ERROR!  File contains %d positions, must contain positions for 25 columns, only.  Load canceled." % (len(preset)))
         else:
-            print("jlakField.LoadColumns(): reading preset file '%s'" % (fName))
-            print("this preset's columns = ",preset)
+            PtDebugPrint("jlakField.LoadColumns(): reading preset file '%s'" % (fName))
+            PtDebugPrint("this preset's columns = ",preset)
             self.AutoColumns(5,preset)    	
         fRead.close()
 
 
     def OnBackdoorMsg(self, target, param):
-        print("jlakField.OnBackdoorMsg()")
+        PtDebugPrint("jlakField.OnBackdoorMsg()")
         if target == "height":
             param = string.atoi(param)
             if param < kMinPos or param > kMaxPos:
-                print("invalid height parameter, must be a # between ",kMinPos," and ",kMaxPos)
+                PtDebugPrint("invalid height parameter, must be a # between ",kMinPos," and ",kMaxPos)
                 return
             newPos = param
             anythingMoved = 0
@@ -824,7 +824,7 @@ class jlakField(ptResponder):
             if param == "widgets":
                 self.ResetWidgets()
             else:
-                print("invalid reset parameter, can only use 'widgets' for now")
+                PtDebugPrint("invalid reset parameter, can only use 'widgets' for now")
 
     def ExecCode(self, code):
         try:
@@ -854,11 +854,11 @@ class jlakField(ptResponder):
             elif btnID == kJalakDestroyBtn:
                 self.ResetWidgets()
             else:
-                print("jlakField.ExecCode(): ERROR! Invalid btnID %d." % (btnID))
+                PtDebugPrint("jlakField.ExecCode(): ERROR! Invalid btnID %d." % (btnID))
         except:
             cmd = code.split(';',1)
             if len(cmd) != 2:
-                print("jlakField.ExecCode(): ERROR! Malformed Command '%s'." % (code))
+                PtDebugPrint("jlakField.ExecCode(): ERROR! Malformed Command '%s'." % (code))
                 return
             
             if cmd[0] == "SaveColumns":
@@ -866,7 +866,7 @@ class jlakField(ptResponder):
             elif cmd[0] == "LoadColumns":
                 self.LoadColumns(cmd[1])
             else:
-                print("jlakField.ExecCode(): ERROR! Invalid code '%s'." % (code))
+                PtDebugPrint("jlakField.ExecCode(): ERROR! Invalid code '%s'." % (code))
 
 #ColumnPos  AnimStart
 #   19      570

--- a/Python/kdshGlowInTheDark.py
+++ b/Python/kdshGlowInTheDark.py
@@ -113,12 +113,12 @@ class kdshGlowInTheDark(ptResponder):
 
         version = 10
         self.version = version
-        print("__init__kdshGlowInTheDark v.", version,".5")
+        PtDebugPrint("__init__kdshGlowInTheDark v.", version,".5")
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print("kdshGlowInTheDark:\tERROR---Cannot find the Kadish Age SDL")
+            PtDebugPrint("kdshGlowInTheDark:\tERROR---Cannot find the Kadish Age SDL")
             #ageSDL["RoofClosed"] = (1, )
             #ageSDL["GlowCharged"] = (0, )
             #ageSDL["TimeOpened"] = (0, )
@@ -143,32 +143,32 @@ class kdshGlowInTheDark(ptResponder):
         GlowCharged = ageSDL["GlowCharged"][0]
         solved = ageSDL["GlowInTheDarkSolved"][0]
 
-        print("kdshGlowInTheDark: When I got here:")
+        PtDebugPrint("kdshGlowInTheDark: When I got here:")
 
         if not RoofClosed:
-            print("\tThe roof was open when I got here.")
+            PtDebugPrint("\tThe roof was open when I got here.")
             respFloorLitFromGlow.run(self.key,fastforward=1)
         else:
-            print("\tThe roof is still closed.")
+            PtDebugPrint("\tThe roof is still closed.")
 
         if RoofClosed and GlowCharged:
-            print("\tThe floor was glowing when I got here.")
+            PtDebugPrint("\tThe floor was glowing when I got here.")
             PtAtTimeCallback(self.key,1,5)
             #~ respFloorGlow.run(self.key,fastforward=1)
         else:
-            print("\tThe floor is not charged.")
+            PtDebugPrint("\tThe floor is not charged.")
 
         if solved:
-            print("\tThe puzzle was solved.")
-            print("\tThere are", len(PtGetPlayerList()), " other players in this Kadish instance.")
+            PtDebugPrint("\tThe puzzle was solved.")
+            PtDebugPrint("\tThere are", len(PtGetPlayerList()), " other players in this Kadish instance.")
             if len(PtGetPlayerList()) == 0:
-                print("\t I'm alone, so I'm starting the elevator.")
+                PtDebugPrint("\t I'm alone, so I'm starting the elevator.")
                 respElevDown.run(self.key)
                 PtAtTimeCallback(self.key,3,2) # clear xRgn at top
             else:
-                print("\t Someone else was already in this Kadish instance. Depending on Overriding HighSDL component to synch elevator.")
+                PtDebugPrint("\t Someone else was already in this Kadish instance. Depending on Overriding HighSDL component to synch elevator.")
         else:
-            print("\t The puzzle has not been solved. Putting elevator at the top.")
+            PtDebugPrint("\t The puzzle has not been solved. Putting elevator at the top.")
             respElevUp.run(self.key, fastforward=True)
 
 
@@ -179,7 +179,7 @@ class kdshGlowInTheDark(ptResponder):
 
         ageSDL = PtGetAgeSDL()
 
-        #~ print "kdshGlowInTheDark.OnNotify:  state=%f id=%d events=" % (state,id),events
+        #~ PtDebugPrint("kdshGlowInTheDark.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if not state:
             return
@@ -189,41 +189,41 @@ class kdshGlowInTheDark(ptResponder):
             return
 
         elif id == respButtonOneshot.id and OnlyOneOwner.sceneobject.isLocallyOwned():
-            print("##")
+            PtDebugPrint("##")
             oldstate = ageSDL["RoofClosed"][0] # 1 is closed, 0 is open
 
             if oldstate == 1: # roof was previously closed
-                print("kdshGlowInTheDark: The roof is now open.")
+                PtDebugPrint("kdshGlowInTheDark: The roof is now open.")
                 self.RecordOpenTime()
 
                 GlowCharged = ageSDL["GlowCharged"][0]
-                print("kdshGlowInTheDark: GlowCharged = ", GlowCharged)
+                PtDebugPrint("kdshGlowInTheDark: GlowCharged = ", GlowCharged)
                 #~ if GlowCharged:
                     #~ respFloorLitFromGlow.run(self.key)
                 #~ else:
                     #~ respFloorLitFromDark.run(self.key)
 
             elif oldstate == 0: # roof was previously open
-                print("kdshGlowInTheDark: The roof is now closed.")
+                PtDebugPrint("kdshGlowInTheDark: The roof is now closed.")
                 self.CalculateTimeOpen()
                 #~ respFloorDark.run(self.key)
 
             else:
-                print("kdshGlowInTheDark: Unexpected roof state: (%s)" % newstate)
+                PtDebugPrint("kdshGlowInTheDark: Unexpected roof state: (%s)" % newstate)
 
             newstate =  abs(oldstate-1) # toggle roof state value
             ageSDL["RoofClosed"] = (newstate, ) #write new state value to SDL
             return
 
         elif id == respElevDown.id:
-            print("kdshGlowInTheDark: The elevator has reached the bottom.")
+            PtDebugPrint("kdshGlowInTheDark: The elevator has reached the bottom.")
             PtAtTimeCallback(self.key,ElevatorDelay,1) # wait 10 seconds, then raise elevator again
             xRgnBottom.releaseNow(self.key)
             rgnEnterSubBtm.enable()
             return
 
         elif id == respElevUp.id:
-            print("kdshGlowInTheDark: The elevator has reached the top.")
+            PtDebugPrint("kdshGlowInTheDark: The elevator has reached the top.")
             PtAtTimeCallback(self.key,ElevatorDelay,3) # wait 10 seconds, then lower elevator again
             xRgnTop.releaseNow(self.key)
             rgnEnterSubTop.enable()
@@ -239,20 +239,20 @@ class kdshGlowInTheDark(ptResponder):
         elif id == 16:  # The Entire Floor Zone
             for event in events:
                 if event[0] == 1 and event[1] == 1:
-                    print("kdshGlowInTheDark: A second player stepped on floor.")
+                    PtDebugPrint("kdshGlowInTheDark: A second player stepped on floor.")
                     baton = 0
                 elif event[0] == 1:
-                    print("kdshGlowInTheDark: Floor unoccupied.")
+                    PtDebugPrint("kdshGlowInTheDark: Floor unoccupied.")
             return
 
         elif id == actResetBtn.id:
-            print("kdshGlowInTheDark Reset Button clicked.")
+            PtDebugPrint("kdshGlowInTheDark Reset Button clicked.")
             Resetting = 1
             respResetBtn.run(self.key,events=events)
             return
 
         elif id == respResetBtn.id and OnlyOneOwner.sceneobject.isLocallyOwned():
-            print("kdshGlowInTheDark Reset Button Pushed. Puzzle resetting.")
+            PtDebugPrint("kdshGlowInTheDark Reset Button Pushed. Puzzle resetting.")
 
             ageSDL["RoofClosed"] = (1, )
             ageSDL["GlowCharged"] = (0, )
@@ -267,23 +267,23 @@ class kdshGlowInTheDark(ptResponder):
         elif PtGetLocalAvatar() == PtFindAvatar(events):
             me = PtGetLocalAvatar()
             if id == rgnExitSubTop.id:
-                print("kdshGlowInTheDark: You stepped off the elevator at the top. Removing from Subworld")
+                PtDebugPrint("kdshGlowInTheDark: You stepped off the elevator at the top. Removing from Subworld")
                 me.avatar.exitSubWorld()
                 return
 
             elif id == rgnExitSubBtm.id:
-                print("kdshGlowInTheDark: You stepped off the elevator at the btm. Removing from Subworld")
+                PtDebugPrint("kdshGlowInTheDark: You stepped off the elevator at the btm. Removing from Subworld")
                 me.avatar.exitSubWorld()
                 return
 
             elif id == rgnEnterSubTop.id:
-                print("You stepped on the elevator at the top. Joining subworld.")
+                PtDebugPrint("You stepped on the elevator at the top. Joining subworld.")
                 #~ rgnExitSubTop.disable()
                 me.avatar.enterSubWorld(elevatorsubworld.value)
                 return
 
             elif id == rgnEnterSubBtm.id:
-                print("You stepped on the elevator at the bottom. Joining subworld.")
+                PtDebugPrint("You stepped on the elevator at the bottom. Joining subworld.")
                 rgnExitSubBtm.disable()
                 me.avatar.enterSubWorld(elevatorsubworld.value)
                 return
@@ -291,49 +291,49 @@ class kdshGlowInTheDark(ptResponder):
         for event in events:
             if event[0] == kVariableEvent: # Did another player just get out of the bucket by hitting ESC/backspace? (An OnControlKeyEvent I wouldn't have received)
                 TimerID=int(event[3])
-                #~ print "\tTimer #", TimerID,"callback came through."
+                #~ PtDebugPrint("\tTimer #", TimerID,"callback came through.")
 
                 if TimerID==1:
-                    print("kdshGlowInTheDark: Timer 1 Callback. Raising elevator again.")
+                    PtDebugPrint("kdshGlowInTheDark: Timer 1 Callback. Raising elevator again.")
                     xRgnBottom.clearNow(self.key)
                     rgnExitSubBtm.disable()
 
                     if not self.sceneobject.isLocallyOwned():
-                        print("\tI'm not the owner, so I'll let another client netforce raise the elevator.")
+                        PtDebugPrint("\tI'm not the owner, so I'll let another client netforce raise the elevator.")
                         return
                     else:
                         respElevUp.run(self.key)
 
                 if TimerID== 2:
-                    print("kdshGlowInTheDark: Timer 2 Callback. Clearing top Xrgn")
+                    PtDebugPrint("kdshGlowInTheDark: Timer 2 Callback. Clearing top Xrgn")
                     xRgnTop.clearNow(self.key)
                     rgnEnterSubTop.disable()
 
                 if TimerID== 3:
-                    print("kdshGlowInTheDark: Timer 3 Callback.")
+                    PtDebugPrint("kdshGlowInTheDark: Timer 3 Callback.")
                     ageSDL = PtGetAgeSDL()
                     solved = ageSDL["GlowInTheDarkSolved"][0]
                     if solved:
-                        print("\t Puzzle is still solved. Lowering Elevator again.")
+                        PtDebugPrint("\t Puzzle is still solved. Lowering Elevator again.")
                         PtAtTimeCallback(self.key,1,2) # clear Xrgn in 1 second
                         for region in objExitTop.value:
                             region.physics.suppress(1)
 
                         rgnExitSubBtm.enable()
                         if not self.sceneobject.isLocallyOwned():
-                            print("\tI'm not the owner, so I'll let another client netforce lower the elevator.")
+                            PtDebugPrint("\tI'm not the owner, so I'll let another client netforce lower the elevator.")
                             return
                         else:
                             respElevDown.run(self.key)
 
                     else:
-                        print("\t Puzzle has been reset. Leaving elevator alone at top.")
+                        PtDebugPrint("\t Puzzle has been reset. Leaving elevator alone at top.")
                         rgnEnterSubTop.disable()
                         for region in objExitTop.value:
                             region.physics.suppress(0)
                 if TimerID== 4:
-                    print("kdshGlowInTheDark: Timer 4 Callback.")
-                    print("\tkdshGlowInTheDark.OnTimer: Running from Lit to Dark.")
+                    PtDebugPrint("kdshGlowInTheDark: Timer 4 Callback.")
+                    PtDebugPrint("\tkdshGlowInTheDark.OnTimer: Running from Lit to Dark.")
                     respFloorDark.run(self.key)
                     Resetting = 0
 
@@ -343,7 +343,7 @@ class kdshGlowInTheDark(ptResponder):
         global Resetting
         ageSDL = PtGetAgeSDL()
 
-        #~ print "kdshGlowInTheDark.OnSDLNotify: Variable",VARname,"updated."
+        #~ PtDebugPrint("kdshGlowInTheDark.OnSDLNotify: Variable",VARname,"updated.")
 
 
         if VARname == "RoofClosed":
@@ -374,7 +374,7 @@ class kdshGlowInTheDark(ptResponder):
             if not Resetting:
                 return
             GlowCharged = ageSDL["GlowCharged"][0]
-            print("\tkdshGlowInTheDark.OnSDLNotify: GlowCharged now =",GlowCharged)
+            PtDebugPrint("\tkdshGlowInTheDark.OnSDLNotify: GlowCharged now =",GlowCharged)
 
             PtAtTimeCallback(self.key,6,4)
             respFloorLitFromGlow.run(self.key)
@@ -384,7 +384,7 @@ class kdshGlowInTheDark(ptResponder):
     def RecordOpenTime(self):
         ageSDL = PtGetAgeSDL()
         CurrentTime = PtGetDniTime()
-        print("kdshGlowInTheDark: The roof was opened at: ", CurrentTime)
+        PtDebugPrint("kdshGlowInTheDark: The roof was opened at: ", CurrentTime)
         ageSDL["TimeOpened"] = (CurrentTime, ) #write new state value to SDL
 
 
@@ -395,27 +395,27 @@ class kdshGlowInTheDark(ptResponder):
 
         TimeOpened = ageSDL["TimeOpened"][0]
         CurrentTime = PtGetDniTime()
-        #~ print "Though it's now closed, the roof was once opened at:", TimeOpened
-        #~ print "The roof was closed at: ", CurrentTime
+        #~ PtDebugPrint("Though it's now closed, the roof was once opened at:", TimeOpened)
+        #~ PtDebugPrint("The roof was closed at: ", CurrentTime)
 
         ElaspedTime = CurrentTime - TimeOpened
 
-        #~ print "The roof was open for:", ElaspedTime
+        #~ PtDebugPrint("The roof was open for:", ElaspedTime)
 
         if ElaspedTime > SecondsToCharge:
-            #~ print "The roof was open for:", ElaspedTime
-            print("kdshGlowInTheDark: The floor is now charged")
+            #~ PtDebugPrint("The roof was open for:", ElaspedTime)
+            PtDebugPrint("kdshGlowInTheDark: The floor is now charged")
             ageSDL["GlowCharged"] = (1, )
         else:
             pass
-            #~ print "Not enough time to charge, because"
-            #~ print "ElapsedTime = ", ElaspedTime
-            #~ print "SecondsToCharge = ", SecondsToCharge
+            #~ PtDebugPrint("Not enough time to charge, because")
+            #~ PtDebugPrint("ElapsedTime = ", ElaspedTime)
+            #~ PtDebugPrint("SecondsToCharge = ", SecondsToCharge)
 
     def BatonPassCheck(self,id,events):
         global baton
         ageSDL = PtGetAgeSDL()
-        print("##")
+        PtDebugPrint("##")
 
         for event in events:
             if event[0] == 7: # pruning a redundant event, so we only process enters and exits
@@ -423,7 +423,7 @@ class kdshGlowInTheDark(ptResponder):
 
 
             if event[1] == 1 :  #Player enters a zone
-                print("kdshGlowInTheDark: Entered Zone:", id-5)
+                PtDebugPrint("kdshGlowInTheDark: Entered Zone:", id-5)
                 if id == 6: # true as player enters start of Glow Path, effectively resetting baton setting
                     baton = 1
                 elif id == baton+6: # true if player is entering a new zone, and the "baton" is in one less zone. Progress is being made here in solving the puzzle.
@@ -431,23 +431,23 @@ class kdshGlowInTheDark(ptResponder):
 
 
             elif event[1] == 0:  # Player exits a zone
-                print(" kdshGlowInTheDark: Exited Zone:", id-5)
+                PtDebugPrint(" kdshGlowInTheDark: Exited Zone:", id-5)
                 if baton != (id-4) and baton != 0: # Correctly advancing players always enter a new zone before exiting the current one. If this progress hasn't already been made, drop the baton.
-                    print("kdshGlowInTheDark: Dropped the baton.")
+                    PtDebugPrint("kdshGlowInTheDark: Dropped the baton.")
                     baton = 0
 
                 if id == 14 and baton == 10: #if you just exited region 9, you are in region 10, and your baton is 10, you solved the puzzle
                     solved = ageSDL["GlowInTheDarkSolved"][0]
                     if not solved:
-                        print("GlowInTheDark: Puzzle solved.")
+                        PtDebugPrint("GlowInTheDark: Puzzle solved.")
                         ageSDL["GlowInTheDarkSolved"] = (1,)
                         baton = 0
                     else:
-                        print("GlowInTheDark: Yes, you completed the path, but I thought the path was already solved.")
+                        PtDebugPrint("GlowInTheDark: Yes, you completed the path, but I thought the path was already solved.")
                         return
 
                     if PtWasLocallyNotified(self.key):
-                        print("kdshGlowInTheDark: Since you solved the puzzle, putting your avatar on elevator")
+                        PtDebugPrint("kdshGlowInTheDark: Since you solved the puzzle, putting your avatar on elevator")
                         avatarInElevator = PtFindAvatar(events)
                         avatarInElevator.avatar.enterSubWorld(elevatorsubworld.value)
 
@@ -461,7 +461,7 @@ class kdshGlowInTheDark(ptResponder):
 
 
         if baton > 0:
-            print("kdshGlowInTheDark: Baton value is now:", baton)
+            PtDebugPrint("kdshGlowInTheDark: Baton value is now:", baton)
 
 
     def OnTimer(self,id):
@@ -475,7 +475,7 @@ class kdshGlowInTheDark(ptResponder):
             note.addVarNumber("foo",id)
             note.send()
 
-            #~ print "kdshGlowInTheDark: Timer 1 Callback. Raising elevator again."
+            #~ PtDebugPrint("kdshGlowInTheDark: Timer 1 Callback. Raising elevator again.")
             #~ respElevUp.run(self.key)
             #~ xRgnBottom.clearNow(self.key)
             #~ rgnExitSubBtm.disable()
@@ -483,7 +483,7 @@ class kdshGlowInTheDark(ptResponder):
         if id == 2:
 
             if not self.sceneobject.isLocallyOwned():
-                print("\tI'm not the owner, so I'll let another client tell all clients to clear top Xrgn.")
+                PtDebugPrint("\tI'm not the owner, so I'll let another client tell all clients to clear top Xrgn.")
                 return
             else:
                 note = ptNotify(self.key)
@@ -493,7 +493,7 @@ class kdshGlowInTheDark(ptResponder):
                 note.addVarNumber("foo",id)
                 note.send()
 
-            #~ print "kdshGlowInTheDark: Timer 2 Callback. Clearing top Xrgn"
+            #~ PtDebugPrint("kdshGlowInTheDark: Timer 2 Callback. Clearing top Xrgn")
             #~ xRgnTop.clearNow(self.key)
             #~ rgnEnterSubTop.disable()
         if id == 3:
@@ -504,11 +504,11 @@ class kdshGlowInTheDark(ptResponder):
             note.addVarNumber("foo",id)
             note.send()
 
-            #~ print "kdshGlowInTheDark: Timer 3 Callback."
+            #~ PtDebugPrint("kdshGlowInTheDark: Timer 3 Callback.")
             #~ ageSDL = PtGetAgeSDL()
             #~ solved = ageSDL["GlowInTheDarkSolved"][0]
             #~ if solved:
-                #~ print "\t Puzzle is still solved. Lowering Elevator again."
+                #~ PtDebugPrint("\t Puzzle is still solved. Lowering Elevator again.")
                 #~ respElevDown.run(self.key)
                 #~ PtAtTimeCallback(self.key,1,2) # clear Xrgn in 1 second
                 ##!!rgnExitSubTop.disable()
@@ -518,7 +518,7 @@ class kdshGlowInTheDark(ptResponder):
                 #~ rgnExitSubBtm.enable()
 
             #~ else:
-                #~ print "\t Puzzle has been reset. Leaving elevator alone at top."
+                #~ PtDebugPrint("\t Puzzle has been reset. Leaving elevator alone at top.")
                 #~ rgnEnterSubTop.disable()
                 #~ for region in objExitTop.value:
                     #~ region.physics.suppress(0)
@@ -530,11 +530,11 @@ class kdshGlowInTheDark(ptResponder):
             note.addVarNumber("foo",id)
             note.send()
 
-            #~ print "kdshGlowInTheDark: Timer 4 Callback."
-            #~ print "\tkdshGlowInTheDark.OnTimer: Running from Lit to Dark."
+            #~ PtDebugPrint("kdshGlowInTheDark: Timer 4 Callback.")
+            #~ PtDebugPrint("\tkdshGlowInTheDark.OnTimer: Running from Lit to Dark.")
             #~ respFloorDark.run(self.key)
             #~ Resetting = 0
 
         if id == 5:
-            print("kdshGlowInTheDark: It's been one second. FF'ing floor to glow state.")
+            PtDebugPrint("kdshGlowInTheDark: It's been one second. FF'ing floor to glow state.")
             respFloorGlow.run(self.key,fastforward=1)

--- a/Python/kdshGlowInTheDark.py
+++ b/Python/kdshGlowInTheDark.py
@@ -113,12 +113,12 @@ class kdshGlowInTheDark(ptResponder):
 
         version = 10
         self.version = version
-        print "__init__kdshGlowInTheDark v.", version,".5"
+        print("__init__kdshGlowInTheDark v.", version,".5")
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print "kdshGlowInTheDark:\tERROR---Cannot find the Kadish Age SDL"
+            print("kdshGlowInTheDark:\tERROR---Cannot find the Kadish Age SDL")
             #ageSDL["RoofClosed"] = (1, )
             #ageSDL["GlowCharged"] = (0, )
             #ageSDL["TimeOpened"] = (0, )
@@ -143,32 +143,32 @@ class kdshGlowInTheDark(ptResponder):
         GlowCharged = ageSDL["GlowCharged"][0]
         solved = ageSDL["GlowInTheDarkSolved"][0]
 
-        print "kdshGlowInTheDark: When I got here:"
+        print("kdshGlowInTheDark: When I got here:")
 
         if not RoofClosed:
-            print "\tThe roof was open when I got here."
+            print("\tThe roof was open when I got here.")
             respFloorLitFromGlow.run(self.key,fastforward=1)
         else:
-            print "\tThe roof is still closed."
+            print("\tThe roof is still closed.")
 
         if RoofClosed and GlowCharged:
-            print "\tThe floor was glowing when I got here."
+            print("\tThe floor was glowing when I got here.")
             PtAtTimeCallback(self.key,1,5)
             #~ respFloorGlow.run(self.key,fastforward=1)
         else:
-            print "\tThe floor is not charged."
+            print("\tThe floor is not charged.")
 
         if solved:
-            print "\tThe puzzle was solved."
-            print "\tThere are", len(PtGetPlayerList()), " other players in this Kadish instance."
+            print("\tThe puzzle was solved.")
+            print("\tThere are", len(PtGetPlayerList()), " other players in this Kadish instance.")
             if len(PtGetPlayerList()) == 0:
-                print "\t I'm alone, so I'm starting the elevator."
+                print("\t I'm alone, so I'm starting the elevator.")
                 respElevDown.run(self.key)
                 PtAtTimeCallback(self.key,3,2) # clear xRgn at top
             else:
-                print "\t Someone else was already in this Kadish instance. Depending on Overriding HighSDL component to synch elevator."
+                print("\t Someone else was already in this Kadish instance. Depending on Overriding HighSDL component to synch elevator.")
         else:
-            print "\t The puzzle has not been solved. Putting elevator at the top."
+            print("\t The puzzle has not been solved. Putting elevator at the top.")
             respElevUp.run(self.key, fastforward=True)
 
 
@@ -189,41 +189,41 @@ class kdshGlowInTheDark(ptResponder):
             return
 
         elif id == respButtonOneshot.id and OnlyOneOwner.sceneobject.isLocallyOwned():
-            print "##"
+            print("##")
             oldstate = ageSDL["RoofClosed"][0] # 1 is closed, 0 is open
 
             if oldstate == 1: # roof was previously closed
-                print "kdshGlowInTheDark: The roof is now open."
+                print("kdshGlowInTheDark: The roof is now open.")
                 self.RecordOpenTime()
 
                 GlowCharged = ageSDL["GlowCharged"][0]
-                print "kdshGlowInTheDark: GlowCharged = ", GlowCharged
+                print("kdshGlowInTheDark: GlowCharged = ", GlowCharged)
                 #~ if GlowCharged:
                     #~ respFloorLitFromGlow.run(self.key)
                 #~ else:
                     #~ respFloorLitFromDark.run(self.key)
 
             elif oldstate == 0: # roof was previously open
-                print "kdshGlowInTheDark: The roof is now closed."
+                print("kdshGlowInTheDark: The roof is now closed.")
                 self.CalculateTimeOpen()
                 #~ respFloorDark.run(self.key)
 
             else:
-                print "kdshGlowInTheDark: Unexpected roof state: (%s)" % newstate
+                print("kdshGlowInTheDark: Unexpected roof state: (%s)" % newstate)
 
             newstate =  abs(oldstate-1) # toggle roof state value
             ageSDL["RoofClosed"] = (newstate, ) #write new state value to SDL
             return
 
         elif id == respElevDown.id:
-            print "kdshGlowInTheDark: The elevator has reached the bottom."
+            print("kdshGlowInTheDark: The elevator has reached the bottom.")
             PtAtTimeCallback(self.key,ElevatorDelay,1) # wait 10 seconds, then raise elevator again
             xRgnBottom.releaseNow(self.key)
             rgnEnterSubBtm.enable()
             return
 
         elif id == respElevUp.id:
-            print "kdshGlowInTheDark: The elevator has reached the top."
+            print("kdshGlowInTheDark: The elevator has reached the top.")
             PtAtTimeCallback(self.key,ElevatorDelay,3) # wait 10 seconds, then lower elevator again
             xRgnTop.releaseNow(self.key)
             rgnEnterSubTop.enable()
@@ -239,20 +239,20 @@ class kdshGlowInTheDark(ptResponder):
         elif id == 16:  # The Entire Floor Zone
             for event in events:
                 if event[0] == 1 and event[1] == 1:
-                    print "kdshGlowInTheDark: A second player stepped on floor."
+                    print("kdshGlowInTheDark: A second player stepped on floor.")
                     baton = 0
                 elif event[0] == 1:
-                    print "kdshGlowInTheDark: Floor unoccupied."
+                    print("kdshGlowInTheDark: Floor unoccupied.")
             return
 
         elif id == actResetBtn.id:
-            print "kdshGlowInTheDark Reset Button clicked."
+            print("kdshGlowInTheDark Reset Button clicked.")
             Resetting = 1
             respResetBtn.run(self.key,events=events)
             return
 
         elif id == respResetBtn.id and OnlyOneOwner.sceneobject.isLocallyOwned():
-            print "kdshGlowInTheDark Reset Button Pushed. Puzzle resetting."
+            print("kdshGlowInTheDark Reset Button Pushed. Puzzle resetting.")
 
             ageSDL["RoofClosed"] = (1, )
             ageSDL["GlowCharged"] = (0, )
@@ -267,23 +267,23 @@ class kdshGlowInTheDark(ptResponder):
         elif PtGetLocalAvatar() == PtFindAvatar(events):
             me = PtGetLocalAvatar()
             if id == rgnExitSubTop.id:
-                print "kdshGlowInTheDark: You stepped off the elevator at the top. Removing from Subworld"
+                print("kdshGlowInTheDark: You stepped off the elevator at the top. Removing from Subworld")
                 me.avatar.exitSubWorld()
                 return
 
             elif id == rgnExitSubBtm.id:
-                print "kdshGlowInTheDark: You stepped off the elevator at the btm. Removing from Subworld"
+                print("kdshGlowInTheDark: You stepped off the elevator at the btm. Removing from Subworld")
                 me.avatar.exitSubWorld()
                 return
 
             elif id == rgnEnterSubTop.id:
-                print "You stepped on the elevator at the top. Joining subworld."
+                print("You stepped on the elevator at the top. Joining subworld.")
                 #~ rgnExitSubTop.disable()
                 me.avatar.enterSubWorld(elevatorsubworld.value)
                 return
 
             elif id == rgnEnterSubBtm.id:
-                print "You stepped on the elevator at the bottom. Joining subworld."
+                print("You stepped on the elevator at the bottom. Joining subworld.")
                 rgnExitSubBtm.disable()
                 me.avatar.enterSubWorld(elevatorsubworld.value)
                 return
@@ -294,46 +294,46 @@ class kdshGlowInTheDark(ptResponder):
                 #~ print "\tTimer #", TimerID,"callback came through."
 
                 if TimerID==1:
-                    print "kdshGlowInTheDark: Timer 1 Callback. Raising elevator again."
+                    print("kdshGlowInTheDark: Timer 1 Callback. Raising elevator again.")
                     xRgnBottom.clearNow(self.key)
                     rgnExitSubBtm.disable()
 
                     if not self.sceneobject.isLocallyOwned():
-                        print "\tI'm not the owner, so I'll let another client netforce raise the elevator."
+                        print("\tI'm not the owner, so I'll let another client netforce raise the elevator.")
                         return
                     else:
                         respElevUp.run(self.key)
 
                 if TimerID== 2:
-                    print "kdshGlowInTheDark: Timer 2 Callback. Clearing top Xrgn"
+                    print("kdshGlowInTheDark: Timer 2 Callback. Clearing top Xrgn")
                     xRgnTop.clearNow(self.key)
                     rgnEnterSubTop.disable()
 
                 if TimerID== 3:
-                    print "kdshGlowInTheDark: Timer 3 Callback."
+                    print("kdshGlowInTheDark: Timer 3 Callback.")
                     ageSDL = PtGetAgeSDL()
                     solved = ageSDL["GlowInTheDarkSolved"][0]
                     if solved:
-                        print "\t Puzzle is still solved. Lowering Elevator again."
+                        print("\t Puzzle is still solved. Lowering Elevator again.")
                         PtAtTimeCallback(self.key,1,2) # clear Xrgn in 1 second
                         for region in objExitTop.value:
                             region.physics.suppress(1)
 
                         rgnExitSubBtm.enable()
                         if not self.sceneobject.isLocallyOwned():
-                            print "\tI'm not the owner, so I'll let another client netforce lower the elevator."
+                            print("\tI'm not the owner, so I'll let another client netforce lower the elevator.")
                             return
                         else:
                             respElevDown.run(self.key)
 
                     else:
-                        print "\t Puzzle has been reset. Leaving elevator alone at top."
+                        print("\t Puzzle has been reset. Leaving elevator alone at top.")
                         rgnEnterSubTop.disable()
                         for region in objExitTop.value:
                             region.physics.suppress(0)
                 if TimerID== 4:
-                    print "kdshGlowInTheDark: Timer 4 Callback."
-                    print "\tkdshGlowInTheDark.OnTimer: Running from Lit to Dark."
+                    print("kdshGlowInTheDark: Timer 4 Callback.")
+                    print("\tkdshGlowInTheDark.OnTimer: Running from Lit to Dark.")
                     respFloorDark.run(self.key)
                     Resetting = 0
 
@@ -374,7 +374,7 @@ class kdshGlowInTheDark(ptResponder):
             if not Resetting:
                 return
             GlowCharged = ageSDL["GlowCharged"][0]
-            print "\tkdshGlowInTheDark.OnSDLNotify: GlowCharged now =",GlowCharged
+            print("\tkdshGlowInTheDark.OnSDLNotify: GlowCharged now =",GlowCharged)
 
             PtAtTimeCallback(self.key,6,4)
             respFloorLitFromGlow.run(self.key)
@@ -384,7 +384,7 @@ class kdshGlowInTheDark(ptResponder):
     def RecordOpenTime(self):
         ageSDL = PtGetAgeSDL()
         CurrentTime = PtGetDniTime()
-        print "kdshGlowInTheDark: The roof was opened at: ", CurrentTime
+        print("kdshGlowInTheDark: The roof was opened at: ", CurrentTime)
         ageSDL["TimeOpened"] = (CurrentTime, ) #write new state value to SDL
 
 
@@ -404,7 +404,7 @@ class kdshGlowInTheDark(ptResponder):
 
         if ElaspedTime > SecondsToCharge:
             #~ print "The roof was open for:", ElaspedTime
-            print "kdshGlowInTheDark: The floor is now charged"
+            print("kdshGlowInTheDark: The floor is now charged")
             ageSDL["GlowCharged"] = (1, )
         else:
             pass
@@ -415,7 +415,7 @@ class kdshGlowInTheDark(ptResponder):
     def BatonPassCheck(self,id,events):
         global baton
         ageSDL = PtGetAgeSDL()
-        print "##"
+        print("##")
 
         for event in events:
             if event[0] == 7: # pruning a redundant event, so we only process enters and exits
@@ -423,7 +423,7 @@ class kdshGlowInTheDark(ptResponder):
 
 
             if event[1] == 1 :  #Player enters a zone
-                print "kdshGlowInTheDark: Entered Zone:", id-5
+                print("kdshGlowInTheDark: Entered Zone:", id-5)
                 if id == 6: # true as player enters start of Glow Path, effectively resetting baton setting
                     baton = 1
                 elif id == baton+6: # true if player is entering a new zone, and the "baton" is in one less zone. Progress is being made here in solving the puzzle.
@@ -431,23 +431,23 @@ class kdshGlowInTheDark(ptResponder):
 
 
             elif event[1] == 0:  # Player exits a zone
-                print " kdshGlowInTheDark: Exited Zone:", id-5
+                print(" kdshGlowInTheDark: Exited Zone:", id-5)
                 if baton != (id-4) and baton != 0: # Correctly advancing players always enter a new zone before exiting the current one. If this progress hasn't already been made, drop the baton.
-                    print "kdshGlowInTheDark: Dropped the baton."
+                    print("kdshGlowInTheDark: Dropped the baton.")
                     baton = 0
 
                 if id == 14 and baton == 10: #if you just exited region 9, you are in region 10, and your baton is 10, you solved the puzzle
                     solved = ageSDL["GlowInTheDarkSolved"][0]
                     if not solved:
-                        print "GlowInTheDark: Puzzle solved."
+                        print("GlowInTheDark: Puzzle solved.")
                         ageSDL["GlowInTheDarkSolved"] = (1,)
                         baton = 0
                     else:
-                        print "GlowInTheDark: Yes, you completed the path, but I thought the path was already solved."
+                        print("GlowInTheDark: Yes, you completed the path, but I thought the path was already solved.")
                         return
 
                     if PtWasLocallyNotified(self.key):
-                        print "kdshGlowInTheDark: Since you solved the puzzle, putting your avatar on elevator"
+                        print("kdshGlowInTheDark: Since you solved the puzzle, putting your avatar on elevator")
                         avatarInElevator = PtFindAvatar(events)
                         avatarInElevator.avatar.enterSubWorld(elevatorsubworld.value)
 
@@ -461,7 +461,7 @@ class kdshGlowInTheDark(ptResponder):
 
 
         if baton > 0:
-            print "kdshGlowInTheDark: Baton value is now:", baton
+            print("kdshGlowInTheDark: Baton value is now:", baton)
 
 
     def OnTimer(self,id):
@@ -483,7 +483,7 @@ class kdshGlowInTheDark(ptResponder):
         if id == 2:
 
             if not self.sceneobject.isLocallyOwned():
-                print "\tI'm not the owner, so I'll let another client tell all clients to clear top Xrgn."
+                print("\tI'm not the owner, so I'll let another client tell all clients to clear top Xrgn.")
                 return
             else:
                 note = ptNotify(self.key)
@@ -536,5 +536,5 @@ class kdshGlowInTheDark(ptResponder):
             #~ Resetting = 0
 
         if id == 5:
-            print "kdshGlowInTheDark: It's been one second. FF'ing floor to glow state."
+            print("kdshGlowInTheDark: It's been one second. FF'ing floor to glow state.")
             respFloorGlow.run(self.key,fastforward=1)

--- a/Python/kdshPillarRoom.py
+++ b/Python/kdshPillarRoom.py
@@ -141,14 +141,14 @@ class kdshPillarRoom(ptResponder):
         
         version = 19
         self.version = version 
-        print("__init__kdshPillarRoom v.", version,".1")
+        PtDebugPrint("__init__kdshPillarRoom v.", version,".1")
 
     def OnServerInitComplete(self):
         global PillarRoomSolvedCheck
 
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print("kdshPillarRoom.OnFirstUpdate():\tERROR---missing SDL (%s)") 
+            PtDebugPrint("kdshPillarRoom.OnFirstUpdate():\tERROR---missing SDL (%s)") 
             return
             
         ageSDL.sendToClients("pheight01")
@@ -180,30 +180,30 @@ class kdshPillarRoom(ptResponder):
         ageSDL.setNotify(self.key,"PillarRoomSolved",0.0)
         ageSDL.setNotify(self.key,"PillarsResetting",0.0)
         
-        print("kdshPillarRoom: When I got here:")
+        PtDebugPrint("kdshPillarRoom: When I got here:")
         # initialize pillar whatnots based on SDL state
         pillar = 1
         for pillar in [1,2,3,4]:
             
             currentheight = ageSDL["pheight0" + str(pillar)][0]  
-            print("\t pheight0%s = %s " % (pillar, currentheight))
+            PtDebugPrint("\t pheight0%s = %s " % (pillar, currentheight))
             
             if currentheight > 0:
                 
                 PillarAnim.byObject["pillar0" + str(pillar)].skipToTime(currentheight * 10)
                 #~ PillarCamBlocker.byObject["pillar0" + str(pillar) + "Collision"].skipToTime(currentheight * 10)
                 
-                #~ print "\t\tUpdating ladderboxes because of pillar #", pillar, " initial state"
+                #~ PtDebugPrint("\t\tUpdating ladderboxes because of pillar #", pillar, " initial state")
                 self.EnableAppropriateLadders(pillar)
 
-        print("\t budget = ", ageSDL["budget"][0])
+        PtDebugPrint("\t budget = ", ageSDL["budget"][0])
         CounterAnim.animation.skipToTime((8 - ageSDL["budget"][0]) * 10)
         if ageSDL["pheight01"][0] == 1 and ageSDL["pheight02"][0] == 4 and ageSDL["pheight03"][0] == 1 and ageSDL["pheight04"][0] == 2 and ageSDL["PillarRoomSolved"][0] != 1: # true if puzzle correct
             #hopefully, this will make sure that the solution is set to solved in case they weren't
             PillarRoomSolvedCheck = 1
             ageSDL["PillarRoomSolved"] = (1,)
 
-        print("\t PillarRoomSolved = ", ageSDL["PillarRoomSolved"][0])
+        PtDebugPrint("\t PillarRoomSolved = ", ageSDL["PillarRoomSolved"][0])
         if ageSDL["PillarRoomSolved"][0] == 1:
             SolutionResp.run(self.key, fastforward=1)
 
@@ -216,7 +216,7 @@ class kdshPillarRoom(ptResponder):
         global PullsInProgress
         
         ageSDL = PtGetAgeSDL()
-        #~ print "kdshPilllarRoom:OnNotify  state=%f id=%d events=" % (state,id),events        
+        #~ PtDebugPrint("kdshPilllarRoom:OnNotify  state=%f id=%d events=" % (state,id),events)
 
         if id in [1,2,3,4,5]: # One of the four levers or the reset ring were clicked by a player
             code = "respLever0" + str(id) + ".run(self.key, events=events)"
@@ -225,16 +225,16 @@ class kdshPillarRoom(ptResponder):
 
         elif id in [6,7,8,9] and OnlyOneOwner.sceneobject.isLocallyOwned(): # One of the four levers actually pulled by an avatar
             if Resetting:
-                print("Lever pull ignored because the puzzle is still resetting.")
+                PtDebugPrint("Lever pull ignored because the puzzle is still resetting.")
                 return
             
             if (self.PillarIsSafeToMove(id)): #check to see if a climber is in the way of this pillar being rased
                 
                 if ageSDL["budget"][0] == 0: # true if 8 "raises" have already happened
-                    print("Counterweight expired.\n")
+                    PtDebugPrint("Counterweight expired.\n")
     
                 elif ageSDL["pheight0" + str(id-5)][0] == 4: # True if that particular pillar has already been raised 4 times
-                    print("Pillar0%d is already at maximum height." % (id-5))
+                    PtDebugPrint("Pillar0%d is already at maximum height." % (id-5))
     
                 else:                 
                     newheight = ageSDL["pheight0" + str(id-5)][0] + 1
@@ -243,7 +243,7 @@ class kdshPillarRoom(ptResponder):
     
                     newbudget = ageSDL["budget"][0] - 1
                     ageSDL["budget"] = (newbudget, )
-                    print("%d pulls left" % (newbudget))
+                    PtDebugPrint("%d pulls left" % (newbudget))
             else:
                 RedLight.run(self.key)
             return
@@ -256,7 +256,7 @@ class kdshPillarRoom(ptResponder):
                 return
             
             if PullsInProgress > 0:
-                print("Can't reset now. PullsInProgress = ", PullsInProgress)
+                PtDebugPrint("Can't reset now. PullsInProgress = ", PullsInProgress)
                 return
             
             safetoreset = True
@@ -265,11 +265,11 @@ class kdshPillarRoom(ptResponder):
                 if (self.PillarIsSafeToMove(pillarcheck)):
                     pass
                 else:
-                    print("kdshPillar.OnNotify: A reset button was pushed, but Pillar", pillarcheck-4, "can't reset now.")
+                    PtDebugPrint("kdshPillar.OnNotify: A reset button was pushed, but Pillar", pillarcheck-4, "can't reset now.")
                     safetoreset = False
                     
             if safetoreset:
-                print("kdshShadowPath Reset Button Pushed.")
+                PtDebugPrint("kdshShadowPath Reset Button Pushed.")
                 self.ResetPuzzle()
             return
 
@@ -277,30 +277,30 @@ class kdshPillarRoom(ptResponder):
             return
 
         elif id >= 18 and id <=28 and PtWasLocallyNotified(self.key):
-            print("Ladderbox %s entered." % ( id- 17))
+            PtDebugPrint("Ladderbox %s entered." % ( id- 17))
             
             LocalAvatar = PtFindAvatar(events)
 
             code = "MultiStage" + str(id-17) + ".run(LocalAvatar)"
-            #~ print "code = ", code
+            #~ PtDebugPrint("code = ", code)
             exec(code) 
             
             return
         
         elif id == SolutionLadderBtm.id and PtWasLocallyNotified(self.key):
-            print("Solution Ladder mounted from bottom.")
+            PtDebugPrint("Solution Ladder mounted from bottom.")
             LocalAvatar = PtFindAvatar(events)
             MultiSolutionBtm.run(LocalAvatar)
             return
             
         elif id == SolutionLadderTop.id and PtWasLocallyNotified(self.key):
-            print("Solution Ladder mounted from top.")            
+            PtDebugPrint("Solution Ladder mounted from top.")            
             LocalAvatar = PtFindAvatar(events)            
             MultiSolutionTop.run(LocalAvatar)
             return
 
         elif id == actResetBtn.id:
-            print("kdshPillarRoom Reset Button clicked.")
+            PtDebugPrint("kdshPillarRoom Reset Button clicked.")
             LocalAvatar = PtFindAvatar(events)
             respResetBtn.run(self.key,events=events)
             return
@@ -338,7 +338,7 @@ class kdshPillarRoom(ptResponder):
         
         elif VARname == "PillarsResetting":
             Resetting = ageSDL["PillarsResetting"][0]
-            print("kdshPillarRoom.OnSDLNotify: Resetting =",Resetting)
+            PtDebugPrint("kdshPillarRoom.OnSDLNotify: Resetting =",Resetting)
             
             if Resetting:
                 
@@ -355,7 +355,7 @@ class kdshPillarRoom(ptResponder):
                     sumofpulls=sumofpulls + thisheight
                     if thisheight > highest:
                         highest = thisheight
-                print("The highest pillar when you reset was ", highest," notches high.")
+                PtDebugPrint("The highest pillar when you reset was ", highest," notches high.")
                 
                 if highest != 0:
                     PtAtTimeCallback(self.key,5*highest,6) #disable everything until all the pillars are down
@@ -388,7 +388,7 @@ class kdshPillarRoom(ptResponder):
                         
                         
                     ageSDL["pheight0" + str(count)] = (0,)                
-                    print("Pillar0%d height is now: %d" % (count, ageSDL["pheight0" +str(count)][0]))                
+                    PtDebugPrint("Pillar0%d height is now: %d" % (count, ageSDL["pheight0" +str(count)][0]))                
      
                     
             return
@@ -400,7 +400,7 @@ class kdshPillarRoom(ptResponder):
             if newpheight == 0: # if height is now 0, don't move it with RaiseAPillar, because ResetPuzzle has already taken care of it
                 return
                 
-            #~ print "OnSDLNotify: Pillar # %d was updated" % (id)
+            #~ PtDebugPrint("OnSDLNotify: Pillar # %d was updated" % (id))
             self.RaiseAPillar(id)
             self.LowerCounterweight()
             self.CheckSolution(playerID)
@@ -415,16 +415,16 @@ class kdshPillarRoom(ptResponder):
             ageSDL["PillarsOccupied"] = (0,)
             ageSDL["PillarsResetting"] = (0,)
         else:
-            print("kdshPillar.Load: I'm not alone in Kadish. Leaving Ladder SDLs as they previously were.")
+            PtDebugPrint("kdshPillar.Load: I'm not alone in Kadish. Leaving Ladder SDLs as they previously were.")
 
     def PillarIsSafeToMove(self,id):
         ageSDL = PtGetAgeSDL() 
 
         if ageSDL["PillarsOccupied"][0]:
-            print("PillarIsSafeToMove: Can't do that now. Someone is on a pillar.")
+            PtDebugPrint("PillarIsSafeToMove: Can't do that now. Someone is on a pillar.")
             return False
         else:
-            #~ print "PillarIsSafeToMove: Pillar",id-5,"is OK to move now."
+            #~ PtDebugPrint("PillarIsSafeToMove: Pillar",id-5,"is OK to move now.")
             return True
 
     def RaiseAPillar(self,id):
@@ -443,8 +443,8 @@ class kdshPillarRoom(ptResponder):
         code = "respSfxRaisePillar0" + str(id) + ".run(self.key)"
         exec(code)
         
-        print("\n##")
-        print("Pillar0%d height is now: %d" % (id, ageSDL["pheight0" + str(id)][0]))
+        PtDebugPrint("\n##")
+        PtDebugPrint("Pillar0%d height is now: %d" % (id, ageSDL["pheight0" + str(id)][0]))
 
     def LowerCounterweight(self):
         global PullsInProgress
@@ -454,25 +454,25 @@ class kdshPillarRoom(ptResponder):
         PullsInProgress = PullsInProgress + 1
 
         CounterAnim.value.speed(PullsInProgress) # lower counterweights faster, because two pillars are in motion.
-        #~ print "\tCounterweight lowering at speed of ", PullsInProgress,"x"
+        #~ PtDebugPrint("\tCounterweight lowering at speed of ", PullsInProgress,"x")
         
         rangeend = (8 - ageSDL["budget"][0]) * 10
-        #~ print "\t Lowering counterweight to: (rangeend)", rangeend
+        #~ PtDebugPrint("\t Lowering counterweight to: (rangeend)", rangeend)
         CounterAnim.animation.playToTime(rangeend)
 
     def CheckSolution(self,pullerID):
         ageSDL = PtGetAgeSDL()
         
         if ageSDL["pheight01"][0] == 1 and ageSDL["pheight02"][0] == 4 and ageSDL["pheight03"][0] == 1 and ageSDL["pheight04"][0] == 2: # true if puzzle correct
-            print("kdshPillarRoom: Puzzle solved. \n")
+            PtDebugPrint("kdshPillarRoom: Puzzle solved. \n")
             PtAtTimeCallback(self.key,10,5)  # 10 second delay before lowering solution rings
 
             #run the solution cam, but only for the person who pulled the final lever
             avatar = PtGetLocalAvatar()   
             myID = PtGetClientIDFromAvatarKey(avatar.getKey())
-            print("kdshPillarRoom.CheckSolution: pullerID=", pullerID,"myID=",myID)
+            PtDebugPrint("kdshPillarRoom.CheckSolution: pullerID=", pullerID,"myID=",myID)
             if myID == pullerID:
-                print("\tI pulled the final lever. Playing solution cam.")
+                PtDebugPrint("\tI pulled the final lever. Playing solution cam.")
                 
                 # Disable First Person Camera
                 cam = ptCamera()
@@ -482,20 +482,20 @@ class kdshPillarRoom(ptResponder):
                 respSolutionCam.run(self.key)
                 
             else:
-                print("\tI did not pull the final lever.")
+                PtDebugPrint("\tI did not pull the final lever.")
  
             
     def ResetPuzzle(self):
         ageSDL = PtGetAgeSDL()
         budget = ageSDL["budget"][0]
-        print("kdshPillarRoom.ResetPuzzle: budget = ", budget)
+        PtDebugPrint("kdshPillarRoom.ResetPuzzle: budget = ", budget)
         if budget != 8:
             
             ageSDL["PillarsResetting"] = (1,)
             ageSDL["PillarRoomSolved"] = (0,)
-            print("\tAt least one pillar has been raised. Resetting Pillar puzzle")
+            PtDebugPrint("\tAt least one pillar has been raised. Resetting Pillar puzzle")
         else: 
-            print("Each of the four pillars was already down. Won't reset.")
+            PtDebugPrint("Each of the four pillars was already down. Won't reset.")
             return
 
     def OnTimer(self,id):
@@ -504,7 +504,7 @@ class kdshPillarRoom(ptResponder):
         global PullsInProgress
 
         if id in [1,2,3,4]:
-            #~ print "Pillar #",id," has finished moving."
+            #~ PtDebugPrint("Pillar #",id," has finished moving.")
             self.EnableAppropriateLadders(id)
             PullsInProgress = PullsInProgress - 1
             
@@ -513,7 +513,7 @@ class kdshPillarRoom(ptResponder):
             
         elif id == 6:
             if Resetting:
-                #~ print "kdshPillarRoom: Puzzle is done resetting (caused by reset ring)"
+                #~ PtDebugPrint("kdshPillarRoom: Puzzle is done resetting (caused by reset ring)")
                 ageSDL["PillarsResetting"] = (0,)
                 Resetting = 0
 
@@ -528,13 +528,13 @@ class kdshPillarRoom(ptResponder):
         elif pillar == 4:
             ladderstodisable = [7,8,11]
         
-        #~ print "DisableAppropriateLadders: pillar = ", pillar,
-        #~ print " ladderstodisable = ", ladderstodisable
+        #~ PtDebugPrint("DisableAppropriateLadders: pillar = ", pillar,)
+        #~ PtDebugPrint(" ladderstodisable = ", ladderstodisable)
 
         for each in ladderstodisable:
             code = "Ladderbox" +str(each) + ".disable()"
             exec(code)
-            #~ print "Immediately disabling ladderbox", each
+            #~ PtDebugPrint("Immediately disabling ladderbox", each)
 
     def EnableAppropriateLadders(self,id): # when pillar is done raising, enable appropriate ladder boxes with new lengths
         ageSDL = PtGetAgeSDL()
@@ -543,17 +543,17 @@ class kdshPillarRoom(ptResponder):
         if id != 1: # true unless the first pillar was raised; Pillar #1 has no proceeding pillar
             difference01 = ageSDL["pheight0" + str(id)][0] - ageSDL["pheight0" + str(id-1)][0] # calculates difference between this and proceeding pillar
             tolerance01 = (5 - id) # Pillar01 ladder is 4 notches high, Pillar02 ladder is 3 notches high, pillar03 ladder is 2 notches high, pillar04 ladder is 1 notch high
-            #print "Ladder tolerance for proceeding pillar:", tolerance01
+            #PtDebugPrint("Ladder tolerance for proceeding pillar:", tolerance01)
             
             if difference01 >= 1: # true if this pillar is higher than proceeding pillar
-                #~ print "\nPillar0%d is %d notches higher than the proceeding pillar" % (id, difference01)
+                #~ PtDebugPrint("\nPillar0%d is %d notches higher than the proceeding pillar" % (id, difference01))
                 if difference01 > tolerance01: # true if the ladder on this pillar is out of reach from the proceeding pillar
-                    #~ print "Ascending Ladder box #%d is now disabled, since the ladder doesn't reach down that far" % (id * 2 - 1)
+                    #~ PtDebugPrint("Ascending Ladder box #%d is now disabled, since the ladder doesn't reach down that far" % (id * 2 - 1))
                     # do something to ladder box (id * 2 - 1)
                     code = "Ladderbox" + str(id * 2 - 1) + ".disable()"
                     exec(code)                    
                     
-                    #~ print "Descending Ladder box #%d is now enabled, but only to %d rungs, and then you hang." % (id + 7, (6*(5-id) - 4)) # 
+                    #~ PtDebugPrint("Descending Ladder box #%d is now enabled, but only to %d rungs, and then you hang." % (id + 7, (6*(5-id) - 4)) #)
                     # do something to ladder box (id * 2)
                     code = "Ladderbox" + str(id * 2) + ".disable()"
                     exec(code)                    
@@ -562,7 +562,7 @@ class kdshPillarRoom(ptResponder):
                     exec(code)                    
                     
                 else: # Now progression from the previous pillar can happen
-                    #~ print "Ascending Ladder box #%d enabled with %d rungs." % (id * 2 - 1, 6 * difference01 - 4)
+                    #~ PtDebugPrint("Ascending Ladder box #%d enabled with %d rungs." % (id * 2 - 1, 6 * difference01 - 4))
                     # do something to ladder box (id * 2 - 1)
                     code = "Ladderbox" + str(id * 2 - 1) + ".enable()"
                     exec(code)
@@ -571,7 +571,7 @@ class kdshPillarRoom(ptResponder):
 
 
 
-                    #~ print "Descending Ladder box #%d enabled with %d rungs." % (id * 2, 6 * difference01 - 4)
+                    #~ PtDebugPrint("Descending Ladder box #%d enabled with %d rungs." % (id * 2, 6 * difference01 - 4))
                     # do something to ladder box (id * 2)
                     code = "Ladderbox" + str(id * 2) + ".enable()"
                     exec(code)
@@ -585,7 +585,7 @@ class kdshPillarRoom(ptResponder):
                     
                     
             else:
-                #~ print "\nPillar0%d is level with or below the proceeding pillar." % (id)
+                #~ PtDebugPrint("\nPillar0%d is level with or below the proceeding pillar." % (id))
                 code = "Ladderbox" + str(id * 2 - 1) + ".disable()"
                 exec(code)
                 code = "Ladderbox" + str(id * 2) + ".disable()"
@@ -594,18 +594,18 @@ class kdshPillarRoom(ptResponder):
 
         else: # special condition for pillar01
             # do something to ladder box 1            
-            #~ print "Pillar01 is %d notches higher than ground level" % (ageSDL["pheight01"][0])
-            #~ print "Ascending Ladder box #1 is now enabled with %d rungs." % (ageSDL["pheight01"][0] * 10)
+            #~ PtDebugPrint("Pillar01 is %d notches higher than ground level" % (ageSDL["pheight01"][0]))
+            #~ PtDebugPrint("Ascending Ladder box #1 is now enabled with %d rungs." % (ageSDL["pheight01"][0] * 10))
             rungs = 6 * (ageSDL["pheight01"][0]) - 4
-            #~ print "Ladderbox1 rungs = ", rungs
+            #~ PtDebugPrint("Ladderbox1 rungs = ", rungs)
             MultiStage1.setLoopCount(1,rungs)
             Ladderbox1.enable()
             
             
-            #~ print "Descending Ladder box #2 is now enabled with %d rungs." % (ageSDL["pheight01"][0] * 10)
+            #~ PtDebugPrint("Descending Ladder box #2 is now enabled with %d rungs." % (ageSDL["pheight01"][0] * 10))
             # do something to ladder box 2
             rungs = 6 * (ageSDL["pheight01"][0]) - 4
-            #~ print "Ladderbox2 rungs = ", rungs
+            #~ PtDebugPrint("Ladderbox2 rungs = ", rungs)
             MultiStage2.setLoopCount(1,rungs)            
             Ladderbox2.enable()            
             
@@ -616,14 +616,14 @@ class kdshPillarRoom(ptResponder):
             tolerance02 = (5 - (id+1)) # Pillar01 ladder is 4 notches high, Pillar02 ladder is 3 notches high, pillar03 ladder is 2 notches high, pillar04 is 1 notch high. Note that we're concerned about the NEXT pillar's ladder, hence the id+1.
  
             if difference02 >= 1:
-                #~ print "\nPillar0%d is %d notches lower than the following pillar" % (id, difference02)
+                #~ PtDebugPrint("\nPillar0%d is %d notches lower than the following pillar" % (id, difference02))
                 if difference02 > tolerance02: # true if the next pillar's ladder is out of reach from this pillar
-                    #~ print "Ascending Ladder box #%d is now disabled, since the ladder doesn't reach down that far" % (id * 2 + 1)
+                    #~ PtDebugPrint("Ascending Ladder box #%d is now disabled, since the ladder doesn't reach down that far" % (id * 2 + 1))
                     #do something to ladder box (id * 2 + 1)
                     code = "Ladderbox" + str(id * 2 + 1) + ".disable()"
                     exec(code)
                     
-                    #~ print "Descending Ladder box #%d is enabled, but only down %d rungs, and then you hang." % (id + 8, (6 *(4-id) - 4)) # "4 - id" here same as "(5 - (id+1))"
+                    #~ PtDebugPrint("Descending Ladder box #%d is enabled, but only down %d rungs, and then you hang." % (id + 8, (6 *(4-id) - 4)) # "4 - id" here same as "(5 - (id+1))")
                     # do something to ladder box (id * 2 + 2)
                     code = "Ladderbox" + str(id * 2 + 2) + ".disable()"
                     exec(code)
@@ -634,7 +634,7 @@ class kdshPillarRoom(ptResponder):
 
                     
                 else: # Now progression to the following pillar can happen
-                    #~ print "Ascending Ladder box #%d enabled with %d rungs." % (id * 2 + 1, 6 * difference02 - 4)
+                    #~ PtDebugPrint("Ascending Ladder box #%d enabled with %d rungs." % (id * 2 + 1, 6 * difference02 - 4))
                     # do something to ladder box (id * 2 + 1)
                     code = "Ladderbox" + str(id * 2 + 1) + ".enable()"
                     exec(code)
@@ -642,7 +642,7 @@ class kdshPillarRoom(ptResponder):
                     exec(code)                    
                     
                     
-                    #~ print "Descending Ladder box #%d enabled with %d rungs." % (id * 2 + 2, 6 * difference02 -4)
+                    #~ PtDebugPrint("Descending Ladder box #%d enabled with %d rungs." % (id * 2 + 2, 6 * difference02 -4))
                     # do something to ladder box (id * 2 + 2)
                     code = "Ladderbox" + str(id * 2 + 2) + ".enable()"
                     exec(code)
@@ -654,9 +654,9 @@ class kdshPillarRoom(ptResponder):
                     exec(code)
 
             else:
-                #~ print "\nPillar0%d is level with or above the following pillar" % (id)
+                #~ PtDebugPrint("\nPillar0%d is level with or above the following pillar" % (id))
                 pass
                 
         else: #special condition for pillar04
             if ageSDL["pheight04"][0] == 4:
-                print("Pillar04 has reached the red herring door")
+                PtDebugPrint("Pillar04 has reached the red herring door")

--- a/Python/kdshPillarRoom.py
+++ b/Python/kdshPillarRoom.py
@@ -141,14 +141,14 @@ class kdshPillarRoom(ptResponder):
         
         version = 19
         self.version = version 
-        print "__init__kdshPillarRoom v.", version,".1"
+        print("__init__kdshPillarRoom v.", version,".1")
 
     def OnServerInitComplete(self):
         global PillarRoomSolvedCheck
 
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print "kdshPillarRoom.OnFirstUpdate():\tERROR---missing SDL (%s)" 
+            print("kdshPillarRoom.OnFirstUpdate():\tERROR---missing SDL (%s)") 
             return
             
         ageSDL.sendToClients("pheight01")
@@ -180,13 +180,13 @@ class kdshPillarRoom(ptResponder):
         ageSDL.setNotify(self.key,"PillarRoomSolved",0.0)
         ageSDL.setNotify(self.key,"PillarsResetting",0.0)
         
-        print "kdshPillarRoom: When I got here:"
+        print("kdshPillarRoom: When I got here:")
         # initialize pillar whatnots based on SDL state
         pillar = 1
         for pillar in [1,2,3,4]:
             
             currentheight = ageSDL["pheight0" + str(pillar)][0]  
-            print "\t pheight0%s = %s " % (pillar, currentheight)
+            print("\t pheight0%s = %s " % (pillar, currentheight))
             
             if currentheight > 0:
                 
@@ -196,14 +196,14 @@ class kdshPillarRoom(ptResponder):
                 #~ print "\t\tUpdating ladderboxes because of pillar #", pillar, " initial state"
                 self.EnableAppropriateLadders(pillar)
 
-        print "\t budget = ", ageSDL["budget"][0]
+        print("\t budget = ", ageSDL["budget"][0])
         CounterAnim.animation.skipToTime((8 - ageSDL["budget"][0]) * 10)
         if ageSDL["pheight01"][0] == 1 and ageSDL["pheight02"][0] == 4 and ageSDL["pheight03"][0] == 1 and ageSDL["pheight04"][0] == 2 and ageSDL["PillarRoomSolved"][0] != 1: # true if puzzle correct
             #hopefully, this will make sure that the solution is set to solved in case they weren't
             PillarRoomSolvedCheck = 1
             ageSDL["PillarRoomSolved"] = (1,)
 
-        print "\t PillarRoomSolved = ", ageSDL["PillarRoomSolved"][0]
+        print("\t PillarRoomSolved = ", ageSDL["PillarRoomSolved"][0])
         if ageSDL["PillarRoomSolved"][0] == 1:
             SolutionResp.run(self.key, fastforward=1)
 
@@ -220,21 +220,21 @@ class kdshPillarRoom(ptResponder):
 
         if id in [1,2,3,4,5]: # One of the four levers or the reset ring were clicked by a player
             code = "respLever0" + str(id) + ".run(self.key, events=events)"
-            exec code
+            exec(code)
             return
 
         elif id in [6,7,8,9] and OnlyOneOwner.sceneobject.isLocallyOwned(): # One of the four levers actually pulled by an avatar
             if Resetting:
-                print "Lever pull ignored because the puzzle is still resetting."
+                print("Lever pull ignored because the puzzle is still resetting.")
                 return
             
             if (self.PillarIsSafeToMove(id)): #check to see if a climber is in the way of this pillar being rased
                 
                 if ageSDL["budget"][0] == 0: # true if 8 "raises" have already happened
-                    print "Counterweight expired.\n"
+                    print("Counterweight expired.\n")
     
                 elif ageSDL["pheight0" + str(id-5)][0] == 4: # True if that particular pillar has already been raised 4 times
-                    print "Pillar0%d is already at maximum height." % (id-5)
+                    print("Pillar0%d is already at maximum height." % (id-5))
     
                 else:                 
                     newheight = ageSDL["pheight0" + str(id-5)][0] + 1
@@ -243,7 +243,7 @@ class kdshPillarRoom(ptResponder):
     
                     newbudget = ageSDL["budget"][0] - 1
                     ageSDL["budget"] = (newbudget, )
-                    print "%d pulls left" % (newbudget)
+                    print("%d pulls left" % (newbudget))
             else:
                 RedLight.run(self.key)
             return
@@ -256,7 +256,7 @@ class kdshPillarRoom(ptResponder):
                 return
             
             if PullsInProgress > 0:
-                print "Can't reset now. PullsInProgress = ", PullsInProgress
+                print("Can't reset now. PullsInProgress = ", PullsInProgress)
                 return
             
             safetoreset = True
@@ -265,11 +265,11 @@ class kdshPillarRoom(ptResponder):
                 if (self.PillarIsSafeToMove(pillarcheck)):
                     pass
                 else:
-                    print "kdshPillar.OnNotify: A reset button was pushed, but Pillar", pillarcheck-4, "can't reset now."
+                    print("kdshPillar.OnNotify: A reset button was pushed, but Pillar", pillarcheck-4, "can't reset now.")
                     safetoreset = False
                     
             if safetoreset:
-                print "kdshShadowPath Reset Button Pushed."
+                print("kdshShadowPath Reset Button Pushed.")
                 self.ResetPuzzle()
             return
 
@@ -277,30 +277,30 @@ class kdshPillarRoom(ptResponder):
             return
 
         elif id >= 18 and id <=28 and PtWasLocallyNotified(self.key):
-            print "Ladderbox %s entered." % ( id- 17)
+            print("Ladderbox %s entered." % ( id- 17))
             
             LocalAvatar = PtFindAvatar(events)
 
             code = "MultiStage" + str(id-17) + ".run(LocalAvatar)"
             #~ print "code = ", code
-            exec code 
+            exec(code) 
             
             return
         
         elif id == SolutionLadderBtm.id and PtWasLocallyNotified(self.key):
-            print "Solution Ladder mounted from bottom."
+            print("Solution Ladder mounted from bottom.")
             LocalAvatar = PtFindAvatar(events)
             MultiSolutionBtm.run(LocalAvatar)
             return
             
         elif id == SolutionLadderTop.id and PtWasLocallyNotified(self.key):
-            print "Solution Ladder mounted from top."            
+            print("Solution Ladder mounted from top.")            
             LocalAvatar = PtFindAvatar(events)            
             MultiSolutionTop.run(LocalAvatar)
             return
 
         elif id == actResetBtn.id:
-            print "kdshPillarRoom Reset Button clicked."
+            print("kdshPillarRoom Reset Button clicked.")
             LocalAvatar = PtFindAvatar(events)
             respResetBtn.run(self.key,events=events)
             return
@@ -338,14 +338,14 @@ class kdshPillarRoom(ptResponder):
         
         elif VARname == "PillarsResetting":
             Resetting = ageSDL["PillarsResetting"][0]
-            print "kdshPillarRoom.OnSDLNotify: Resetting =",Resetting
+            print("kdshPillarRoom.OnSDLNotify: Resetting =",Resetting)
             
             if Resetting:
                 
                 #this loop disables all ladder boxes, so the ladders can't be climbed.                
                 for count in range(1,12): 
                     code = "Ladderbox" + str(count) + ".disable()"
-                    exec code
+                    exec(code)
                     
                 #determine the height of the highest pillar so we can reset them at the same speed as the pillars reset
                 highest = 0
@@ -355,13 +355,13 @@ class kdshPillarRoom(ptResponder):
                     sumofpulls=sumofpulls + thisheight
                     if thisheight > highest:
                         highest = thisheight
-                print "The highest pillar when you reset was ", highest," notches high."
+                print("The highest pillar when you reset was ", highest," notches high.")
                 
                 if highest != 0:
                     PtAtTimeCallback(self.key,5*highest,6) #disable everything until all the pillars are down
         
                     code = "respSfxResetFromHeight" + str(highest) + ".run(self.key)"
-                    exec code
+                    exec(code)
 
                 # if the counterweights have been lowered at all, this loop resets them
                 if ageSDL["budget"][0] != 8: 
@@ -388,7 +388,7 @@ class kdshPillarRoom(ptResponder):
                         
                         
                     ageSDL["pheight0" + str(count)] = (0,)                
-                    print "Pillar0%d height is now: %d" % (count, ageSDL["pheight0" +str(count)][0])                
+                    print("Pillar0%d height is now: %d" % (count, ageSDL["pheight0" +str(count)][0]))                
      
                     
             return
@@ -415,13 +415,13 @@ class kdshPillarRoom(ptResponder):
             ageSDL["PillarsOccupied"] = (0,)
             ageSDL["PillarsResetting"] = (0,)
         else:
-            print "kdshPillar.Load: I'm not alone in Kadish. Leaving Ladder SDLs as they previously were."
+            print("kdshPillar.Load: I'm not alone in Kadish. Leaving Ladder SDLs as they previously were.")
 
     def PillarIsSafeToMove(self,id):
         ageSDL = PtGetAgeSDL() 
 
         if ageSDL["PillarsOccupied"][0]:
-            print "PillarIsSafeToMove: Can't do that now. Someone is on a pillar."
+            print("PillarIsSafeToMove: Can't do that now. Someone is on a pillar.")
             return False
         else:
             #~ print "PillarIsSafeToMove: Pillar",id-5,"is OK to move now."
@@ -441,10 +441,10 @@ class kdshPillarRoom(ptResponder):
         
         #play the sound effect for that pillar
         code = "respSfxRaisePillar0" + str(id) + ".run(self.key)"
-        exec code
+        exec(code)
         
-        print "\n##"
-        print "Pillar0%d height is now: %d" % (id, ageSDL["pheight0" + str(id)][0])
+        print("\n##")
+        print("Pillar0%d height is now: %d" % (id, ageSDL["pheight0" + str(id)][0]))
 
     def LowerCounterweight(self):
         global PullsInProgress
@@ -464,15 +464,15 @@ class kdshPillarRoom(ptResponder):
         ageSDL = PtGetAgeSDL()
         
         if ageSDL["pheight01"][0] == 1 and ageSDL["pheight02"][0] == 4 and ageSDL["pheight03"][0] == 1 and ageSDL["pheight04"][0] == 2: # true if puzzle correct
-            print "kdshPillarRoom: Puzzle solved. \n"
+            print("kdshPillarRoom: Puzzle solved. \n")
             PtAtTimeCallback(self.key,10,5)  # 10 second delay before lowering solution rings
 
             #run the solution cam, but only for the person who pulled the final lever
             avatar = PtGetLocalAvatar()   
             myID = PtGetClientIDFromAvatarKey(avatar.getKey())
-            print "kdshPillarRoom.CheckSolution: pullerID=", pullerID,"myID=",myID
+            print("kdshPillarRoom.CheckSolution: pullerID=", pullerID,"myID=",myID)
             if myID == pullerID:
-                print "\tI pulled the final lever. Playing solution cam."
+                print("\tI pulled the final lever. Playing solution cam.")
                 
                 # Disable First Person Camera
                 cam = ptCamera()
@@ -482,20 +482,20 @@ class kdshPillarRoom(ptResponder):
                 respSolutionCam.run(self.key)
                 
             else:
-                print "\tI did not pull the final lever."
+                print("\tI did not pull the final lever.")
  
             
     def ResetPuzzle(self):
         ageSDL = PtGetAgeSDL()
         budget = ageSDL["budget"][0]
-        print "kdshPillarRoom.ResetPuzzle: budget = ", budget
+        print("kdshPillarRoom.ResetPuzzle: budget = ", budget)
         if budget != 8:
             
             ageSDL["PillarsResetting"] = (1,)
             ageSDL["PillarRoomSolved"] = (0,)
-            print "\tAt least one pillar has been raised. Resetting Pillar puzzle"
+            print("\tAt least one pillar has been raised. Resetting Pillar puzzle")
         else: 
-            print "Each of the four pillars was already down. Won't reset."
+            print("Each of the four pillars was already down. Won't reset.")
             return
 
     def OnTimer(self,id):
@@ -533,7 +533,7 @@ class kdshPillarRoom(ptResponder):
 
         for each in ladderstodisable:
             code = "Ladderbox" +str(each) + ".disable()"
-            exec code
+            exec(code)
             #~ print "Immediately disabling ladderbox", each
 
     def EnableAppropriateLadders(self,id): # when pillar is done raising, enable appropriate ladder boxes with new lengths
@@ -551,45 +551,45 @@ class kdshPillarRoom(ptResponder):
                     #~ print "Ascending Ladder box #%d is now disabled, since the ladder doesn't reach down that far" % (id * 2 - 1)
                     # do something to ladder box (id * 2 - 1)
                     code = "Ladderbox" + str(id * 2 - 1) + ".disable()"
-                    exec code                    
+                    exec(code)                    
                     
                     #~ print "Descending Ladder box #%d is now enabled, but only to %d rungs, and then you hang." % (id + 7, (6*(5-id) - 4)) # 
                     # do something to ladder box (id * 2)
                     code = "Ladderbox" + str(id * 2) + ".disable()"
-                    exec code                    
+                    exec(code)                    
                     #do something to ladderbox (id + 7)
                     code = "Ladderbox" + str(id + 7) + ".enable()"
-                    exec code                    
+                    exec(code)                    
                     
                 else: # Now progression from the previous pillar can happen
                     #~ print "Ascending Ladder box #%d enabled with %d rungs." % (id * 2 - 1, 6 * difference01 - 4)
                     # do something to ladder box (id * 2 - 1)
                     code = "Ladderbox" + str(id * 2 - 1) + ".enable()"
-                    exec code
+                    exec(code)
                     code = "MultiStage" + str(id * 2 - 1) + ".setLoopCount(1," + str( 6 * difference01 - 4) + ")"
-                    exec code
+                    exec(code)
 
 
 
                     #~ print "Descending Ladder box #%d enabled with %d rungs." % (id * 2, 6 * difference01 - 4)
                     # do something to ladder box (id * 2)
                     code = "Ladderbox" + str(id * 2) + ".enable()"
-                    exec code
+                    exec(code)
                     code = "MultiStage" + str(id * 2) + ".setLoopCount(1," + str(6 * difference01 - 4) + ")"
-                    exec code
+                    exec(code)
                     
                     #disable the "hang" ladder box
                     code = "Ladderbox" + str(id + 7) + ".disable()"
-                    exec code
+                    exec(code)
 
                     
                     
             else:
                 #~ print "\nPillar0%d is level with or below the proceeding pillar." % (id)
                 code = "Ladderbox" + str(id * 2 - 1) + ".disable()"
-                exec code
+                exec(code)
                 code = "Ladderbox" + str(id * 2) + ".disable()"
-                exec code
+                exec(code)
                 
 
         else: # special condition for pillar01
@@ -621,15 +621,15 @@ class kdshPillarRoom(ptResponder):
                     #~ print "Ascending Ladder box #%d is now disabled, since the ladder doesn't reach down that far" % (id * 2 + 1)
                     #do something to ladder box (id * 2 + 1)
                     code = "Ladderbox" + str(id * 2 + 1) + ".disable()"
-                    exec code
+                    exec(code)
                     
                     #~ print "Descending Ladder box #%d is enabled, but only down %d rungs, and then you hang." % (id + 8, (6 *(4-id) - 4)) # "4 - id" here same as "(5 - (id+1))"
                     # do something to ladder box (id * 2 + 2)
                     code = "Ladderbox" + str(id * 2 + 2) + ".disable()"
-                    exec code
+                    exec(code)
                     #do something to ladderbox (id + 8)
                     code = "Ladderbox" + str(id + 8) + ".enable()"
-                    exec code                    
+                    exec(code)                    
 
 
                     
@@ -637,21 +637,21 @@ class kdshPillarRoom(ptResponder):
                     #~ print "Ascending Ladder box #%d enabled with %d rungs." % (id * 2 + 1, 6 * difference02 - 4)
                     # do something to ladder box (id * 2 + 1)
                     code = "Ladderbox" + str(id * 2 + 1) + ".enable()"
-                    exec code
+                    exec(code)
                     code = "MultiStage" + str(id * 2 + 1) + ".setLoopCount(1," + str( 6 * difference02 - 4) + ")"
-                    exec code                    
+                    exec(code)                    
                     
                     
                     #~ print "Descending Ladder box #%d enabled with %d rungs." % (id * 2 + 2, 6 * difference02 -4)
                     # do something to ladder box (id * 2 + 2)
                     code = "Ladderbox" + str(id * 2 + 2) + ".enable()"
-                    exec code
+                    exec(code)
                     code = "MultiStage" + str(id * 2 + 2) + ".setLoopCount(1," + str(6 * difference02 - 4) + ")"
-                    exec code
+                    exec(code)
                     
                     #disable the "hang" ladder box
                     code = "Ladderbox" + str(id + 8) + ".disable()"
-                    exec code
+                    exec(code)
 
             else:
                 #~ print "\nPillar0%d is level with or above the following pillar" % (id)
@@ -659,4 +659,4 @@ class kdshPillarRoom(ptResponder):
                 
         else: #special condition for pillar04
             if ageSDL["pheight04"][0] == 4:
-                print "Pillar04 has reached the red herring door"
+                print("Pillar04 has reached the red herring door")

--- a/Python/kdshShadowPath.py
+++ b/Python/kdshShadowPath.py
@@ -115,7 +115,7 @@ class kdshShadowPath(ptResponder):
 
         version = 10
         self.version = version
-        print "__init__kdshShadowPath v.", version,".2"
+        print("__init__kdshShadowPath v.", version,".2")
         
 
     def OnServerInitComplete(self):
@@ -149,31 +149,31 @@ class kdshShadowPath(ptResponder):
 
 
 
-        print "kdshShadowPath: When I got here:"
+        print("kdshShadowPath: When I got here:")
         # initialize pillar whatnots based on SDL state
         
         for light in [1,2,3,4,5]:
             
             lightstate = ageSDL["ShadowPathLight0" + str(light)][0]  
-            print "\t ShadowPathLight0%s = %s " % (light, lightstate)
+            print("\t ShadowPathLight0%s = %s " % (light, lightstate))
             
             if lightstate == 1:
                 
                 code = "respSwitch0" + str(light) + ".run(self.key,fastforward=1)"
-                exec code
+                exec(code)
                
-                print "\t\tTurning on light #", light
+                print("\t\tTurning on light #", light)
         
         solved = ageSDL["ShadowPathSolved"][0]
         if solved:
-            print "\tThe Shadow Path was already solved. Revealing stairs."
+            print("\tThe Shadow Path was already solved. Revealing stairs.")
             RevealStairs.run(self.key,fastforward=1)
                 
 
     def Load(self):
         count = 1
         while count < 5:
-            print "kdshShadowPath.Load(): ageSDL[ShadowPathLight0",count,"]=%d" % (ageSDL["ShadowPathLight0" + str(count)][0])
+            print("kdshShadowPath.Load(): ageSDL[ShadowPathLight0",count,"]=%d" % (ageSDL["ShadowPathLight0" + str(count)][0]))
             count = count + 1
 
     def OnNotify(self,state,id,events):
@@ -185,24 +185,24 @@ class kdshShadowPath(ptResponder):
         global gameStarted
         ageSDL = PtGetAgeSDL()
 
-        print "kdshShadowPath:OnNotify  state=%f id=%d events=" % (state,id),events
+        print("kdshShadowPath:OnNotify  state=%f id=%d events=" % (state,id),events)
 
 
         if id == FloorZone.id:
             if events[0][1] == 1:
-                print "kdshShadowPath.OnNotify: More than one person on the floor!"
+                print("kdshShadowPath.OnNotify: More than one person on the floor!")
                 regZoneStart.disable()
                 gameStarted = 0
             elif events[0][1] == 0:
-                print "kdshShadowPath.OnNotify: Only one person on the floor!"
+                print("kdshShadowPath.OnNotify: Only one person on the floor!")
                 regZoneStart.enable()
 
         elif id == regZoneReset.id:
             if events[0][1] == 1:
-                print "kdshShadowPath.OnNotify: Someone in the stairwell, reset disabled."
+                print("kdshShadowPath.OnNotify: Someone in the stairwell, reset disabled.")
                 actResetBtn.disable()
             elif events[0][1] == 0:
-                print "kdshShadowPath.OnNotify: No one's in the stairwell, reset enabled."
+                print("kdshShadowPath.OnNotify: No one's in the stairwell, reset enabled.")
                 actResetBtn.enable()
 
         elif id in [1,2,3,4,5]: #true if one of the five switches clicked
@@ -214,9 +214,9 @@ class kdshShadowPath(ptResponder):
                 lightClickedByAvatar = None
                 return
 
-            print "Light ", id, " clicked."
+            print("Light ", id, " clicked.")
             code = 'respBtnPush0' + str(id) + '.run(self.key,events=events)'
-            exec code
+            exec(code)
 
         elif id in [26,27,28,29,30]: 
             if lightClickedByAvatar != localAvatar:  #Make sure we don't have any rogue avatars reporting...
@@ -225,7 +225,7 @@ class kdshShadowPath(ptResponder):
 
             lightClickedByAvatar = None  #Reset avatar reporting
 
-            print "Light ", id-25, " actually touched by avatar."
+            print("Light ", id-25, " actually touched by avatar.")
             oldstate = ageSDL["ShadowPathLight0" + str(id-25)][0] 
             newstate = abs(oldstate-1) # toggle value of switch state
             ageSDL["ShadowPathLight0" + str(id-25)] = (newstate, ) # write new state value to SDL            
@@ -233,21 +233,21 @@ class kdshShadowPath(ptResponder):
 
         elif id in [regZone01.id,regZone02.id,regZone03.id,regZone04.id,regZone05.id,regZone06.id,regZone07.id,regZone08.id,regZone09.id]:
             if gameStarted:
-                print "Triggered Bad Region!"
+                print("Triggered Bad Region!")
                 gameStarted = 0
 
         elif id == regZoneStart.id:
-            print "Triggered Start Region!"
+            print("Triggered Start Region!")
             gameStarted = 1
 
         elif id == regZoneFinish.id:
             if gameStarted:
                 gameStarted = 0
-                print "kdshShadowPath: Puzzle solved."
+                print("kdshShadowPath: Puzzle solved.")
                 ageSDL["ShadowPathSolved"] = (1, ) # write new state value to SDL     
 
         elif state and id == actResetBtn.id:
-            print "kdshShadowPath Reset Button clicked."
+            print("kdshShadowPath Reset Button clicked.")
             resetBtnByAvatar = PtFindAvatar(events)
             respResetBtn.run(self.key,events=events)
             
@@ -256,7 +256,7 @@ class kdshShadowPath(ptResponder):
                 resetBtnByAvatar = None
                 return
 
-            print "kdshShadowPath Reset Button Pushed. Puzzle resetting."
+            print("kdshShadowPath Reset Button Pushed. Puzzle resetting.")
             resetBtnByAvatar = None
             
             #turn off the lights
@@ -264,10 +264,10 @@ class kdshShadowPath(ptResponder):
                 lightstate = ageSDL["ShadowPathLight0" + str(light)][0]  
                 if lightstate == 1:
                     code = 'ageSDL["ShadowPathLight0' + str(light) + '"] = (0,)'
-                    print "resetcode = ", code
-                    exec code
+                    print("resetcode = ", code)
+                    exec(code)
                         
-                    print "\tTurning off light #", light
+                    print("\tTurning off light #", light)
                     
             #...and close the floor
             ageSDL["ShadowPathSolved"] = (0,)
@@ -278,10 +278,10 @@ class kdshShadowPath(ptResponder):
         
         if VARname == "ShadowPathSolved":
             if ageSDL["ShadowPathSolved"][0] == 1:
-                print "kdshShadowPath: Opening floor"
+                print("kdshShadowPath: Opening floor")
                 RevealStairs.run(self.key)
             else:
-                print "kdshShadowPath: Closing floor"
+                print("kdshShadowPath: Closing floor")
                 ConcealStairs.run(self.key)
                 
         elif VARname[:15] == "ShadowPathLight":
@@ -292,19 +292,19 @@ class kdshShadowPath(ptResponder):
             newstate = ageSDL["ShadowPathLight0" + str(light)][0] 
 
             if newstate == 0: # true if that switch is now off
-                print "kdshShadowPath.OnSDLNotify: Light", light," was on. Turning it off."
+                print("kdshShadowPath.OnSDLNotify: Light", light," was on. Turning it off.")
                 code = "respSwitch0" + str(light) + ".run(self.key, state='off')"
                 #~ print "off code = ", code
-                exec code
+                exec(code)
                 
             elif newstate == 1: # true if that switch is now on
-                print "kdshShadowPath.OnSDLNotify: Light", light," was off. Turning it on."
+                print("kdshShadowPath.OnSDLNotify: Light", light," was off. Turning it on.")
                 code = "respSwitch0" + str(light) + ".run(self.key, state='on')"
                 #~ print "On code = ", code
-                exec code
+                exec(code)
 
             else: 
-                print "Error. Not sure what the light thought it was."
+                print("Error. Not sure what the light thought it was.")
 
 '''
     def BatonPassCheck(self,id,events,ageSDL):

--- a/Python/kdshShadowPath.py
+++ b/Python/kdshShadowPath.py
@@ -115,7 +115,7 @@ class kdshShadowPath(ptResponder):
 
         version = 10
         self.version = version
-        print("__init__kdshShadowPath v.", version,".2")
+        PtDebugPrint("__init__kdshShadowPath v.", version,".2")
         
 
     def OnServerInitComplete(self):
@@ -149,31 +149,31 @@ class kdshShadowPath(ptResponder):
 
 
 
-        print("kdshShadowPath: When I got here:")
+        PtDebugPrint("kdshShadowPath: When I got here:")
         # initialize pillar whatnots based on SDL state
         
         for light in [1,2,3,4,5]:
             
             lightstate = ageSDL["ShadowPathLight0" + str(light)][0]  
-            print("\t ShadowPathLight0%s = %s " % (light, lightstate))
+            PtDebugPrint("\t ShadowPathLight0%s = %s " % (light, lightstate))
             
             if lightstate == 1:
                 
                 code = "respSwitch0" + str(light) + ".run(self.key,fastforward=1)"
                 exec(code)
                
-                print("\t\tTurning on light #", light)
+                PtDebugPrint("\t\tTurning on light #", light)
         
         solved = ageSDL["ShadowPathSolved"][0]
         if solved:
-            print("\tThe Shadow Path was already solved. Revealing stairs.")
+            PtDebugPrint("\tThe Shadow Path was already solved. Revealing stairs.")
             RevealStairs.run(self.key,fastforward=1)
                 
 
     def Load(self):
         count = 1
         while count < 5:
-            print("kdshShadowPath.Load(): ageSDL[ShadowPathLight0",count,"]=%d" % (ageSDL["ShadowPathLight0" + str(count)][0]))
+            PtDebugPrint("kdshShadowPath.Load(): ageSDL[ShadowPathLight0",count,"]=%d" % (ageSDL["ShadowPathLight0" + str(count)][0]))
             count = count + 1
 
     def OnNotify(self,state,id,events):
@@ -185,24 +185,24 @@ class kdshShadowPath(ptResponder):
         global gameStarted
         ageSDL = PtGetAgeSDL()
 
-        print("kdshShadowPath:OnNotify  state=%f id=%d events=" % (state,id),events)
+        PtDebugPrint("kdshShadowPath:OnNotify  state=%f id=%d events=" % (state,id),events)
 
 
         if id == FloorZone.id:
             if events[0][1] == 1:
-                print("kdshShadowPath.OnNotify: More than one person on the floor!")
+                PtDebugPrint("kdshShadowPath.OnNotify: More than one person on the floor!")
                 regZoneStart.disable()
                 gameStarted = 0
             elif events[0][1] == 0:
-                print("kdshShadowPath.OnNotify: Only one person on the floor!")
+                PtDebugPrint("kdshShadowPath.OnNotify: Only one person on the floor!")
                 regZoneStart.enable()
 
         elif id == regZoneReset.id:
             if events[0][1] == 1:
-                print("kdshShadowPath.OnNotify: Someone in the stairwell, reset disabled.")
+                PtDebugPrint("kdshShadowPath.OnNotify: Someone in the stairwell, reset disabled.")
                 actResetBtn.disable()
             elif events[0][1] == 0:
-                print("kdshShadowPath.OnNotify: No one's in the stairwell, reset enabled.")
+                PtDebugPrint("kdshShadowPath.OnNotify: No one's in the stairwell, reset enabled.")
                 actResetBtn.enable()
 
         elif id in [1,2,3,4,5]: #true if one of the five switches clicked
@@ -214,7 +214,7 @@ class kdshShadowPath(ptResponder):
                 lightClickedByAvatar = None
                 return
 
-            print("Light ", id, " clicked.")
+            PtDebugPrint("Light ", id, " clicked.")
             code = 'respBtnPush0' + str(id) + '.run(self.key,events=events)'
             exec(code)
 
@@ -225,7 +225,7 @@ class kdshShadowPath(ptResponder):
 
             lightClickedByAvatar = None  #Reset avatar reporting
 
-            print("Light ", id-25, " actually touched by avatar.")
+            PtDebugPrint("Light ", id-25, " actually touched by avatar.")
             oldstate = ageSDL["ShadowPathLight0" + str(id-25)][0] 
             newstate = abs(oldstate-1) # toggle value of switch state
             ageSDL["ShadowPathLight0" + str(id-25)] = (newstate, ) # write new state value to SDL            
@@ -233,21 +233,21 @@ class kdshShadowPath(ptResponder):
 
         elif id in [regZone01.id,regZone02.id,regZone03.id,regZone04.id,regZone05.id,regZone06.id,regZone07.id,regZone08.id,regZone09.id]:
             if gameStarted:
-                print("Triggered Bad Region!")
+                PtDebugPrint("Triggered Bad Region!")
                 gameStarted = 0
 
         elif id == regZoneStart.id:
-            print("Triggered Start Region!")
+            PtDebugPrint("Triggered Start Region!")
             gameStarted = 1
 
         elif id == regZoneFinish.id:
             if gameStarted:
                 gameStarted = 0
-                print("kdshShadowPath: Puzzle solved.")
+                PtDebugPrint("kdshShadowPath: Puzzle solved.")
                 ageSDL["ShadowPathSolved"] = (1, ) # write new state value to SDL     
 
         elif state and id == actResetBtn.id:
-            print("kdshShadowPath Reset Button clicked.")
+            PtDebugPrint("kdshShadowPath Reset Button clicked.")
             resetBtnByAvatar = PtFindAvatar(events)
             respResetBtn.run(self.key,events=events)
             
@@ -256,7 +256,7 @@ class kdshShadowPath(ptResponder):
                 resetBtnByAvatar = None
                 return
 
-            print("kdshShadowPath Reset Button Pushed. Puzzle resetting.")
+            PtDebugPrint("kdshShadowPath Reset Button Pushed. Puzzle resetting.")
             resetBtnByAvatar = None
             
             #turn off the lights
@@ -264,52 +264,52 @@ class kdshShadowPath(ptResponder):
                 lightstate = ageSDL["ShadowPathLight0" + str(light)][0]  
                 if lightstate == 1:
                     code = 'ageSDL["ShadowPathLight0' + str(light) + '"] = (0,)'
-                    print("resetcode = ", code)
+                    PtDebugPrint("resetcode = ", code)
                     exec(code)
                         
-                    print("\tTurning off light #", light)
+                    PtDebugPrint("\tTurning off light #", light)
                     
             #...and close the floor
             ageSDL["ShadowPathSolved"] = (0,)
             
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()        
-        #~ print "OnSDLNotified."
+        #~ PtDebugPrint("OnSDLNotified.")
         
         if VARname == "ShadowPathSolved":
             if ageSDL["ShadowPathSolved"][0] == 1:
-                print("kdshShadowPath: Opening floor")
+                PtDebugPrint("kdshShadowPath: Opening floor")
                 RevealStairs.run(self.key)
             else:
-                print("kdshShadowPath: Closing floor")
+                PtDebugPrint("kdshShadowPath: Closing floor")
                 ConcealStairs.run(self.key)
                 
         elif VARname[:15] == "ShadowPathLight":
             light = string.atoi(VARname[-2:]) #get the last two digits, which is the light number
                 
-            #~ print "OnSDLNotify: Light ", light," SDL updated."
+            #~ PtDebugPrint("OnSDLNotify: Light ", light," SDL updated.")
                 
             newstate = ageSDL["ShadowPathLight0" + str(light)][0] 
 
             if newstate == 0: # true if that switch is now off
-                print("kdshShadowPath.OnSDLNotify: Light", light," was on. Turning it off.")
+                PtDebugPrint("kdshShadowPath.OnSDLNotify: Light", light," was on. Turning it off.")
                 code = "respSwitch0" + str(light) + ".run(self.key, state='off')"
-                #~ print "off code = ", code
+                #~ PtDebugPrint("off code = ", code)
                 exec(code)
                 
             elif newstate == 1: # true if that switch is now on
-                print("kdshShadowPath.OnSDLNotify: Light", light," was off. Turning it on.")
+                PtDebugPrint("kdshShadowPath.OnSDLNotify: Light", light," was off. Turning it on.")
                 code = "respSwitch0" + str(light) + ".run(self.key, state='on')"
-                #~ print "On code = ", code
+                #~ PtDebugPrint("On code = ", code)
                 exec(code)
 
             else: 
-                print("Error. Not sure what the light thought it was.")
+                PtDebugPrint("Error. Not sure what the light thought it was.")
 
 '''
     def BatonPassCheck(self,id,events,ageSDL):
         global baton
-        print "##"
+        PtDebugPrint("##")
 
         for event in events:
             if event[0] == 7: # pruning a redundant event, so we only process enters and exits
@@ -317,28 +317,28 @@ class kdshShadowPath(ptResponder):
                 
 
             if event[1] == 1 :  #Player enters a zone    
-                print "kdshShadowPath: Entered Zone:", id-10
+                PtDebugPrint("kdshShadowPath: Entered Zone:", id-10)
                 if id == 11: # true as player enters start of Shadow Path, effectively resetting baton setting
                     baton = 1
                 elif id == baton+11: # true if player is entering a new zone, and the "baton" is in one less zone. Progress is being made here in solving the puzzle.
                     baton = baton + 1
                     if baton == 10:
-                        print "kdshShadowPath: Puzzle solved."
+                        PtDebugPrint("kdshShadowPath: Puzzle solved.")
                         ageSDL["ShadowPathSolved"] = (1, ) # write new state value to SDL     
                 
                 elif baton != 0: # true if player stepped off the path. Must start over to solve puzzle.
                     baton = 0
-                    print "Baton dropped. \n"                    
+                    PtDebugPrint("Baton dropped. \n")
 
                     
             elif event[1] == 0:  # Player exits a zone
-                print "kdshShadowPath: Exited Zone:", id-10
+                PtDebugPrint("kdshShadowPath: Exited Zone:", id-10)
                 if baton != 0 and baton != (id-9): # Correctly advancing players always enter a new zone before exiting the current one. If this progress hasn't already been made, drop the baton.
-                    print "kdshShadowPath: Dropped the baton."
+                    PtDebugPrint("kdshShadowPath: Dropped the baton.")
                     baton = 0
 
  
         
         if baton > 0:
-            print "Baton value is now:", baton
+            PtDebugPrint("Baton value is now:", baton)
 '''

--- a/Python/kdshTreeRings.py
+++ b/Python/kdshTreeRings.py
@@ -94,16 +94,16 @@ class kdshTreeRings(ptModifier):
         
         version = 13
         self.version = version
-        print("__init__kdshTreeRings v.", version,".1")
+        PtDebugPrint("__init__kdshTreeRings v.", version,".1")
 
     def OnFirstUpdate(self):
         PtLoadDialog("kdshScope0" + str(ScopeNumber.value), self.key, "Kadish")       
-        #~ print "kdshTreeRings: Loading dialog ", ("kdshScope0" + str(ScopeNumber.value))              
+        #~ PtDebugPrint("kdshTreeRings: Loading dialog ", ("kdshScope0" + str(ScopeNumber.value)))
     """  ###Commented this out because it was never available anyway (note the 2nd defn)!!!
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print "kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value
+            PtDebugPrint("kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
       
         if ScopeNumber.value == 1:
             ageSDL.sendToClients("boolOperatedScope01")
@@ -158,24 +158,24 @@ class kdshTreeRings(ptModifier):
         MiddleRing = ageSDL["MiddleRing0" + str(ScopeNumber.value)][0]
         InnerRing = ageSDL["InnerRing0" + str(ScopeNumber.value)][0]
         
-        print("Current %s Ring settings:" % (ScopeNumber.value))
-        print("/tOuterRing: ", OuterRing)
-        print("/tMiddleRing: ", MiddleRing)
-        print("/tInnerRing: ", InnerRing)
+        PtDebugPrint("Current %s Ring settings:" % (ScopeNumber.value))
+        PtDebugPrint("/tOuterRing: ", OuterRing)
+        PtDebugPrint("/tMiddleRing: ", MiddleRing)
+        PtDebugPrint("/tInnerRing: ", InnerRing)
 
         solo = not PtGetPlayerList()
 
         boolOperated = ageSDL["boolOperatedScope0" + str(ScopeNumber.value)][0]
         if boolOperated:
             if solo:
-                print("kdshTreeRings.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated)
+                PtDebugPrint("kdshTreeRings.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated)
                 boolOperated = 0
                 ageSDL["boolOperatedScope0" + str(ScopeNumber.value)] = (0,)
                 ageSDL["OperatorIDScope0" + str(ScopeNumber.value)] = (-1,)
                 Activate.enable()
             else:
                 Activate.disable()
-                print("kdshTreeRings.Load():\tboolOperated=%d, disabling telescope clickable" % boolOperated)
+                PtDebugPrint("kdshTreeRings.Load():\tboolOperated=%d, disabling telescope clickable" % boolOperated)
         #START-->multiplayer fix
         ageSDL.sendToClients(('boolOperatedScope0' + str(ScopeNumber.value)))
         ageSDL.setFlags(('boolOperatedScope0' + str(ScopeNumber.value)), 1, 1)
@@ -208,7 +208,7 @@ class kdshTreeRings(ptModifier):
             Activate.enable()
             ageSDL["OperatorIDScope0" + str(ScopeNumber.value)] = (-1,)
             ageSDL["boolOperatedScope0" + str(ScopeNumber.value)] = (0,)
-            print("kdshTreeRings.AvatarPage(): telescope operator paged out, reenabled telescope.")
+            PtDebugPrint("kdshTreeRings.AvatarPage(): telescope operator paged out, reenabled telescope.")
         else:
             return
             
@@ -221,7 +221,7 @@ class kdshTreeRings(ptModifier):
         global LocalAvatar
         global boolScopeOperator
         ageSDL = PtGetAgeSDL()                   
-        #~ print "kdshTreeRings:OnNotify  state=%f id=%d events=" % (state,id),events
+        #~ PtDebugPrint("kdshTreeRings:OnNotify  state=%f id=%d events=" % (state,id),events)
         
         if state and id == Activate.id and PtWasLocallyNotified(self.key):
             LocalAvatar = PtFindAvatar(events)
@@ -231,7 +231,7 @@ class kdshTreeRings(ptModifier):
             respResetBtn.run(self.key,state='Reset',events=events)
             
         elif id == respResetBtn.id and OnlyOneOwner.sceneobject.isLocallyOwned():
-            print("kdshTreeRing Reset Button Pushed. Puzzle resetting.")
+            PtDebugPrint("kdshTreeRing Reset Button Pushed. Puzzle resetting.")
             
             #close the door
             ageSDL.setTagString("TreeRingDoorClosed","fromInside")
@@ -258,18 +258,18 @@ class kdshTreeRings(ptModifier):
         global OuterRing01
         ageSDL = PtGetAgeSDL()   
         
-        #~ print "kdshTreeRings: GUI Notify id=%d, event=%d control=" % (id,event),control
+        #~ PtDebugPrint("kdshTreeRings: GUI Notify id=%d, event=%d control=" % (id,event),control)
         
         #~ if event == kExitMode:
             #~ self.IQuitTelescope()            
         
         if event == kDialogLoaded:
             return
-            print("GUI Notify id=%d, event=%d control=" % (id,event),control)
+            PtDebugPrint("GUI Notify id=%d, event=%d control=" % (id,event),control)
             # if the dialog was just loaded then show it
             #~ control.show()
             PtShowDialog("kdshScope0" + str(ScopeNumber.value))
-            print("kdshTreeRings: Showing scope dialog ", ("kdshScope0" + str(ScopeNumber.value)))
+            PtDebugPrint("kdshTreeRings: Showing scope dialog ", ("kdshScope0" + str(ScopeNumber.value)))
             
         btnID = 0
 
@@ -328,7 +328,7 @@ class kdshTreeRings(ptModifier):
         ageSDL["boolOperatedScope0" + str(ScopeNumber.value)] = (1,)
         avID = PtGetClientIDFromAvatarKey(LocalAvatar.getKey())
         ageSDL["OperatorIDScope0" + str(ScopeNumber.value)] = (avID,)
-        print("kdshTreeRings.OnNotify:\twrote SDL - scope operator id = ", avID)
+        PtDebugPrint("kdshTreeRings.OnNotify:\twrote SDL - scope operator id = ", avID)
        # start the behavior
         Behavior.run(LocalAvatar)
         
@@ -361,7 +361,7 @@ class kdshTreeRings(ptModifier):
         
         # show the cockpit
         PtShowDialog("kdshScope0" + str(ScopeNumber.value))
-        #~ print "kdshTreeRings: Showing scope dialog ", ("kdshScope0" + str(ScopeNumber.value))
+        #~ PtDebugPrint("kdshTreeRings: Showing scope dialog ", ("kdshScope0" + str(ScopeNumber.value)))
 
 
     def IQuitTelescope(self):

--- a/Python/kdshTreeRings.py
+++ b/Python/kdshTreeRings.py
@@ -94,7 +94,7 @@ class kdshTreeRings(ptModifier):
         
         version = 13
         self.version = version
-        print "__init__kdshTreeRings v.", version,".1"
+        print("__init__kdshTreeRings v.", version,".1")
 
     def OnFirstUpdate(self):
         PtLoadDialog("kdshScope0" + str(ScopeNumber.value), self.key, "Kadish")       
@@ -158,24 +158,24 @@ class kdshTreeRings(ptModifier):
         MiddleRing = ageSDL["MiddleRing0" + str(ScopeNumber.value)][0]
         InnerRing = ageSDL["InnerRing0" + str(ScopeNumber.value)][0]
         
-        print "Current %s Ring settings:" % (ScopeNumber.value)
-        print "/tOuterRing: ", OuterRing
-        print "/tMiddleRing: ", MiddleRing
-        print "/tInnerRing: ", InnerRing
+        print("Current %s Ring settings:" % (ScopeNumber.value))
+        print("/tOuterRing: ", OuterRing)
+        print("/tMiddleRing: ", MiddleRing)
+        print("/tInnerRing: ", InnerRing)
 
         solo = not PtGetPlayerList()
 
         boolOperated = ageSDL["boolOperatedScope0" + str(ScopeNumber.value)][0]
         if boolOperated:
             if solo:
-                print "kdshTreeRings.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated
+                print("kdshTreeRings.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated)
                 boolOperated = 0
                 ageSDL["boolOperatedScope0" + str(ScopeNumber.value)] = (0,)
                 ageSDL["OperatorIDScope0" + str(ScopeNumber.value)] = (-1,)
                 Activate.enable()
             else:
                 Activate.disable()
-                print "kdshTreeRings.Load():\tboolOperated=%d, disabling telescope clickable" % boolOperated
+                print("kdshTreeRings.Load():\tboolOperated=%d, disabling telescope clickable" % boolOperated)
         #START-->multiplayer fix
         ageSDL.sendToClients(('boolOperatedScope0' + str(ScopeNumber.value)))
         ageSDL.setFlags(('boolOperatedScope0' + str(ScopeNumber.value)), 1, 1)
@@ -208,7 +208,7 @@ class kdshTreeRings(ptModifier):
             Activate.enable()
             ageSDL["OperatorIDScope0" + str(ScopeNumber.value)] = (-1,)
             ageSDL["boolOperatedScope0" + str(ScopeNumber.value)] = (0,)
-            print "kdshTreeRings.AvatarPage(): telescope operator paged out, reenabled telescope."
+            print("kdshTreeRings.AvatarPage(): telescope operator paged out, reenabled telescope.")
         else:
             return
             
@@ -231,7 +231,7 @@ class kdshTreeRings(ptModifier):
             respResetBtn.run(self.key,state='Reset',events=events)
             
         elif id == respResetBtn.id and OnlyOneOwner.sceneobject.isLocallyOwned():
-            print "kdshTreeRing Reset Button Pushed. Puzzle resetting."
+            print("kdshTreeRing Reset Button Pushed. Puzzle resetting.")
             
             #close the door
             ageSDL.setTagString("TreeRingDoorClosed","fromInside")
@@ -265,11 +265,11 @@ class kdshTreeRings(ptModifier):
         
         if event == kDialogLoaded:
             return
-            print "GUI Notify id=%d, event=%d control=" % (id,event),control
+            print("GUI Notify id=%d, event=%d control=" % (id,event),control)
             # if the dialog was just loaded then show it
             #~ control.show()
             PtShowDialog("kdshScope0" + str(ScopeNumber.value))
-            print "kdshTreeRings: Showing scope dialog ", ("kdshScope0" + str(ScopeNumber.value))
+            print("kdshTreeRings: Showing scope dialog ", ("kdshScope0" + str(ScopeNumber.value)))
             
         btnID = 0
 
@@ -328,7 +328,7 @@ class kdshTreeRings(ptModifier):
         ageSDL["boolOperatedScope0" + str(ScopeNumber.value)] = (1,)
         avID = PtGetClientIDFromAvatarKey(LocalAvatar.getKey())
         ageSDL["OperatorIDScope0" + str(ScopeNumber.value)] = (avID,)
-        print "kdshTreeRings.OnNotify:\twrote SDL - scope operator id = ", avID
+        print("kdshTreeRings.OnNotify:\twrote SDL - scope operator id = ", avID)
        # start the behavior
         Behavior.run(LocalAvatar)
         

--- a/Python/kdshTreeRingsSolution.py
+++ b/Python/kdshTreeRingsSolution.py
@@ -220,12 +220,12 @@ class kdshTreeRingsSolution(ptModifier):
         
         version = 6
         self.version = version
-        print "__init__kdshTreeRingsSolution v.", version,".2"
+        print("__init__kdshTreeRingsSolution v.", version,".2")
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()        
         if ageSDL == None:
-            print "kdshTreeRingsResp.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value
+            print("kdshTreeRingsResp.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
 
         ageSDL.setNotify(self.key,"OuterRing01",0.0)
         ageSDL.setNotify(self.key,"MiddleRing01",0.0)
@@ -254,7 +254,7 @@ class kdshTreeRingsSolution(ptModifier):
         MiddleRing03 = ageSDL["MiddleRing03"][0]
         InnerRing03 = ageSDL["InnerRing03"][0]
 
-        print "kdshTreeRingSolution: When I got here:"
+        print("kdshTreeRingSolution: When I got here:")
         #~ print "\tOuterRing01=",OuterRing01
         #~ print "\tMiddleRing01=",MiddleRing01
         #~ print "\tInnerRing01=",InnerRing01
@@ -271,16 +271,16 @@ class kdshTreeRingsSolution(ptModifier):
                 ffcode1 = "InitState = "+i + "Ring0" +j
                 #~ print "ffcode1 = ", ffcode1
                 
-                exec ffcode1
+                exec(ffcode1)
                 #~ print "InitState = ", InitState
                 
                 ffcode2 = i + "Ring0" + j + "_0" + str(InitState) + ".animation.skipToEnd()"
                 #~ print "ffcode2 = ", ffcode2
                 
-                exec ffcode2
+                exec(ffcode2)
             
                 #~ print "Fastforwarding: Set = ",j," Ring = ",i," Position = ",InitState
-                print "\t",i,"Ring0",j," = ", InitState
+                print("\t",i,"Ring0",j," = ", InitState)
 
         
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -294,7 +294,7 @@ class kdshTreeRingsSolution(ptModifier):
         
         code = VARname + "_0" + str(newbearing) + ".animation.play()"
         #~ print "code = ", code
-        exec code # this runs the animation on the actual ring in the garden
+        exec(code) # this runs the animation on the actual ring in the garden
         
         if "3" in VARname: 
             #~ print "TRS: Nothing to ff. VARname = ", VARname
@@ -302,7 +302,7 @@ class kdshTreeRingsSolution(ptModifier):
         else:
             GUIcode = "GUI" + string.join(string.split(VARname, "Ring"), "") + "_0" + str(newbearing) + ".animation.play()"
             #~ print "GUIcode = ", GUIcode
-            exec GUIcode # this runs the animation on the "fake" ring in front of the GUI
+            exec(GUIcode) # this runs the animation on the "fake" ring in front of the GUI
 
 ###
 #Check to see if the Puzzle has been solved
@@ -318,10 +318,10 @@ class kdshTreeRingsSolution(ptModifier):
         MiddleRing03 = ageSDL["MiddleRing03"][0]
         InnerRing03 = ageSDL["InnerRing03"][0]
             
-        print "Current Scope Positions [Outer, Middle, Inner]:"
-        print "\tRing #1: [", OuterRing01 ,", ",MiddleRing01,", ",InnerRing01," ]"
-        print "\tRing #2: [", OuterRing02 ,", ",MiddleRing02,", ",InnerRing02," ]"
-        print "\tRing #3: [", OuterRing03 ,", ",MiddleRing03,", ",InnerRing03," ]"
+        print("Current Scope Positions [Outer, Middle, Inner]:")
+        print("\tRing #1: [", OuterRing01 ,", ",MiddleRing01,", ",InnerRing01," ]")
+        print("\tRing #2: [", OuterRing02 ,", ",MiddleRing02,", ",InnerRing02," ]")
+        print("\tRing #3: [", OuterRing03 ,", ",MiddleRing03,", ",InnerRing03," ]")
         
         if OuterRing01 ==   5 and\
             MiddleRing01 == 6 and\
@@ -332,7 +332,7 @@ class kdshTreeRingsSolution(ptModifier):
             OuterRing03 == 4 and\
             MiddleRing03 == 3 and\
             InnerRing03 == 6:
-                print "Tree Ring Puzzle solved. Opening Door."
+                print("Tree Ring Puzzle solved. Opening Door.")
                 StillSolved = True
                 PtAtTimeCallback(self.key,kPatienceDelayToSolve,1) # Put in this delay to avoid people "speed clicking" past solution and opening door. 
 
@@ -350,13 +350,13 @@ class kdshTreeRingsSolution(ptModifier):
             #~ print "kdshTreeRingsSolution: Scope #3 occupied. Fast forwarding Scope 2 Rings in GUI"
             ScopeNumber = 3
         else:
-            print "ERROR: Not sure who the notify came from."
-            print "id = ", id
+            print("ERROR: Not sure who the notify came from.")
+            print("id = ", id)
             return
             
         ageSDL = PtGetAgeSDL()        
         if ageSDL == None:
-            print "kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value
+            print("kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
 
         Outerbearing = ageSDL["OuterRing0" + str(ScopeNumber-1)][0]
         Middlebearing = ageSDL["MiddleRing0" + str(ScopeNumber-1)][0]
@@ -369,15 +369,15 @@ class kdshTreeRingsSolution(ptModifier):
 
         GUIcode = "GUIOuter0" + str(ScopeNumber-1) + "_0" + str(Outerbearing) + ".animation.skipToEnd()"
         #~ print "FF Outer code = ", GUIcode
-        exec GUIcode 
+        exec(GUIcode) 
 
         GUIcode = "GUIMiddle0" + str(ScopeNumber-1) + "_0" + str(Middlebearing) + ".animation.skipToEnd()"
         #~ print "FF Middle code = ", GUIcode
-        exec GUIcode 
+        exec(GUIcode) 
 
         GUIcode = "GUIInner0" + str(ScopeNumber-1) + "_0" + str(Innerbearing) + ".animation.skipToEnd()"
         #~ print "FF Inner code = ", GUIcode
-        exec GUIcode 
+        exec(GUIcode) 
         
         #~ GUIcode = "GUI" + string.join(string.split(VARname, "Ring"), "") + "_0" + str(newbearing) + ".animation.play()"
         #~ print "GUIcode = ", GUIcode
@@ -393,5 +393,5 @@ class kdshTreeRingsSolution(ptModifier):
                 ageSDL.setTagString("TreeRingDoorClosed","fromOutside")                
                 ageSDL["TreeRingDoorClosed"] = (0,)
             else:
-                print "Patience, grasshopper."
+                print("Patience, grasshopper.")
             

--- a/Python/kdshTreeRingsSolution.py
+++ b/Python/kdshTreeRingsSolution.py
@@ -220,12 +220,12 @@ class kdshTreeRingsSolution(ptModifier):
         
         version = 6
         self.version = version
-        print("__init__kdshTreeRingsSolution v.", version,".2")
+        PtDebugPrint("__init__kdshTreeRingsSolution v.", version,".2")
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()        
         if ageSDL == None:
-            print("kdshTreeRingsResp.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
+            PtDebugPrint("kdshTreeRingsResp.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
 
         ageSDL.setNotify(self.key,"OuterRing01",0.0)
         ageSDL.setNotify(self.key,"MiddleRing01",0.0)
@@ -254,33 +254,33 @@ class kdshTreeRingsSolution(ptModifier):
         MiddleRing03 = ageSDL["MiddleRing03"][0]
         InnerRing03 = ageSDL["InnerRing03"][0]
 
-        print("kdshTreeRingSolution: When I got here:")
-        #~ print "\tOuterRing01=",OuterRing01
-        #~ print "\tMiddleRing01=",MiddleRing01
-        #~ print "\tInnerRing01=",InnerRing01
-        #~ print "\tOuterRing02=",OuterRing02
-        #~ print "\tMiddleRing02=",MiddleRing02
-        #~ print "\tInnerRing02=",InnerRing02
-        #~ print "\tOuterRing03=",OuterRing03
-        #~ print "\tMiddleRing03=",MiddleRing03
-        #~ print "\tInnerRing03=",InnerRing03
+        PtDebugPrint("kdshTreeRingSolution: When I got here:")
+        #~ PtDebugPrint("\tOuterRing01=",OuterRing01)
+        #~ PtDebugPrint("\tMiddleRing01=",MiddleRing01)
+        #~ PtDebugPrint("\tInnerRing01=",InnerRing01)
+        #~ PtDebugPrint("\tOuterRing02=",OuterRing02)
+        #~ PtDebugPrint("\tMiddleRing02=",MiddleRing02)
+        #~ PtDebugPrint("\tInnerRing02=",InnerRing02)
+        #~ PtDebugPrint("\tOuterRing03=",OuterRing03)
+        #~ PtDebugPrint("\tMiddleRing03=",MiddleRing03)
+        #~ PtDebugPrint("\tInnerRing03=",InnerRing03)
 
         for i in ["Outer", "Middle", "Inner"]:
             for j in ["1","2","3"]:
                 
                 ffcode1 = "InitState = "+i + "Ring0" +j
-                #~ print "ffcode1 = ", ffcode1
+                #~ PtDebugPrint("ffcode1 = ", ffcode1)
                 
                 exec(ffcode1)
-                #~ print "InitState = ", InitState
+                #~ PtDebugPrint("InitState = ", InitState)
                 
                 ffcode2 = i + "Ring0" + j + "_0" + str(InitState) + ".animation.skipToEnd()"
-                #~ print "ffcode2 = ", ffcode2
+                #~ PtDebugPrint("ffcode2 = ", ffcode2)
                 
                 exec(ffcode2)
             
-                #~ print "Fastforwarding: Set = ",j," Ring = ",i," Position = ",InitState
-                print("\t",i,"Ring0",j," = ", InitState)
+                #~ PtDebugPrint("Fastforwarding: Set = ",j," Ring = ",i," Position = ",InitState)
+                PtDebugPrint("\t",i,"Ring0",j," = ", InitState)
 
         
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -290,18 +290,18 @@ class kdshTreeRingsSolution(ptModifier):
 
         StillSolved = False
         newbearing = ageSDL[VARname][0]
-        #~ print "VARname = ", VARname, "newbear = ", newbearing
+        #~ PtDebugPrint("VARname = ", VARname, "newbear = ", newbearing)
         
         code = VARname + "_0" + str(newbearing) + ".animation.play()"
-        #~ print "code = ", code
+        #~ PtDebugPrint("code = ", code)
         exec(code) # this runs the animation on the actual ring in the garden
         
         if "3" in VARname: 
-            #~ print "TRS: Nothing to ff. VARname = ", VARname
+            #~ PtDebugPrint("TRS: Nothing to ff. VARname = ", VARname)
             pass
         else:
             GUIcode = "GUI" + string.join(string.split(VARname, "Ring"), "") + "_0" + str(newbearing) + ".animation.play()"
-            #~ print "GUIcode = ", GUIcode
+            #~ PtDebugPrint("GUIcode = ", GUIcode)
             exec(GUIcode) # this runs the animation on the "fake" ring in front of the GUI
 
 ###
@@ -318,10 +318,10 @@ class kdshTreeRingsSolution(ptModifier):
         MiddleRing03 = ageSDL["MiddleRing03"][0]
         InnerRing03 = ageSDL["InnerRing03"][0]
             
-        print("Current Scope Positions [Outer, Middle, Inner]:")
-        print("\tRing #1: [", OuterRing01 ,", ",MiddleRing01,", ",InnerRing01," ]")
-        print("\tRing #2: [", OuterRing02 ,", ",MiddleRing02,", ",InnerRing02," ]")
-        print("\tRing #3: [", OuterRing03 ,", ",MiddleRing03,", ",InnerRing03," ]")
+        PtDebugPrint("Current Scope Positions [Outer, Middle, Inner]:")
+        PtDebugPrint("\tRing #1: [", OuterRing01 ,", ",MiddleRing01,", ",InnerRing01," ]")
+        PtDebugPrint("\tRing #2: [", OuterRing02 ,", ",MiddleRing02,", ",InnerRing02," ]")
+        PtDebugPrint("\tRing #3: [", OuterRing03 ,", ",MiddleRing03,", ",InnerRing03," ]")
         
         if OuterRing01 ==   5 and\
             MiddleRing01 == 6 and\
@@ -332,7 +332,7 @@ class kdshTreeRingsSolution(ptModifier):
             OuterRing03 == 4 and\
             MiddleRing03 == 3 and\
             InnerRing03 == 6:
-                print("Tree Ring Puzzle solved. Opening Door.")
+                PtDebugPrint("Tree Ring Puzzle solved. Opening Door.")
                 StillSolved = True
                 PtAtTimeCallback(self.key,kPatienceDelayToSolve,1) # Put in this delay to avoid people "speed clicking" past solution and opening door. 
 
@@ -344,43 +344,43 @@ class kdshTreeRingsSolution(ptModifier):
         
         
         if id == actScope2.id:
-            #~ print "kdshTreeRingsSolution: Scope #2 occupied. Fast forwarding Scope 1 Rings in GUI"
+            #~ PtDebugPrint("kdshTreeRingsSolution: Scope #2 occupied. Fast forwarding Scope 1 Rings in GUI")
             ScopeNumber = 2
         elif id == actScope3.id:
-            #~ print "kdshTreeRingsSolution: Scope #3 occupied. Fast forwarding Scope 2 Rings in GUI"
+            #~ PtDebugPrint("kdshTreeRingsSolution: Scope #3 occupied. Fast forwarding Scope 2 Rings in GUI")
             ScopeNumber = 3
         else:
-            print("ERROR: Not sure who the notify came from.")
-            print("id = ", id)
+            PtDebugPrint("ERROR: Not sure who the notify came from.")
+            PtDebugPrint("id = ", id)
             return
             
         ageSDL = PtGetAgeSDL()        
         if ageSDL == None:
-            print("kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
+            PtDebugPrint("kdshTreeRings.OnFirstUpdate():\tERROR---missing age SDL (%s)" % varstring.value)
 
         Outerbearing = ageSDL["OuterRing0" + str(ScopeNumber-1)][0]
         Middlebearing = ageSDL["MiddleRing0" + str(ScopeNumber-1)][0]
         Innerbearing = ageSDL["InnerRing0" + str(ScopeNumber-1)][0]
 
-        #~ print "Outerbearing = ", Outerbearing
-        #~ print "Middlebearing = ", Middlebearing
-        #~ print "Innerbearing = ", Innerbearing
+        #~ PtDebugPrint("Outerbearing = ", Outerbearing)
+        #~ PtDebugPrint("Middlebearing = ", Middlebearing)
+        #~ PtDebugPrint("Innerbearing = ", Innerbearing)
         
 
         GUIcode = "GUIOuter0" + str(ScopeNumber-1) + "_0" + str(Outerbearing) + ".animation.skipToEnd()"
-        #~ print "FF Outer code = ", GUIcode
+        #~ PtDebugPrint("FF Outer code = ", GUIcode)
         exec(GUIcode) 
 
         GUIcode = "GUIMiddle0" + str(ScopeNumber-1) + "_0" + str(Middlebearing) + ".animation.skipToEnd()"
-        #~ print "FF Middle code = ", GUIcode
+        #~ PtDebugPrint("FF Middle code = ", GUIcode)
         exec(GUIcode) 
 
         GUIcode = "GUIInner0" + str(ScopeNumber-1) + "_0" + str(Innerbearing) + ".animation.skipToEnd()"
-        #~ print "FF Inner code = ", GUIcode
+        #~ PtDebugPrint("FF Inner code = ", GUIcode)
         exec(GUIcode) 
         
         #~ GUIcode = "GUI" + string.join(string.split(VARname, "Ring"), "") + "_0" + str(newbearing) + ".animation.play()"
-        #~ print "GUIcode = ", GUIcode
+        #~ PtDebugPrint("GUIcode = ", GUIcode)
         #~ exec GUIcode # this runs the animation on the "fake" ring in front of the GUI        
         
         
@@ -393,5 +393,5 @@ class kdshTreeRingsSolution(ptModifier):
                 ageSDL.setTagString("TreeRingDoorClosed","fromOutside")                
                 ageSDL["TreeRingDoorClosed"] = (0,)
             else:
-                print("Patience, grasshopper.")
+                PtDebugPrint("Patience, grasshopper.")
             

--- a/Python/kdshVault.py
+++ b/Python/kdshVault.py
@@ -108,7 +108,7 @@ class kdshVault(ptResponder):
         
         version = 6
         self.version = version
-        print "__init__kdshVault v. ", version,".2"
+        print("__init__kdshVault v. ", version,".2")
 
     def OnServerInitComplete(self):
         global ButtonsPushed
@@ -130,44 +130,44 @@ class kdshVault(ptResponder):
         
         ButtonsPushed = ageSDL["ButtonsPushed"][0]
 
-        print "kdshVault: When I got here:"
-        print "\t ButtonsPushed = ", ButtonsPushed
+        print("kdshVault: When I got here:")
+        print("\t ButtonsPushed = ", ButtonsPushed)
         
         ButtonsPushed = str(ButtonsPushed)
         
         if len(ButtonsPushed) >= 6:
-            print "All 6 buttons were already pushed. Resetting."
+            print("All 6 buttons were already pushed. Resetting.")
             respResetButtons.run(self.key)
             ageSDL["ButtonsPushed"] = (0,)
             
             return
         
         if "1" in ButtonsPushed:
-            print "fast forwarding button 1"
+            print("fast forwarding button 1")
             respButton1.run(self.key, fastforward=1)
             actButton1.disable()
         if "2" in ButtonsPushed:
-            print "fast forwarding button 2"
+            print("fast forwarding button 2")
             respButton2.run(self.key, fastforward=1)
             actButton2.disable()          
         if "3" in ButtonsPushed:
-            print "fast forwarding button 3"
+            print("fast forwarding button 3")
             respButton3.run(self.key, fastforward=1)
             actButton3.disable()
         if "4" in ButtonsPushed:
-            print "fast forwarding button 4"
+            print("fast forwarding button 4")
             respButton4.run(self.key, fastforward=1)
             actButton4.disable()            
         if "5" in ButtonsPushed:
-            print "fast forwarding button 5"
+            print("fast forwarding button 5")
             respButton5.run(self.key, fastforward=1)
             actButton5.disable()            
         if "6" in ButtonsPushed:
-            print "fast forwarding button 6"
+            print("fast forwarding button 6")
             respButton6.run(self.key, fastforward=1)
             actButton6.disable()
         if "0" in ButtonsPushed:
-            print "No buttons have been pushed."
+            print("No buttons have been pushed.")
             #~ string.join(string.split(ButtonsPushed, "0"), "")
             ageSDL["ButtonsPushed"] = (0,)
             
@@ -183,14 +183,14 @@ class kdshVault(ptResponder):
         VCPboolOperated = ageSDL["VCPboolOperated"][0]
         if VCPboolOperated:
             if solo:
-                print "kdshVault.Load():\tVCPboolOperated=%d but no one else here...correcting" % VCPboolOperated
+                print("kdshVault.Load():\tVCPboolOperated=%d but no one else here...correcting" % VCPboolOperated)
                 VCPboolOperated = 0
                 ageSDL["VCPboolOperated"] = (0,)
                 ageSDL["VCPOperatorID"] = (-1,)
                 Activate.enable()
             else:
                 Activate.disable()
-                print "kdshVault.Load():\tVCPboolOperated=%d, disabling Vault Control Panel clickable" % VCPboolOperated
+                print("kdshVault.Load():\tVCPboolOperated=%d, disabling Vault Control Panel clickable" % VCPboolOperated)
 
     def AvatarPage(self, avObj, pageIn, lastOut):
         "reset scope accessibility if scope user quits or crashes"
@@ -207,7 +207,7 @@ class kdshVault(ptResponder):
             ageSDL["VCPOperatorID"] = (-1,)
             ageSDL["VCPboolOperated"] = (0,)
             LowerVCPClickable.run(self.key)
-            print "kdshVault.AvatarPage(): Vault Control Panel operator paged out, reenabled VCP clickable."
+            print("kdshVault.AvatarPage(): Vault Control Panel operator paged out, reenabled VCP clickable.")
         else:
             return
             
@@ -228,7 +228,7 @@ class kdshVault(ptResponder):
         avatar = PtFindAvatar(events)
         
         if state and id == Activate.id and avatar == PtGetLocalAvatar():
-            print "kdshVault: I'm engaging VCP."
+            print("kdshVault: I'm engaging VCP.")
 
             # Disable First Person Camera
             cam = ptCamera()
@@ -269,20 +269,20 @@ class kdshVault(ptResponder):
 
         elif state and id in [1,2,3,4,5,6] and avatar == PtGetLocalAvatar():
             if VaultDoorMoving:
-                print "Button has no effect. The Vault Door is already moving."
+                print("Button has no effect. The Vault Door is already moving.")
                 return            
             
-            print "\tkdshVault.OnNotify: Button #%d pushed" % (id)
+            print("\tkdshVault.OnNotify: Button #%d pushed" % (id))
             
 
             #append the pushed button to the list of those already clicked            
             ButtonsPushed = ageSDL["ButtonsPushed"][0]
             ButtonsPushed = str(ButtonsPushed)
-            print "kdshVault.OnNotify: Before, ButtonsPushed was ", ButtonsPushed
+            print("kdshVault.OnNotify: Before, ButtonsPushed was ", ButtonsPushed)
 
             
             ButtonsPushed = string.atoi(ButtonsPushed + (str(id)))
-            print "kdshVault.OnNotify: Now, ButtonsPushed = ", ButtonsPushed
+            print("kdshVault.OnNotify: Now, ButtonsPushed = ", ButtonsPushed)
             
             #update the ageSDL value for that button            
             ageSDL["ButtonsPushed"] = (ButtonsPushed,)
@@ -298,22 +298,22 @@ class kdshVault(ptResponder):
             
         elif id == respResetBtn.id and OnlyOneOwner.sceneobject.isLocallyOwned():
             if VaultDoorMoving:
-                print "Button has no effect. The Vault Door is already moving."
+                print("Button has no effect. The Vault Door is already moving.")
                 return
                 
-            print "kdshVault.OnNotify: Reset Button Pushed. Toggling Vault Door state."
+            print("kdshVault.OnNotify: Reset Button Pushed. Toggling Vault Door state.")
             
             vaultclosed = ageSDL["VaultClosed"][0]
             if vaultclosed == 1:
                 #Open the door
-                print "\t trying to open the Vault."
+                print("\t trying to open the Vault.")
                 
                 ageSDL.setTagString("VaultClosed","fromOutside")                
                 ageSDL["VaultClosed"] = (0,)                
                 
             elif vaultclosed == 0:
                 #Close the door
-                print "\t trying to close the Vault."
+                print("\t trying to close the Vault.")
                 ageSDL.setTagString("VaultClosed","fromInside")                
                 ageSDL["VaultClosed"] = (1,)
             
@@ -343,7 +343,7 @@ class kdshVault(ptResponder):
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
 
-        print "kdshVault.OnSDLNotify:\tVARname=",VARname," value=",ageSDL[VARname][0]
+        print("kdshVault.OnSDLNotify:\tVARname=",VARname," value=",ageSDL[VARname][0])
             
         
         if VARname == "ButtonsPushed":
@@ -355,18 +355,18 @@ class kdshVault(ptResponder):
             
             ButtonsPushed = str(ButtonsPushed)
             lastbuttonpushed = ButtonsPushed[-1:]
-            print "kdshVault.OnSDLNotify: new ButtonsPushed = ", ButtonsPushed
+            print("kdshVault.OnSDLNotify: new ButtonsPushed = ", ButtonsPushed)
             #~ print "kdshVault.OnSDLNotify: lastbuttonpushed = ", lastbuttonpushed
             
             #run the animation on the button itself
             code = "respButton" + str(lastbuttonpushed) + ".run(self.key)"
             #~ print "code = ", code
-            exec code
+            exec(code)
         
             #disable the clickable for that button
             code = "actButton" + str(lastbuttonpushed) + ".disable()"
             #~ print "code = ", code
-            exec code
+            exec(code)
         
     def OnTimer(self,id):
         global VaultDoorMoving
@@ -374,9 +374,9 @@ class kdshVault(ptResponder):
         ageSDL = PtGetAgeSDL()     
         if id==1:
             ButtonsPushed = ageSDL["ButtonsPushed"][0]
-            print "kdshVault: Check solution. ButtonsPushed = ", ButtonsPushed
+            print("kdshVault: Check solution. ButtonsPushed = ", ButtonsPushed)
             if ButtonsPushed == 152346:
-                print "kdshVault: Puzzle solved. Opening door."
+                print("kdshVault: Puzzle solved. Opening door.")
 
                 ageSDL.setTagString("VaultClosed","fromOutside")                
                 ageSDL["VaultClosed"] = (0,)
@@ -392,7 +392,7 @@ class kdshVault(ptResponder):
             PtFadeLocalAvatar(1)
         
         elif id == 3:
-            print "kdshVault: The Vault door has stopped moving."
+            print("kdshVault: The Vault door has stopped moving.")
             VaultDoorMoving=0
 
             

--- a/Python/kdshVault.py
+++ b/Python/kdshVault.py
@@ -108,7 +108,7 @@ class kdshVault(ptResponder):
         
         version = 6
         self.version = version
-        print("__init__kdshVault v. ", version,".2")
+        PtDebugPrint("__init__kdshVault v. ", version,".2")
 
     def OnServerInitComplete(self):
         global ButtonsPushed
@@ -130,44 +130,44 @@ class kdshVault(ptResponder):
         
         ButtonsPushed = ageSDL["ButtonsPushed"][0]
 
-        print("kdshVault: When I got here:")
-        print("\t ButtonsPushed = ", ButtonsPushed)
+        PtDebugPrint("kdshVault: When I got here:")
+        PtDebugPrint("\t ButtonsPushed = ", ButtonsPushed)
         
         ButtonsPushed = str(ButtonsPushed)
         
         if len(ButtonsPushed) >= 6:
-            print("All 6 buttons were already pushed. Resetting.")
+            PtDebugPrint("All 6 buttons were already pushed. Resetting.")
             respResetButtons.run(self.key)
             ageSDL["ButtonsPushed"] = (0,)
             
             return
         
         if "1" in ButtonsPushed:
-            print("fast forwarding button 1")
+            PtDebugPrint("fast forwarding button 1")
             respButton1.run(self.key, fastforward=1)
             actButton1.disable()
         if "2" in ButtonsPushed:
-            print("fast forwarding button 2")
+            PtDebugPrint("fast forwarding button 2")
             respButton2.run(self.key, fastforward=1)
             actButton2.disable()          
         if "3" in ButtonsPushed:
-            print("fast forwarding button 3")
+            PtDebugPrint("fast forwarding button 3")
             respButton3.run(self.key, fastforward=1)
             actButton3.disable()
         if "4" in ButtonsPushed:
-            print("fast forwarding button 4")
+            PtDebugPrint("fast forwarding button 4")
             respButton4.run(self.key, fastforward=1)
             actButton4.disable()            
         if "5" in ButtonsPushed:
-            print("fast forwarding button 5")
+            PtDebugPrint("fast forwarding button 5")
             respButton5.run(self.key, fastforward=1)
             actButton5.disable()            
         if "6" in ButtonsPushed:
-            print("fast forwarding button 6")
+            PtDebugPrint("fast forwarding button 6")
             respButton6.run(self.key, fastforward=1)
             actButton6.disable()
         if "0" in ButtonsPushed:
-            print("No buttons have been pushed.")
+            PtDebugPrint("No buttons have been pushed.")
             #~ string.join(string.split(ButtonsPushed, "0"), "")
             ageSDL["ButtonsPushed"] = (0,)
             
@@ -183,14 +183,14 @@ class kdshVault(ptResponder):
         VCPboolOperated = ageSDL["VCPboolOperated"][0]
         if VCPboolOperated:
             if solo:
-                print("kdshVault.Load():\tVCPboolOperated=%d but no one else here...correcting" % VCPboolOperated)
+                PtDebugPrint("kdshVault.Load():\tVCPboolOperated=%d but no one else here...correcting" % VCPboolOperated)
                 VCPboolOperated = 0
                 ageSDL["VCPboolOperated"] = (0,)
                 ageSDL["VCPOperatorID"] = (-1,)
                 Activate.enable()
             else:
                 Activate.disable()
-                print("kdshVault.Load():\tVCPboolOperated=%d, disabling Vault Control Panel clickable" % VCPboolOperated)
+                PtDebugPrint("kdshVault.Load():\tVCPboolOperated=%d, disabling Vault Control Panel clickable" % VCPboolOperated)
 
     def AvatarPage(self, avObj, pageIn, lastOut):
         "reset scope accessibility if scope user quits or crashes"
@@ -207,7 +207,7 @@ class kdshVault(ptResponder):
             ageSDL["VCPOperatorID"] = (-1,)
             ageSDL["VCPboolOperated"] = (0,)
             LowerVCPClickable.run(self.key)
-            print("kdshVault.AvatarPage(): Vault Control Panel operator paged out, reenabled VCP clickable.")
+            PtDebugPrint("kdshVault.AvatarPage(): Vault Control Panel operator paged out, reenabled VCP clickable.")
         else:
             return
             
@@ -222,13 +222,13 @@ class kdshVault(ptResponder):
         
         ageSDL = PtGetAgeSDL()             
         
-        #~ print "kdshVault:OnNotify  state=%f id=%d events=" % (state,id),events
+        #~ PtDebugPrint("kdshVault:OnNotify  state=%f id=%d events=" % (state,id),events)
 
         #Hacked this in to work with the UruLive changes
         avatar = PtFindAvatar(events)
         
         if state and id == Activate.id and avatar == PtGetLocalAvatar():
-            print("kdshVault: I'm engaging VCP.")
+            PtDebugPrint("kdshVault: I'm engaging VCP.")
 
             # Disable First Person Camera
             cam = ptCamera()
@@ -248,7 +248,7 @@ class kdshVault(ptResponder):
 
 
         elif id == Behavior.id and avatar == PtGetLocalAvatar(): # Smart seek done
-            #~ print "Done with smart seek"
+            #~ PtDebugPrint("Done with smart seek")
             LocalAvatar = avatar
             Behavior.gotoStage(LocalAvatar, -1)
             
@@ -269,20 +269,20 @@ class kdshVault(ptResponder):
 
         elif state and id in [1,2,3,4,5,6] and avatar == PtGetLocalAvatar():
             if VaultDoorMoving:
-                print("Button has no effect. The Vault Door is already moving.")
+                PtDebugPrint("Button has no effect. The Vault Door is already moving.")
                 return            
             
-            print("\tkdshVault.OnNotify: Button #%d pushed" % (id))
+            PtDebugPrint("\tkdshVault.OnNotify: Button #%d pushed" % (id))
             
 
             #append the pushed button to the list of those already clicked            
             ButtonsPushed = ageSDL["ButtonsPushed"][0]
             ButtonsPushed = str(ButtonsPushed)
-            print("kdshVault.OnNotify: Before, ButtonsPushed was ", ButtonsPushed)
+            PtDebugPrint("kdshVault.OnNotify: Before, ButtonsPushed was ", ButtonsPushed)
 
             
             ButtonsPushed = string.atoi(ButtonsPushed + (str(id)))
-            print("kdshVault.OnNotify: Now, ButtonsPushed = ", ButtonsPushed)
+            PtDebugPrint("kdshVault.OnNotify: Now, ButtonsPushed = ", ButtonsPushed)
             
             #update the ageSDL value for that button            
             ageSDL["ButtonsPushed"] = (ButtonsPushed,)
@@ -292,28 +292,28 @@ class kdshVault(ptResponder):
                 #~ self.CheckSolution()
 
         elif state and id == actResetBtn.id:
-            #~ print "kdshVault.OnNotify: Reset Button clicked."
+            #~ PtDebugPrint("kdshVault.OnNotify: Reset Button clicked.")
             LocalAvatar = PtFindAvatar(events)
             respResetBtn.run(self.key,events=events)
             
         elif id == respResetBtn.id and OnlyOneOwner.sceneobject.isLocallyOwned():
             if VaultDoorMoving:
-                print("Button has no effect. The Vault Door is already moving.")
+                PtDebugPrint("Button has no effect. The Vault Door is already moving.")
                 return
                 
-            print("kdshVault.OnNotify: Reset Button Pushed. Toggling Vault Door state.")
+            PtDebugPrint("kdshVault.OnNotify: Reset Button Pushed. Toggling Vault Door state.")
             
             vaultclosed = ageSDL["VaultClosed"][0]
             if vaultclosed == 1:
                 #Open the door
-                print("\t trying to open the Vault.")
+                PtDebugPrint("\t trying to open the Vault.")
                 
                 ageSDL.setTagString("VaultClosed","fromOutside")                
                 ageSDL["VaultClosed"] = (0,)                
                 
             elif vaultclosed == 0:
                 #Close the door
-                print("\t trying to close the Vault.")
+                PtDebugPrint("\t trying to close the Vault.")
                 ageSDL.setTagString("VaultClosed","fromInside")                
                 ageSDL["VaultClosed"] = (1,)
             
@@ -343,7 +343,7 @@ class kdshVault(ptResponder):
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
 
-        print("kdshVault.OnSDLNotify:\tVARname=",VARname," value=",ageSDL[VARname][0])
+        PtDebugPrint("kdshVault.OnSDLNotify:\tVARname=",VARname," value=",ageSDL[VARname][0])
             
         
         if VARname == "ButtonsPushed":
@@ -355,17 +355,17 @@ class kdshVault(ptResponder):
             
             ButtonsPushed = str(ButtonsPushed)
             lastbuttonpushed = ButtonsPushed[-1:]
-            print("kdshVault.OnSDLNotify: new ButtonsPushed = ", ButtonsPushed)
-            #~ print "kdshVault.OnSDLNotify: lastbuttonpushed = ", lastbuttonpushed
+            PtDebugPrint("kdshVault.OnSDLNotify: new ButtonsPushed = ", ButtonsPushed)
+            #~ PtDebugPrint("kdshVault.OnSDLNotify: lastbuttonpushed = ", lastbuttonpushed)
             
             #run the animation on the button itself
             code = "respButton" + str(lastbuttonpushed) + ".run(self.key)"
-            #~ print "code = ", code
+            #~ PtDebugPrint("code = ", code)
             exec(code)
         
             #disable the clickable for that button
             code = "actButton" + str(lastbuttonpushed) + ".disable()"
-            #~ print "code = ", code
+            #~ PtDebugPrint("code = ", code)
             exec(code)
         
     def OnTimer(self,id):
@@ -374,9 +374,9 @@ class kdshVault(ptResponder):
         ageSDL = PtGetAgeSDL()     
         if id==1:
             ButtonsPushed = ageSDL["ButtonsPushed"][0]
-            print("kdshVault: Check solution. ButtonsPushed = ", ButtonsPushed)
+            PtDebugPrint("kdshVault: Check solution. ButtonsPushed = ", ButtonsPushed)
             if ButtonsPushed == 152346:
-                print("kdshVault: Puzzle solved. Opening door.")
+                PtDebugPrint("kdshVault: Puzzle solved. Opening door.")
 
                 ageSDL.setTagString("VaultClosed","fromOutside")                
                 ageSDL["VaultClosed"] = (0,)
@@ -392,7 +392,7 @@ class kdshVault(ptResponder):
             PtFadeLocalAvatar(1)
         
         elif id == 3:
-            print("kdshVault: The Vault door has stopped moving.")
+            PtDebugPrint("kdshVault: The Vault door has stopped moving.")
             VaultDoorMoving=0
 
             

--- a/Python/kemoEmgrPhase0.py
+++ b/Python/kemoEmgrPhase0.py
@@ -70,7 +70,7 @@ class kemoEmgrPhase0(ptResponder):
 
         version = 1
         self.version = version
-        print "__init__kemoEmgrPhase0 v.", version
+        print("__init__kemoEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -80,7 +80,7 @@ class kemoEmgrPhase0(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             for variable in BooleanVARs:
-                print "tying together", variable
+                print("tying together", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
        
@@ -92,7 +92,7 @@ class kemoEmgrPhase0(ptResponder):
         PtDebugPrint("kemoEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
         
         if VARname in BooleanVARs:
-            print "kemoEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname)
+            print("kemoEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
             self.IManageBOOLs(VARname,SDLname)
             
         else:
@@ -107,7 +107,7 @@ class kemoEmgrPhase0(ptResponder):
                 PtDebugPrint("kemoEmgrPhase0.OnSDLNotify:\tPaging in room ", VARname)
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print "variable = ", VARname
+                print("variable = ", VARname)
                 PtDebugPrint("kemoEmgrPhase0.OnSDLNotify:\tPaging out room ", VARname)
                 PtPageOutNode(VARname)
             else:

--- a/Python/kemoEmgrPhase0.py
+++ b/Python/kemoEmgrPhase0.py
@@ -70,7 +70,7 @@ class kemoEmgrPhase0(ptResponder):
 
         version = 1
         self.version = version
-        print("__init__kemoEmgrPhase0 v.", version)
+        PtDebugPrint("__init__kemoEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -80,7 +80,7 @@ class kemoEmgrPhase0(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             for variable in BooleanVARs:
-                print("tying together", variable)
+                PtDebugPrint("tying together", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
        
@@ -92,7 +92,7 @@ class kemoEmgrPhase0(ptResponder):
         PtDebugPrint("kemoEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
         
         if VARname in BooleanVARs:
-            print("kemoEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
+            PtDebugPrint("kemoEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
             self.IManageBOOLs(VARname,SDLname)
             
         else:
@@ -107,7 +107,7 @@ class kemoEmgrPhase0(ptResponder):
                 PtDebugPrint("kemoEmgrPhase0.OnSDLNotify:\tPaging in room ", VARname)
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print("variable = ", VARname)
+                PtDebugPrint("variable = ", VARname)
                 PtDebugPrint("kemoEmgrPhase0.OnSDLNotify:\tPaging out room ", VARname)
                 PtPageOutNode(VARname)
             else:

--- a/Python/kemoJourneyClothGate.py
+++ b/Python/kemoJourneyClothGate.py
@@ -125,7 +125,7 @@ class kemoJourneyClothGate(ptResponder):
         if not state:
             return
         
-        print "##"
+        print("##")
         
         if id == actTrigger.id:
             
@@ -138,7 +138,7 @@ class kemoJourneyClothGate(ptResponder):
                     PtDebugPrint("kemoJourneyClothGate.OnServerInitComplete():\tERROR reading age SDL")
                     GateCurrentlyClosed = False
                 
-                print "OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed
+                print("OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed)
                 if not GateCurrentlyClosed:
                     PtDebugPrint ("The gate is already open.")
                     return
@@ -165,7 +165,7 @@ class kemoJourneyClothGate(ptResponder):
                     entry = vault.findChronicleEntry("JourneyClothProgress")
                     FoundJCs = entry.chronicleGetValue()
                     FoundJCs = FoundJCs + "Z"
-                    print "Updating Chronicle entry to ", FoundJCs
+                    print("Updating Chronicle entry to ", FoundJCs)
                     entry.chronicleSetValue("%s" % (FoundJCs)) 
                     entry.save()
                     respBackofCave.run(self.key, events=events)
@@ -187,43 +187,43 @@ class kemoJourneyClothGate(ptResponder):
         PtAtTimeCallback(self.key,8,1)         
 
         if not PtWasLocallyNotified(self.key):
-            print "Somebody touched the Journey Cloth Gate"
+            print("Somebody touched the Journey Cloth Gate")
             return
 
-        print "You clicked on the Gate"
+        print("You clicked on the Gate")
         vault = ptVault()
             
         entry = vault.findChronicleEntry("JourneyClothProgress")
         if entry is None: # is this the player's first Journey Cloth?
-            print "No cloths have been found. Get to work!"
+            print("No cloths have been found. Get to work!")
         else:
             FoundJCs = entry.chronicleGetValue()
             length = len(FoundJCs)
             all = len(AllCloths)
 
-            print "You've found the following %d Journey Cloths: %s" % (length, FoundJCs)
+            print("You've found the following %d Journey Cloths: %s" % (length, FoundJCs))
             
             if length < 0 or length > 11: 
-                print "xJourneyClothGate: ERROR: Unexpected length value received."
+                print("xJourneyClothGate: ERROR: Unexpected length value received.")
                 return
                 
             if "Z" in FoundJCs:
-                print "You've been here before, traveller."
+                print("You've been here before, traveller.")
                 PalmGlowStrong.run(self.key)                    
                 self.ToggleSDL("fromOutside")
                 return
 
             for each in FoundJCs:
                 if each not in AllCloths:
-                    print "Unexpected value among the 10 letters in the Chronicle:", each
+                    print("Unexpected value among the 10 letters in the Chronicle:", each)
                     return
 
             if length < all:
-                print "There are more Cloths out there. Get to work."
+                print("There are more Cloths out there. Get to work.")
                 PalmGlowWeak.run(self.key)
                 
             elif length == all:
-                print "All expected Cloths were found. Opening Door."
+                print("All expected Cloths were found. Opening Door.")
                 PalmGlowStrong.run(self.key)
                 self.ToggleSDL("fromOutside")
 
@@ -239,7 +239,7 @@ class kemoJourneyClothGate(ptResponder):
                 PtDebugPrint("kemoJourneyClothGate.OnServerInitComplete():\tERROR reading age SDL")
                 GateCurrentlyClosed = False
     
-            print "ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed
+            print("ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed)
     
             # Toggle the sdl value
             if GateCurrentlyClosed:
@@ -263,7 +263,7 @@ class kemoJourneyClothGate(ptResponder):
 
     def OnTimer(self,id):
         global GateInUse
-        print "Gate reactivated."
+        print("Gate reactivated.")
         if id==1:
             GateInUse = 0
 

--- a/Python/kemoJourneyClothGate.py
+++ b/Python/kemoJourneyClothGate.py
@@ -125,7 +125,7 @@ class kemoJourneyClothGate(ptResponder):
         if not state:
             return
         
-        print("##")
+        PtDebugPrint("##")
         
         if id == actTrigger.id:
             
@@ -138,7 +138,7 @@ class kemoJourneyClothGate(ptResponder):
                     PtDebugPrint("kemoJourneyClothGate.OnServerInitComplete():\tERROR reading age SDL")
                     GateCurrentlyClosed = False
                 
-                print("OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed)
+                PtDebugPrint("OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed)
                 if not GateCurrentlyClosed:
                     PtDebugPrint ("The gate is already open.")
                     return
@@ -165,7 +165,7 @@ class kemoJourneyClothGate(ptResponder):
                     entry = vault.findChronicleEntry("JourneyClothProgress")
                     FoundJCs = entry.chronicleGetValue()
                     FoundJCs = FoundJCs + "Z"
-                    print("Updating Chronicle entry to ", FoundJCs)
+                    PtDebugPrint("Updating Chronicle entry to ", FoundJCs)
                     entry.chronicleSetValue("%s" % (FoundJCs)) 
                     entry.save()
                     respBackofCave.run(self.key, events=events)
@@ -187,43 +187,43 @@ class kemoJourneyClothGate(ptResponder):
         PtAtTimeCallback(self.key,8,1)         
 
         if not PtWasLocallyNotified(self.key):
-            print("Somebody touched the Journey Cloth Gate")
+            PtDebugPrint("Somebody touched the Journey Cloth Gate")
             return
 
-        print("You clicked on the Gate")
+        PtDebugPrint("You clicked on the Gate")
         vault = ptVault()
             
         entry = vault.findChronicleEntry("JourneyClothProgress")
         if entry is None: # is this the player's first Journey Cloth?
-            print("No cloths have been found. Get to work!")
+            PtDebugPrint("No cloths have been found. Get to work!")
         else:
             FoundJCs = entry.chronicleGetValue()
             length = len(FoundJCs)
             all = len(AllCloths)
 
-            print("You've found the following %d Journey Cloths: %s" % (length, FoundJCs))
+            PtDebugPrint("You've found the following %d Journey Cloths: %s" % (length, FoundJCs))
             
             if length < 0 or length > 11: 
-                print("xJourneyClothGate: ERROR: Unexpected length value received.")
+                PtDebugPrint("xJourneyClothGate: ERROR: Unexpected length value received.")
                 return
                 
             if "Z" in FoundJCs:
-                print("You've been here before, traveller.")
+                PtDebugPrint("You've been here before, traveller.")
                 PalmGlowStrong.run(self.key)                    
                 self.ToggleSDL("fromOutside")
                 return
 
             for each in FoundJCs:
                 if each not in AllCloths:
-                    print("Unexpected value among the 10 letters in the Chronicle:", each)
+                    PtDebugPrint("Unexpected value among the 10 letters in the Chronicle:", each)
                     return
 
             if length < all:
-                print("There are more Cloths out there. Get to work.")
+                PtDebugPrint("There are more Cloths out there. Get to work.")
                 PalmGlowWeak.run(self.key)
                 
             elif length == all:
-                print("All expected Cloths were found. Opening Door.")
+                PtDebugPrint("All expected Cloths were found. Opening Door.")
                 PalmGlowStrong.run(self.key)
                 self.ToggleSDL("fromOutside")
 
@@ -239,7 +239,7 @@ class kemoJourneyClothGate(ptResponder):
                 PtDebugPrint("kemoJourneyClothGate.OnServerInitComplete():\tERROR reading age SDL")
                 GateCurrentlyClosed = False
     
-            print("ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed)
+            PtDebugPrint("ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed)
     
             # Toggle the sdl value
             if GateCurrentlyClosed:
@@ -263,7 +263,7 @@ class kemoJourneyClothGate(ptResponder):
 
     def OnTimer(self,id):
         global GateInUse
-        print("Gate reactivated.")
+        PtDebugPrint("Gate reactivated.")
         if id==1:
             GateInUse = 0
 

--- a/Python/kemoStormWaterModifier.py
+++ b/Python/kemoStormWaterModifier.py
@@ -76,7 +76,7 @@ class kemoStormWaterModifier(ptModifier):
             return
         
         if id == startRain.id:
-            print "starting rain drops on water"
+            print("starting rain drops on water")
             rainlevel = 3.0
             texamp  = 0.2
             #print "changing specular noise from %f to %f" % (theWater.waveset.getSpecularNoise(), rainlevel)
@@ -84,7 +84,7 @@ class kemoStormWaterModifier(ptModifier):
             theWater.waveset.setSpecularNoise(rainlevel, 5)
             theWater.waveset.setTexAmpOverLen(texamp, 5)
         elif id == stopRain.id:
-            print "stoping raindrops on water"
+            print("stoping raindrops on water")
             rainlevel = NoiseStartValue
             texamp = TexAmpStartValue
             #print "changing specular noise from %f to %f" % (theWater.waveset.getSpecularNoise(), rainlevel)
@@ -119,29 +119,29 @@ class kemoStormWaterModifier(ptModifier):
                         else:
                             p = val
 
-                    print "Using: get/set" + x[3:]
+                    print("Using: get/set" + x[3:])
 
                     startval = getattr(theWater.waveset, "get" + x[3:])()
 
                     if ifisinstance(p, ptColor):
-                        print "\tstartval = " + str( (startval.getRed(), startval.getGreen(), startval.getBlue()) )
-                        print "\tsetting to " + str( (p.getRed(), p.getGreen(), p.getBlue()) )
+                        print("\tstartval = " + str( (startval.getRed(), startval.getGreen(), startval.getBlue()) ))
+                        print("\tsetting to " + str( (p.getRed(), p.getGreen(), p.getBlue()) ))
                     elif isinstance(p, (ptPoint3, ptVector3)):
-                        print "\tstartval = " + str( (startval.getX(), startval.getY(), startval.getZ()) )
-                        print "\tsetting to " + str( (p.getX(), p.getY(), p.getZ()) )
+                        print("\tstartval = " + str( (startval.getX(), startval.getY(), startval.getZ()) ))
+                        print("\tsetting to " + str( (p.getX(), p.getY(), p.getZ()) ))
                     else:
-                        print "\tstartval = " + str(startval)
-                        print "\tsetting to " + str(p)
+                        print("\tstartval = " + str(startval))
+                        print("\tsetting to " + str(p))
                     
                     getattr(theWater.waveset, x)(p)
 
                     endval = getattr(theWater.waveset, "get" + x[3:])()
 
                     if ifisinstance(p, ptColor):
-                        print "\tendval = " + str( (endval.getRed(), endval.getGreen(), endval.getBlue()) )
+                        print("\tendval = " + str( (endval.getRed(), endval.getGreen(), endval.getBlue()) ))
                     elif isinstance(p, (ptPoint3, ptVector3)):
-                        print "\tendval = " + str( (endval.getX(), endval.getY(), endval.getZ()) )
+                        print("\tendval = " + str( (endval.getX(), endval.getY(), endval.getZ()) ))
                     else:
-                        print "\tendval = " + str(endval)
+                        print("\tendval = " + str(endval))
                     
                     val += 1

--- a/Python/kemoStormWaterModifier.py
+++ b/Python/kemoStormWaterModifier.py
@@ -76,19 +76,19 @@ class kemoStormWaterModifier(ptModifier):
             return
         
         if id == startRain.id:
-            print("starting rain drops on water")
+            PtDebugPrint("starting rain drops on water")
             rainlevel = 3.0
             texamp  = 0.2
-            #print "changing specular noise from %f to %f" % (theWater.waveset.getSpecularNoise(), rainlevel)
-            #print "changing tex amplitude  from %f to %f" % (theWater.waveset.getTexAmpOverLen(), texamp)
+            #PtDebugPrint("changing specular noise from %f to %f" % (theWater.waveset.getSpecularNoise(), rainlevel))
+            #PtDebugPrint("changing tex amplitude  from %f to %f" % (theWater.waveset.getTexAmpOverLen(), texamp))
             theWater.waveset.setSpecularNoise(rainlevel, 5)
             theWater.waveset.setTexAmpOverLen(texamp, 5)
         elif id == stopRain.id:
-            print("stoping raindrops on water")
+            PtDebugPrint("stoping raindrops on water")
             rainlevel = NoiseStartValue
             texamp = TexAmpStartValue
-            #print "changing specular noise from %f to %f" % (theWater.waveset.getSpecularNoise(), rainlevel)
-            #print "changing tex amplitude  from %f to %f" % (theWater.waveset.getTexAmpOverLen(), texamp)
+            #PtDebugPrint("changing specular noise from %f to %f" % (theWater.waveset.getSpecularNoise(), rainlevel))
+            #PtDebugPrint("changing tex amplitude  from %f to %f" % (theWater.waveset.getTexAmpOverLen(), texamp))
             theWater.waveset.setSpecularNoise(rainlevel, 5)
             theWater.waveset.setTexAmpOverLen(texamp, 5)
 
@@ -119,29 +119,29 @@ class kemoStormWaterModifier(ptModifier):
                         else:
                             p = val
 
-                    print("Using: get/set" + x[3:])
+                    PtDebugPrint("Using: get/set" + x[3:])
 
                     startval = getattr(theWater.waveset, "get" + x[3:])()
 
                     if ifisinstance(p, ptColor):
-                        print("\tstartval = " + str( (startval.getRed(), startval.getGreen(), startval.getBlue()) ))
-                        print("\tsetting to " + str( (p.getRed(), p.getGreen(), p.getBlue()) ))
+                        PtDebugPrint("\tstartval = " + str( (startval.getRed(), startval.getGreen(), startval.getBlue()) ))
+                        PtDebugPrint("\tsetting to " + str( (p.getRed(), p.getGreen(), p.getBlue()) ))
                     elif isinstance(p, (ptPoint3, ptVector3)):
-                        print("\tstartval = " + str( (startval.getX(), startval.getY(), startval.getZ()) ))
-                        print("\tsetting to " + str( (p.getX(), p.getY(), p.getZ()) ))
+                        PtDebugPrint("\tstartval = " + str( (startval.getX(), startval.getY(), startval.getZ()) ))
+                        PtDebugPrint("\tsetting to " + str( (p.getX(), p.getY(), p.getZ()) ))
                     else:
-                        print("\tstartval = " + str(startval))
-                        print("\tsetting to " + str(p))
+                        PtDebugPrint("\tstartval = " + str(startval))
+                        PtDebugPrint("\tsetting to " + str(p))
                     
                     getattr(theWater.waveset, x)(p)
 
                     endval = getattr(theWater.waveset, "get" + x[3:])()
 
                     if ifisinstance(p, ptColor):
-                        print("\tendval = " + str( (endval.getRed(), endval.getGreen(), endval.getBlue()) ))
+                        PtDebugPrint("\tendval = " + str( (endval.getRed(), endval.getGreen(), endval.getBlue()) ))
                     elif isinstance(p, (ptPoint3, ptVector3)):
-                        print("\tendval = " + str( (endval.getX(), endval.getY(), endval.getZ()) ))
+                        PtDebugPrint("\tendval = " + str( (endval.getX(), endval.getY(), endval.getZ()) ))
                     else:
-                        print("\tendval = " + str(endval))
+                        PtDebugPrint("\tendval = " + str(endval))
                     
                     val += 1

--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -72,13 +72,13 @@ from xPsnlVaultSDL import *
 from jlakConstants import *
 
 # xKI sub-modules.
-import xKIExtChatCommands
-import xKIChat
-from xKIConstants import *
-from xKIHelpers import *
+from . import xKIExtChatCommands
+from . import xKIChat
+from .xKIConstants import *
+from .xKIHelpers import *
 
 # Marker Game thingies
-import xMarkerMgr
+from . import xMarkerMgr
 
 # Define the attributes that will be entered in Max.
 KIBlackbar = ptAttribGUIDialog(1, "The Blackbar dialog")

--- a/Python/ki/xKIChat.py
+++ b/Python/ki/xKIChat.py
@@ -56,9 +56,9 @@ import xCensor
 import xLocTools
 
 # xKI sub-modules.
-import xKIExtChatCommands
-from xKIConstants import *
-from xKIHelpers import *
+from . import xKIExtChatCommands
+from .xKIConstants import *
+from .xKIHelpers import *
 
 
 ## A class to process all the RT Chat functions of the KI.

--- a/Python/ki/xKIHelpers.py
+++ b/Python/ki/xKIHelpers.py
@@ -51,7 +51,7 @@ import xLocTools
 from xPsnlVaultSDL import *
 
 # xKI sub-modules.
-from xKIConstants import *
+from .xKIConstants import *
 
 
 ## Helper class for autocompletion in the KI.

--- a/Python/ki/xMarkerBrainQuest.py
+++ b/Python/ki/xMarkerBrainQuest.py
@@ -46,8 +46,8 @@ from PlasmaKITypes import *
 from PlasmaTypes import *
 
 import grtzMarkerGames
-from xMarkerGameBrain import *
-from xMarkerBrainUser import *
+from .xMarkerGameBrain import *
+from .xMarkerBrainUser import *
 
 class QuestMarkerBrain(object):
     def CaptureAllMarkers(self):

--- a/Python/ki/xMarkerMgr.py
+++ b/Python/ki/xMarkerMgr.py
@@ -46,8 +46,8 @@ from PlasmaConstants import *
 from PlasmaKITypes import *
 from PlasmaTypes import *
 
-from xMarkerBrainQuest import *
-from xMarkerGameBrain import *
+from .xMarkerBrainQuest import *
+from .xMarkerGameBrain import *
 
 class MarkerGameManager(object):
     def __init__(self):

--- a/Python/krelPodium.py
+++ b/Python/krelPodium.py
@@ -82,13 +82,13 @@ class krelPodium(ptResponder):
 
         version = 2
         self.version = version
-        print "__init__krelPodium v.", version,".0"
+        print("__init__krelPodium v.", version,".0")
     
     def OnServerInitComplete(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "krelPodium:\tERROR---Cannot find the Kirel Age SDL"
+            print("krelPodium:\tERROR---Cannot find the Kirel Age SDL")
             ageSDL["nb01CmnRmSpeech"] = (0, ) 
 
         ageSDL.setNotify(self.key,"nb01CmnRmSpeech",0.0)        
@@ -105,7 +105,7 @@ class krelPodium(ptResponder):
     def OnNotify(self,state,id,events):
         ageSDL = PtGetAgeSDL()     
         
-        print "krelPodium.OnNotify:  state=%f id=%d events=" % (state,id),events
+        print("krelPodium.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if not state:
             return
@@ -115,21 +115,21 @@ class krelPodium(ptResponder):
             return
             
         elif id == respButtonOneshot.id and self.sceneobject.isLocallyOwned():
-            print "##"
+            print("##")
             nb01CmnRmSpeech = ageSDL["nb01CmnRmSpeech"][0] 
             
             if nb01CmnRmSpeech == 0: # No speech was playing
-                print "krelPodium: No speech was previously playing. Playing speech #1."
+                print("krelPodium: No speech was previously playing. Playing speech #1.")
                 respSpeech01.run(self.key)
                 ageSDL["nb01CmnRmSpeech"] = (1,)
 
             else: 
-                print "krelPodium: Speech #1 was stopped manually by the avatar."
+                print("krelPodium: Speech #1 was stopped manually by the avatar.")
                 respSilence.run(self.key)
                 ageSDL["nb01CmnRmSpeech"] = (0,)
                 
                 
         elif id == respSpeech01.id:
-            print "krelPodium: Speech #1 was stopped automatically after it finished playing."
+            print("krelPodium: Speech #1 was stopped automatically after it finished playing.")
             respSilence.run(self.key)
             ageSDL["nb01CmnRmSpeech"] = (0,)

--- a/Python/krelPodium.py
+++ b/Python/krelPodium.py
@@ -82,13 +82,13 @@ class krelPodium(ptResponder):
 
         version = 2
         self.version = version
-        print("__init__krelPodium v.", version,".0")
+        PtDebugPrint("__init__krelPodium v.", version,".0")
     
     def OnServerInitComplete(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("krelPodium:\tERROR---Cannot find the Kirel Age SDL")
+            PtDebugPrint("krelPodium:\tERROR---Cannot find the Kirel Age SDL")
             ageSDL["nb01CmnRmSpeech"] = (0, ) 
 
         ageSDL.setNotify(self.key,"nb01CmnRmSpeech",0.0)        
@@ -105,7 +105,7 @@ class krelPodium(ptResponder):
     def OnNotify(self,state,id,events):
         ageSDL = PtGetAgeSDL()     
         
-        print("krelPodium.OnNotify:  state=%f id=%d events=" % (state,id),events)
+        PtDebugPrint("krelPodium.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if not state:
             return
@@ -115,21 +115,21 @@ class krelPodium(ptResponder):
             return
             
         elif id == respButtonOneshot.id and self.sceneobject.isLocallyOwned():
-            print("##")
+            PtDebugPrint("##")
             nb01CmnRmSpeech = ageSDL["nb01CmnRmSpeech"][0] 
             
             if nb01CmnRmSpeech == 0: # No speech was playing
-                print("krelPodium: No speech was previously playing. Playing speech #1.")
+                PtDebugPrint("krelPodium: No speech was previously playing. Playing speech #1.")
                 respSpeech01.run(self.key)
                 ageSDL["nb01CmnRmSpeech"] = (1,)
 
             else: 
-                print("krelPodium: Speech #1 was stopped manually by the avatar.")
+                PtDebugPrint("krelPodium: Speech #1 was stopped manually by the avatar.")
                 respSilence.run(self.key)
                 ageSDL["nb01CmnRmSpeech"] = (0,)
                 
                 
         elif id == respSpeech01.id:
-            print("krelPodium: Speech #1 was stopped automatically after it finished playing.")
+            PtDebugPrint("krelPodium: Speech #1 was stopped automatically after it finished playing.")
             respSilence.run(self.key)
             ageSDL["nb01CmnRmSpeech"] = (0,)

--- a/Python/minkCage.py
+++ b/Python/minkCage.py
@@ -66,7 +66,7 @@ class minkCage(ptResponder):
         self.id = 5261
         version = 2
         self.version = version
-        print "__init__minkCage v.", version,".0"
+        print("__init__minkCage v.", version,".0")
 
     ###########################
     def OnFirstUpdate(self):
@@ -74,7 +74,7 @@ class minkCage(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "minkCage.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL"
+            print("minkCage.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL")
 
         ageSDL.setFlags("minkSymbolPart01", 1, 1)
         ageSDL.setFlags("minkSymbolPart02", 1, 1)
@@ -94,33 +94,33 @@ class minkCage(ptResponder):
         ageSDL.setNotify(self.key, "minkSymbolPart04", 0.0)
         ageSDL.setNotify(self.key, "minkSymbolPart05", 0.0)
 
-        print "minkCage.OnFirstUpdate(): Hiding all Cage Symbol pieces"
+        print("minkCage.OnFirstUpdate(): Hiding all Cage Symbol pieces")
         respCageSymbol.run(self.key, state="Hide")
 
         symbolCount = 0
 
         if ageSDL["minkSymbolPart01"][0]:
-            print "minkCage.OnFirstUpdate(): You've found piece 1"
+            print("minkCage.OnFirstUpdate(): You've found piece 1")
             respCageSymbol.run(self.key, state="1")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart02"][0]:
-            print "minkCage.OnFirstUpdate(): You've found piece 2"
+            print("minkCage.OnFirstUpdate(): You've found piece 2")
             respCageSymbol.run(self.key, state="2")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart03"][0]:
-            print "minkCage.OnFirstUpdate(): You've found piece 3"
+            print("minkCage.OnFirstUpdate(): You've found piece 3")
             respCageSymbol.run(self.key, state="3")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart04"][0]:
-            print "minkCage.OnFirstUpdate(): You've found piece 4"
+            print("minkCage.OnFirstUpdate(): You've found piece 4")
             respCageSymbol.run(self.key, state="4")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart05"][0]:
-            print "minkCage.OnFirstUpdate(): You've found piece 5"
+            print("minkCage.OnFirstUpdate(): You've found piece 5")
             respCageSymbol.run(self.key, state="5")
             symbolCount += 1
 
@@ -130,15 +130,15 @@ class minkCage(ptResponder):
 
 
         if ageSDL["minkSymbolPart01"][0] and ageSDL["minkSymbolPart02"][0] and ageSDL["minkSymbolPart03"][0] and ageSDL["minkSymbolPart04"][0] and ageSDL["minkSymbolPart05"][0]:
-            print "minkCage.OnFirstUpdate(): You've found all the Pieces, enabling link"
+            print("minkCage.OnFirstUpdate(): You've found all the Pieces, enabling link")
             regCageSymbol.enable()
 
     ###########################
     def OnNotify(self,state,id,events):
-        print "minkCage.OnNotify(): state=%s id=%d events=" % (state, id), events
+        print("minkCage.OnNotify(): state=%s id=%d events=" % (state, id), events)
 
         if id == regCageSymbol.id and PtFindAvatar(events) == PtGetLocalAvatar():
-            print "minkCage.OnNotify(): Linking to bahro cave."
+            print("minkCage.OnNotify(): Linking to bahro cave.")
             respCageSymbol.run(self.key, state="Link", avatar=PtGetLocalAvatar())
 
     ###########################

--- a/Python/minkCage.py
+++ b/Python/minkCage.py
@@ -66,7 +66,7 @@ class minkCage(ptResponder):
         self.id = 5261
         version = 2
         self.version = version
-        print("__init__minkCage v.", version,".0")
+        PtDebugPrint("__init__minkCage v.", version,".0")
 
     ###########################
     def OnFirstUpdate(self):
@@ -74,7 +74,7 @@ class minkCage(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("minkCage.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL")
+            PtDebugPrint("minkCage.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL")
 
         ageSDL.setFlags("minkSymbolPart01", 1, 1)
         ageSDL.setFlags("minkSymbolPart02", 1, 1)
@@ -94,33 +94,33 @@ class minkCage(ptResponder):
         ageSDL.setNotify(self.key, "minkSymbolPart04", 0.0)
         ageSDL.setNotify(self.key, "minkSymbolPart05", 0.0)
 
-        print("minkCage.OnFirstUpdate(): Hiding all Cage Symbol pieces")
+        PtDebugPrint("minkCage.OnFirstUpdate(): Hiding all Cage Symbol pieces")
         respCageSymbol.run(self.key, state="Hide")
 
         symbolCount = 0
 
         if ageSDL["minkSymbolPart01"][0]:
-            print("minkCage.OnFirstUpdate(): You've found piece 1")
+            PtDebugPrint("minkCage.OnFirstUpdate(): You've found piece 1")
             respCageSymbol.run(self.key, state="1")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart02"][0]:
-            print("minkCage.OnFirstUpdate(): You've found piece 2")
+            PtDebugPrint("minkCage.OnFirstUpdate(): You've found piece 2")
             respCageSymbol.run(self.key, state="2")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart03"][0]:
-            print("minkCage.OnFirstUpdate(): You've found piece 3")
+            PtDebugPrint("minkCage.OnFirstUpdate(): You've found piece 3")
             respCageSymbol.run(self.key, state="3")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart04"][0]:
-            print("minkCage.OnFirstUpdate(): You've found piece 4")
+            PtDebugPrint("minkCage.OnFirstUpdate(): You've found piece 4")
             respCageSymbol.run(self.key, state="4")
             symbolCount += 1
 
         if ageSDL["minkSymbolPart05"][0]:
-            print("minkCage.OnFirstUpdate(): You've found piece 5")
+            PtDebugPrint("minkCage.OnFirstUpdate(): You've found piece 5")
             respCageSymbol.run(self.key, state="5")
             symbolCount += 1
 
@@ -130,15 +130,15 @@ class minkCage(ptResponder):
 
 
         if ageSDL["minkSymbolPart01"][0] and ageSDL["minkSymbolPart02"][0] and ageSDL["minkSymbolPart03"][0] and ageSDL["minkSymbolPart04"][0] and ageSDL["minkSymbolPart05"][0]:
-            print("minkCage.OnFirstUpdate(): You've found all the Pieces, enabling link")
+            PtDebugPrint("minkCage.OnFirstUpdate(): You've found all the Pieces, enabling link")
             regCageSymbol.enable()
 
     ###########################
     def OnNotify(self,state,id,events):
-        print("minkCage.OnNotify(): state=%s id=%d events=" % (state, id), events)
+        PtDebugPrint("minkCage.OnNotify(): state=%s id=%d events=" % (state, id), events)
 
         if id == regCageSymbol.id and PtFindAvatar(events) == PtGetLocalAvatar():
-            print("minkCage.OnNotify(): Linking to bahro cave.")
+            PtDebugPrint("minkCage.OnNotify(): Linking to bahro cave.")
             respCageSymbol.run(self.key, state="Link", avatar=PtGetLocalAvatar())
 
     ###########################

--- a/Python/minkDayClicks.py
+++ b/Python/minkDayClicks.py
@@ -93,14 +93,14 @@ class minkDayClicks(ptResponder):
         self.id = 5259
         version = 1
         self.version = version
-        print "__init__minkDayClicks v.", version,".0"
+        print("__init__minkDayClicks v.", version,".0")
 
     ###########################
     def OnFirstUpdate(self):
         ageSDL = PtGetAgeSDL()
 
         if not len(PtGetPlayerList()) and ageSDL["minkIsDayTime"][0]:
-            print "minkDayClicks.OnFirstUpdate(): Resetting Show and Touch vars."
+            print("minkDayClicks.OnFirstUpdate(): Resetting Show and Touch vars.")
             ageSDL["minkSymbolShow01"] = (0,)
             ageSDL["minkSymbolShow02"] = (0,)
             ageSDL["minkSymbolShow03"] = (0,)
@@ -115,10 +115,10 @@ class minkDayClicks(ptResponder):
 
     ###########################
     def OnNotify(self,state,id,events):
-        print "minkDayClicks.OnNotify(): state=%s id=%d events=" % (state, id), events
+        print("minkDayClicks.OnNotify(): state=%s id=%d events=" % (state, id), events)
 
         if id in ClickToResponder.viewkeys() and state and PtFindAvatar(events) == PtGetLocalAvatar():
-            print "minkDayClicks.OnNotify(): Clicked on %d, running %d" % (id, ClickToResponder[id].id)
+            print("minkDayClicks.OnNotify(): Clicked on %d, running %d" % (id, ClickToResponder[id].id))
             LocalAvatar = PtFindAvatar(events)
             clkCave01.disable()
             clkCave02.disable()
@@ -129,12 +129,12 @@ class minkDayClicks(ptResponder):
             ClickToResponder[id].run(self.key, avatar=LocalAvatar)
 
         elif id in ResponderId:
-            print "minkDayClicks.OnNotify(): Responder Finished, Updating SDL"
+            print("minkDayClicks.OnNotify(): Responder Finished, Updating SDL")
             ageSDL = PtGetAgeSDL()
             ageSDL["minkIsDayTime"] = (not ageSDL["minkIsDayTime"][0],)
 
             if id != behRespCage.id:
                 num = ResponderId.index(id) + 1
-                print "minkDayClicks.OnNotify(): Should show %d" % (num)
+                print("minkDayClicks.OnNotify(): Should show %d" % (num))
                 code = "ageSDL[\"minkSymbolShow0%d\"] = (1,)" % (num)
-                exec code
+                exec(code)

--- a/Python/minkDayClicks.py
+++ b/Python/minkDayClicks.py
@@ -93,14 +93,14 @@ class minkDayClicks(ptResponder):
         self.id = 5259
         version = 1
         self.version = version
-        print("__init__minkDayClicks v.", version,".0")
+        PtDebugPrint("__init__minkDayClicks v.", version,".0")
 
     ###########################
     def OnFirstUpdate(self):
         ageSDL = PtGetAgeSDL()
 
         if not len(PtGetPlayerList()) and ageSDL["minkIsDayTime"][0]:
-            print("minkDayClicks.OnFirstUpdate(): Resetting Show and Touch vars.")
+            PtDebugPrint("minkDayClicks.OnFirstUpdate(): Resetting Show and Touch vars.")
             ageSDL["minkSymbolShow01"] = (0,)
             ageSDL["minkSymbolShow02"] = (0,)
             ageSDL["minkSymbolShow03"] = (0,)
@@ -115,10 +115,10 @@ class minkDayClicks(ptResponder):
 
     ###########################
     def OnNotify(self,state,id,events):
-        print("minkDayClicks.OnNotify(): state=%s id=%d events=" % (state, id), events)
+        PtDebugPrint("minkDayClicks.OnNotify(): state=%s id=%d events=" % (state, id), events)
 
         if id in ClickToResponder.viewkeys() and state and PtFindAvatar(events) == PtGetLocalAvatar():
-            print("minkDayClicks.OnNotify(): Clicked on %d, running %d" % (id, ClickToResponder[id].id))
+            PtDebugPrint("minkDayClicks.OnNotify(): Clicked on %d, running %d" % (id, ClickToResponder[id].id))
             LocalAvatar = PtFindAvatar(events)
             clkCave01.disable()
             clkCave02.disable()
@@ -129,12 +129,12 @@ class minkDayClicks(ptResponder):
             ClickToResponder[id].run(self.key, avatar=LocalAvatar)
 
         elif id in ResponderId:
-            print("minkDayClicks.OnNotify(): Responder Finished, Updating SDL")
+            PtDebugPrint("minkDayClicks.OnNotify(): Responder Finished, Updating SDL")
             ageSDL = PtGetAgeSDL()
             ageSDL["minkIsDayTime"] = (not ageSDL["minkIsDayTime"][0],)
 
             if id != behRespCage.id:
                 num = ResponderId.index(id) + 1
-                print("minkDayClicks.OnNotify(): Should show %d" % (num))
+                PtDebugPrint("minkDayClicks.OnNotify(): Should show %d" % (num))
                 code = "ageSDL[\"minkSymbolShow0%d\"] = (1,)" % (num)
                 exec(code)

--- a/Python/minkDayNight.py
+++ b/Python/minkDayNight.py
@@ -67,7 +67,7 @@ class minkDayNight(ptResponder):
         self.id = 5258
         version = 1
         self.version = version
-        print "__init__minkDayNight v.", version,".0"
+        print("__init__minkDayNight v.", version,".0")
 
     ###########################
     def OnServerInitComplete(self):
@@ -76,7 +76,7 @@ class minkDayNight(ptResponder):
             ageSDL = PtGetAgeSDL()
             ageSDL["minkIsDayTime"][0]
         except:
-            print "minkDayNight.OnServerInitComplete(): ERROR --- Cannot find Minkata age SDL"
+            print("minkDayNight.OnServerInitComplete(): ERROR --- Cannot find Minkata age SDL")
             ageSDL["minkIsDayTime"] = (1,)
 
         ageSDL.setFlags("minkIsDayTime", 1, 1)
@@ -87,19 +87,19 @@ class minkDayNight(ptResponder):
             ageSDL["minkIsDayTime"] = (1,)
 
         if ageSDL["minkIsDayTime"][0]:
-            print "minkDayNight.OnServerInitComplete(): It's Day Time, Loading Day Page"
+            print("minkDayNight.OnServerInitComplete(): It's Day Time, Loading Day Page")
             PtPageInNode("minkExteriorDay")
         else:
-            print "minkDayNight.OnServerInitComplete(): It's Night Time, Loading Night Page"
+            print("minkDayNight.OnServerInitComplete(): It's Night Time, Loading Night Page")
             PtPageInNode("minkExteriorNight")
         
     ###########################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
-        print "minkDayNight.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID)
+        print("minkDayNight.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
 
         if VARname == "minkIsDayTime" and not HackIt:
-            print "minkDayNight.OnSDLNotify(): SDL Updated, Fading Screen"
+            print("minkDayNight.OnSDLNotify(): SDL Updated, Fading Screen")
             PtDisableMovementKeys()
             PtSendKIMessage(kDisableKIandBB,0)
             PtFadeOut(1.5, 1)
@@ -111,14 +111,14 @@ class minkDayNight(ptResponder):
         if id == 1:
             ageSDL = PtGetAgeSDL()
             if ageSDL["minkIsDayTime"][0]:
-                print "minkDayNight.OnTimer(): Paging in Day Page"
+                print("minkDayNight.OnTimer(): Paging in Day Page")
                 PtPageInNode("minkExteriorDay")
             else:
-                print "minkDayNight.OnTimer(): Paging in Night Page"
+                print("minkDayNight.OnTimer(): Paging in Night Page")
                 PtPageInNode("minkExteriorNight")
 
         elif id == 2:
-            print "minkDayNight.OnTimer(): Finished faux link, Re-enable controls"
+            print("minkDayNight.OnTimer(): Finished faux link, Re-enable controls")
             PtEnableMovementKeys()
             PtSendKIMessage(kEnableKIandBB,0)
 
@@ -136,19 +136,19 @@ class minkDayNight(ptResponder):
                 if HackIt:
                     HackIt = 0
                     return
-                print "minkDayNight.OnPageLoad(): Day Page loaded, unloading Night"
+                print("minkDayNight.OnPageLoad(): Day Page loaded, unloading Night")
                 PtPageOutNode("minkExteriorNight")
             elif who in {u"Minkata_District_minkExteriorNight", u"Minkata_minkExteriorNight"}:
                 if HackIt:
                     HackIt = 0
                     return
-                print "minkDayNight.OnPageLoad(): Night Page loaded, unloading Day"
+                print("minkDayNight.OnPageLoad(): Night Page loaded, unloading Day")
                 PtPageOutNode("minkExteriorDay")
                 
         elif what == kUnloaded:
             if who in {u"Minkata_District_minkExteriorDay", u"Minkata_District_minkExteriorNight",
                        u"Minkata_minkExteriorDay", u"Minkata_minkExteriorNight"}:
-                print "minkDayNight.OnPageLoad(): Page unloaded, Fading screen back in"
+                print("minkDayNight.OnPageLoad(): Page unloaded, Fading screen back in")
                 PtFadeIn(1.5, 1)
                 respExcludeRegion.run(self.key, state="Release")
                 PtAtTimeCallback(self.key, 2, 2)

--- a/Python/minkDayNight.py
+++ b/Python/minkDayNight.py
@@ -67,7 +67,7 @@ class minkDayNight(ptResponder):
         self.id = 5258
         version = 1
         self.version = version
-        print("__init__minkDayNight v.", version,".0")
+        PtDebugPrint("__init__minkDayNight v.", version,".0")
 
     ###########################
     def OnServerInitComplete(self):
@@ -76,7 +76,7 @@ class minkDayNight(ptResponder):
             ageSDL = PtGetAgeSDL()
             ageSDL["minkIsDayTime"][0]
         except:
-            print("minkDayNight.OnServerInitComplete(): ERROR --- Cannot find Minkata age SDL")
+            PtDebugPrint("minkDayNight.OnServerInitComplete(): ERROR --- Cannot find Minkata age SDL")
             ageSDL["minkIsDayTime"] = (1,)
 
         ageSDL.setFlags("minkIsDayTime", 1, 1)
@@ -87,19 +87,19 @@ class minkDayNight(ptResponder):
             ageSDL["minkIsDayTime"] = (1,)
 
         if ageSDL["minkIsDayTime"][0]:
-            print("minkDayNight.OnServerInitComplete(): It's Day Time, Loading Day Page")
+            PtDebugPrint("minkDayNight.OnServerInitComplete(): It's Day Time, Loading Day Page")
             PtPageInNode("minkExteriorDay")
         else:
-            print("minkDayNight.OnServerInitComplete(): It's Night Time, Loading Night Page")
+            PtDebugPrint("minkDayNight.OnServerInitComplete(): It's Night Time, Loading Night Page")
             PtPageInNode("minkExteriorNight")
         
     ###########################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
-        print("minkDayNight.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
+        PtDebugPrint("minkDayNight.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
 
         if VARname == "minkIsDayTime" and not HackIt:
-            print("minkDayNight.OnSDLNotify(): SDL Updated, Fading Screen")
+            PtDebugPrint("minkDayNight.OnSDLNotify(): SDL Updated, Fading Screen")
             PtDisableMovementKeys()
             PtSendKIMessage(kDisableKIandBB,0)
             PtFadeOut(1.5, 1)
@@ -111,14 +111,14 @@ class minkDayNight(ptResponder):
         if id == 1:
             ageSDL = PtGetAgeSDL()
             if ageSDL["minkIsDayTime"][0]:
-                print("minkDayNight.OnTimer(): Paging in Day Page")
+                PtDebugPrint("minkDayNight.OnTimer(): Paging in Day Page")
                 PtPageInNode("minkExteriorDay")
             else:
-                print("minkDayNight.OnTimer(): Paging in Night Page")
+                PtDebugPrint("minkDayNight.OnTimer(): Paging in Night Page")
                 PtPageInNode("minkExteriorNight")
 
         elif id == 2:
-            print("minkDayNight.OnTimer(): Finished faux link, Re-enable controls")
+            PtDebugPrint("minkDayNight.OnTimer(): Finished faux link, Re-enable controls")
             PtEnableMovementKeys()
             PtSendKIMessage(kEnableKIandBB,0)
 
@@ -136,19 +136,19 @@ class minkDayNight(ptResponder):
                 if HackIt:
                     HackIt = 0
                     return
-                print("minkDayNight.OnPageLoad(): Day Page loaded, unloading Night")
+                PtDebugPrint("minkDayNight.OnPageLoad(): Day Page loaded, unloading Night")
                 PtPageOutNode("minkExteriorNight")
             elif who in {u"Minkata_District_minkExteriorNight", u"Minkata_minkExteriorNight"}:
                 if HackIt:
                     HackIt = 0
                     return
-                print("minkDayNight.OnPageLoad(): Night Page loaded, unloading Day")
+                PtDebugPrint("minkDayNight.OnPageLoad(): Night Page loaded, unloading Day")
                 PtPageOutNode("minkExteriorDay")
                 
         elif what == kUnloaded:
             if who in {u"Minkata_District_minkExteriorDay", u"Minkata_District_minkExteriorNight",
                        u"Minkata_minkExteriorDay", u"Minkata_minkExteriorNight"}:
-                print("minkDayNight.OnPageLoad(): Page unloaded, Fading screen back in")
+                PtDebugPrint("minkDayNight.OnPageLoad(): Page unloaded, Fading screen back in")
                 PtFadeIn(1.5, 1)
                 respExcludeRegion.run(self.key, state="Release")
                 PtAtTimeCallback(self.key, 2, 2)

--- a/Python/minkSymbols.py
+++ b/Python/minkSymbols.py
@@ -89,7 +89,7 @@ class minkSymbols(ptResponder):
         self.id = 5260
         version = 1
         self.version = version
-        print "__init__minkSymbols v.", version,".0"
+        print("__init__minkSymbols v.", version,".0")
 
     ###########################
     def OnFirstUpdate(self):
@@ -97,7 +97,7 @@ class minkSymbols(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "minkSymbols.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL"
+            print("minkSymbols.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL")
 
         ageSDL.setFlags("minkSymbolPart01", 1, 1)
         ageSDL.setFlags("minkSymbolPart02", 1, 1)
@@ -148,66 +148,66 @@ class minkSymbols(ptResponder):
         ageSDL.setNotify(self.key, "minkSymbolTouch05", 0.0)
 
         if ageSDL["minkSymbolPart01"][0] or not ageSDL["minkSymbolShow01"][0]:
-            print "minkSymbols.OnFirstUpdate(): You already found piece 1"
+            print("minkSymbols.OnFirstUpdate(): You already found piece 1")
             respDisableCave01.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart02"][0] or not ageSDL["minkSymbolShow02"][0]:
-            print "minkSymbols.OnFirstUpdate(): You already found piece 2"
+            print("minkSymbols.OnFirstUpdate(): You already found piece 2")
             respDisableCave02.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart03"][0] or not ageSDL["minkSymbolShow03"][0]:
-            print "minkSymbols.OnFirstUpdate(): You already found piece 3"
+            print("minkSymbols.OnFirstUpdate(): You already found piece 3")
             respDisableCave03.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart04"][0] or not ageSDL["minkSymbolShow04"][0]:
-            print "minkSymbols.OnFirstUpdate(): You already found piece 4"
+            print("minkSymbols.OnFirstUpdate(): You already found piece 4")
             respDisableCave04.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart05"][0] or not ageSDL["minkSymbolShow05"][0]:
-            print "minkSymbols.OnFirstUpdate(): You already found piece 5"
+            print("minkSymbols.OnFirstUpdate(): You already found piece 5")
             respDisableCave05.run(self.key, netPropagate=0)
 
 
         #If someone links in and someone else already activated the symbol, we need to try syncing them
         if ageSDL["minkSymbolTouch01"][0]:
-            print "minkSymbols.OnFirstUpdate(): Piece 1 was touched this session."
+            print("minkSymbols.OnFirstUpdate(): Piece 1 was touched this session.")
             respCave01.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch02"][0]:
-            print "minkSymbols.OnFirstUpdate(): Piece 2 was touched this session."
+            print("minkSymbols.OnFirstUpdate(): Piece 2 was touched this session.")
             respCave02.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch03"][0]:
-            print "minkSymbols.OnFirstUpdate(): Piece 3 was touched this session."
+            print("minkSymbols.OnFirstUpdate(): Piece 3 was touched this session.")
             respCave03.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch04"][0]:
-            print "minkSymbols.OnFirstUpdate(): Piece 4 was touched this session."
+            print("minkSymbols.OnFirstUpdate(): Piece 4 was touched this session.")
             respCave04.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch05"][0]:
-            print "minkSymbols.OnFirstUpdate(): Piece 5 was touched this session."
+            print("minkSymbols.OnFirstUpdate(): Piece 5 was touched this session.")
             respCave05.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
     ###########################
     def OnNotify(self,state,id,events):
-        print "minkSymbols.OnNotify(): state=%s id=%d events=" % (state, id), events
+        print("minkSymbols.OnNotify(): state=%s id=%d events=" % (state, id), events)
 
         if id in RegionToResponder.viewkeys():
-            print "minkSymbols.OnNotify(): Region %d triggered" % (id)
+            print("minkSymbols.OnNotify(): Region %d triggered" % (id))
             code = "regCave0" + str(id) + ".disable()"
-            exec code
+            exec(code)
 
             ageSDL = PtGetAgeSDL()
             code = "ageSDL[\"minkSymbolPart0" + str(id) + "\"] = (1,)"
-            exec code
+            exec(code)
 
             code = "ageSDL[\"minkSymbolTouch0" + str(id) + "\"] = (1,)"
-            exec code
+            exec(code)
 
             RegionToResponder[id].run(self.key)

--- a/Python/minkSymbols.py
+++ b/Python/minkSymbols.py
@@ -89,7 +89,7 @@ class minkSymbols(ptResponder):
         self.id = 5260
         version = 1
         self.version = version
-        print("__init__minkSymbols v.", version,".0")
+        PtDebugPrint("__init__minkSymbols v.", version,".0")
 
     ###########################
     def OnFirstUpdate(self):
@@ -97,7 +97,7 @@ class minkSymbols(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("minkSymbols.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): ERROR --- Cannot find Minkata age SDL")
 
         ageSDL.setFlags("minkSymbolPart01", 1, 1)
         ageSDL.setFlags("minkSymbolPart02", 1, 1)
@@ -148,58 +148,58 @@ class minkSymbols(ptResponder):
         ageSDL.setNotify(self.key, "minkSymbolTouch05", 0.0)
 
         if ageSDL["minkSymbolPart01"][0] or not ageSDL["minkSymbolShow01"][0]:
-            print("minkSymbols.OnFirstUpdate(): You already found piece 1")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): You already found piece 1")
             respDisableCave01.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart02"][0] or not ageSDL["minkSymbolShow02"][0]:
-            print("minkSymbols.OnFirstUpdate(): You already found piece 2")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): You already found piece 2")
             respDisableCave02.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart03"][0] or not ageSDL["minkSymbolShow03"][0]:
-            print("minkSymbols.OnFirstUpdate(): You already found piece 3")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): You already found piece 3")
             respDisableCave03.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart04"][0] or not ageSDL["minkSymbolShow04"][0]:
-            print("minkSymbols.OnFirstUpdate(): You already found piece 4")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): You already found piece 4")
             respDisableCave04.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolPart05"][0] or not ageSDL["minkSymbolShow05"][0]:
-            print("minkSymbols.OnFirstUpdate(): You already found piece 5")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): You already found piece 5")
             respDisableCave05.run(self.key, netPropagate=0)
 
 
         #If someone links in and someone else already activated the symbol, we need to try syncing them
         if ageSDL["minkSymbolTouch01"][0]:
-            print("minkSymbols.OnFirstUpdate(): Piece 1 was touched this session.")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): Piece 1 was touched this session.")
             respCave01.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch02"][0]:
-            print("minkSymbols.OnFirstUpdate(): Piece 2 was touched this session.")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): Piece 2 was touched this session.")
             respCave02.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch03"][0]:
-            print("minkSymbols.OnFirstUpdate(): Piece 3 was touched this session.")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): Piece 3 was touched this session.")
             respCave03.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch04"][0]:
-            print("minkSymbols.OnFirstUpdate(): Piece 4 was touched this session.")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): Piece 4 was touched this session.")
             respCave04.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
         if ageSDL["minkSymbolTouch05"][0]:
-            print("minkSymbols.OnFirstUpdate(): Piece 5 was touched this session.")
+            PtDebugPrint("minkSymbols.OnFirstUpdate(): Piece 5 was touched this session.")
             respCave05.run(self.key, fastforward=1, netPropagate=0)
             respMusic.run(self.key, netPropagate=0)
 
     ###########################
     def OnNotify(self,state,id,events):
-        print("minkSymbols.OnNotify(): state=%s id=%d events=" % (state, id), events)
+        PtDebugPrint("minkSymbols.OnNotify(): state=%s id=%d events=" % (state, id), events)
 
         if id in RegionToResponder.viewkeys():
-            print("minkSymbols.OnNotify(): Region %d triggered" % (id))
+            PtDebugPrint("minkSymbols.OnNotify(): Region %d triggered" % (id))
             code = "regCave0" + str(id) + ".disable()"
             exec(code)
 

--- a/Python/mymod.py
+++ b/Python/mymod.py
@@ -154,7 +154,7 @@ class mymod(ptModifier):
 
     def Save(self,savefile):
         "Save variables that we need to be persistent"
-        print("Save variables")
+        PtDebugPrint("Save variables")
         cPickle.dump(self.svMyNumber,savefile)
         cPickle.dump(openb.value,savefile)
         # this will recursively go through all the elements of the list and pickle each item
@@ -163,7 +163,7 @@ class mymod(ptModifier):
 
     def Load(self, loadfile):
         "Load the persistent variables"
-        print("Load variables")
+        PtDebugPrint("Load variables")
         self.svMyNumber = cPickle.load(loadfile)
         openb.value = cPickle.load(loadfile)
         # this will recreate a list of myHelper objects
@@ -171,9 +171,9 @@ class mymod(ptModifier):
 
     def OnPageLoad(self,what,who):
         if what==kLoaded:
-            print("%s is finished loading" % (who))
+            PtDebugPrint("%s is finished loading" % (who))
         elif what == kUnloaded:
-            print("%s is finished unloading" % (who))
+            PtDebugPrint("%s is finished unloading" % (who))
 
 #====================================
 # Helper class

--- a/Python/mymod.py
+++ b/Python/mymod.py
@@ -154,7 +154,7 @@ class mymod(ptModifier):
 
     def Save(self,savefile):
         "Save variables that we need to be persistent"
-        print "Save variables"
+        print("Save variables")
         cPickle.dump(self.svMyNumber,savefile)
         cPickle.dump(openb.value,savefile)
         # this will recursively go through all the elements of the list and pickle each item
@@ -163,7 +163,7 @@ class mymod(ptModifier):
 
     def Load(self, loadfile):
         "Load the persistent variables"
-        print "Load variables"
+        print("Load variables")
         self.svMyNumber = cPickle.load(loadfile)
         openb.value = cPickle.load(loadfile)
         # this will recreate a list of myHelper objects
@@ -171,9 +171,9 @@ class mymod(ptModifier):
 
     def OnPageLoad(self,what,who):
         if what==kLoaded:
-            print "%s is finished loading" % (who)
+            print("%s is finished loading" % (who))
         elif what == kUnloaded:
-            print "%s is finished unloading" % (who)
+            print("%s is finished unloading" % (who))
 
 #====================================
 # Helper class

--- a/Python/mystFireplace.py
+++ b/Python/mystFireplace.py
@@ -105,7 +105,7 @@ class mystFireplace(ptModifier):
         self.id = 5335
 
         self.version = 3
-        print "__init__MystFireplace v.", self.version
+        print("__init__MystFireplace v.", self.version)
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
@@ -144,7 +144,7 @@ class mystFireplace(ptModifier):
     def OnNotify(self,state,id,events):
         global IgnorePanelClick
         
-        print "onnotify: id -", id
+        print("onnotify: id -", id)
 
         if id == actButton.id and state:
             #actPanelButtons.disable()
@@ -282,7 +282,7 @@ class mystFireplace(ptModifier):
                     bstate = "press"
                     CheckedButtons.append(id)
 
-                print panelName, bstate
+                print(panelName, bstate)
 
                 for rkey,rvalue in respMorphButtons.byObject.viewitems():
                     parent = rvalue.getParentKey()
@@ -378,8 +378,8 @@ class mystFireplace(ptModifier):
         CheckedButtons.sort()
         solution.sort()
 
-        print "CheckedButtons:", CheckedButtons
-        print "solution      :", solution
+        print("CheckedButtons:", CheckedButtons)
+        print("solution      :", solution)
 
         return CheckedButtons == solution
 

--- a/Python/mystFireplace.py
+++ b/Python/mystFireplace.py
@@ -105,7 +105,7 @@ class mystFireplace(ptModifier):
         self.id = 5335
 
         self.version = 3
-        print("__init__MystFireplace v.", self.version)
+        PtDebugPrint("__init__MystFireplace v.", self.version)
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
@@ -134,17 +134,17 @@ class mystFireplace(ptModifier):
         respFPDoor.run(self.key, state = "close", fastforward = 1)
 
         #for key,value in actPanelButtons.byObject.viewitems():
-            #print key
+            #PtDebugPrint(key)
             #p = value.getParentKey()
             #if p:
-                #print "\t", p.getName()
+                #PtDebugPrint("\t", p.getName())
             #actPanelButtons.enable(objectName=key)
 
             
     def OnNotify(self,state,id,events):
         global IgnorePanelClick
         
-        print("onnotify: id -", id)
+        PtDebugPrint("onnotify: id -", id)
 
         if id == actButton.id and state:
             #actPanelButtons.disable()
@@ -282,14 +282,14 @@ class mystFireplace(ptModifier):
                     bstate = "press"
                     CheckedButtons.append(id)
 
-                print(panelName, bstate)
+                PtDebugPrint(panelName, bstate)
 
                 for rkey,rvalue in respMorphButtons.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         pname = parent.getName()
                         #pnum = 8*(int(pname[-2:]) - 1) + (ord(pname[-3]) - ord("A"))
-                        #print id, pnum
+                        #PtDebugPrint(id, pnum)
                         #if panelName == parent.getName():
                         if id == pname[-3:]:
                             respMorphButtons.run(self.key,objectName=rkey, state = bstate)
@@ -378,8 +378,8 @@ class mystFireplace(ptModifier):
         CheckedButtons.sort()
         solution.sort()
 
-        print("CheckedButtons:", CheckedButtons)
-        print("solution      :", solution)
+        PtDebugPrint("CheckedButtons:", CheckedButtons)
+        PtDebugPrint("solution      :", solution)
 
         return CheckedButtons == solution
 

--- a/Python/nb01RegisterNexusLink.py
+++ b/Python/nb01RegisterNexusLink.py
@@ -73,7 +73,7 @@ class nb01RegisterNexusLink(ptModifier):
         self.id = 5020
         version = 1
         self.version = version
-        print("__init__nb01RegisterNexusLink v.", version)
+        PtDebugPrint("__init__nb01RegisterNexusLink v.", version)
         
     def OnNotify(self,state,id,events):
         global boolClickerIsMe
@@ -110,7 +110,7 @@ class nb01RegisterNexusLink(ptModifier):
             boolClickerIsMe = False # done with this var, reset it
             
             kiLevel = PtDetermineKILevel()
-            print("nb01RegisterNexusLink.OnNotify:\tplayer ki level is",kiLevel)
+            PtDebugPrint("nb01RegisterNexusLink.OnNotify:\tplayer ki level is",kiLevel)
 
             # case 1:  player has no KI
             # ki slot doesn't respond, just return

--- a/Python/nb01RegisterNexusLink.py
+++ b/Python/nb01RegisterNexusLink.py
@@ -73,7 +73,7 @@ class nb01RegisterNexusLink(ptModifier):
         self.id = 5020
         version = 1
         self.version = version
-        print "__init__nb01RegisterNexusLink v.", version
+        print("__init__nb01RegisterNexusLink v.", version)
         
     def OnNotify(self,state,id,events):
         global boolClickerIsMe
@@ -110,7 +110,7 @@ class nb01RegisterNexusLink(ptModifier):
             boolClickerIsMe = False # done with this var, reset it
             
             kiLevel = PtDetermineKILevel()
-            print "nb01RegisterNexusLink.OnNotify:\tplayer ki level is",kiLevel
+            print("nb01RegisterNexusLink.OnNotify:\tplayer ki level is",kiLevel)
 
             # case 1:  player has no KI
             # ki slot doesn't respond, just return

--- a/Python/nb01UpdateHoodInfoImager.py
+++ b/Python/nb01UpdateHoodInfoImager.py
@@ -59,7 +59,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
         self.id = 5262
 
         self.version = 2
-        print "__init__nb01UpdateHoodInfoImager v.", self.version
+        print("__init__nb01UpdateHoodInfoImager v.", self.version)
 
     def IGetDeviceInbox(self):
         deviceNode = None
@@ -171,7 +171,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
                 score = msg.getScores()[0]
                 if msg.getName() == "PelletDrop":
                     self.IUpdateHoodPelletScore(score)
-            except Exception, detail:
+            except Exception as detail:
                 PtDebugPrint("nb01UpdateHoodInfoImager.OnGameScoreMsg(): " + detail)
 
     def IUpdateHoodPelletScore(self, score):
@@ -249,10 +249,10 @@ class nb01UpdateHoodInfoImager(ptResponder):
 
             if pelletscores and pelletscores.getID() > 0:
                 sname = "Update=%d" % (pelletscores.getID())
-                print "Sending notify to update node: ", pelletscores.getID()
+                print("Sending notify to update node: ", pelletscores.getID())
                 self.ISendNotify(HoodInfoImagerScript.value, sname, 1.0)
             else:
-                print "Not sending notify because we don't have a valid pelletscore node"
+                print("Not sending notify because we don't have a valid pelletscore node")
 
             self.IUpdateHoodImager()
 
@@ -271,7 +271,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
         notify.send()
 
     def OnServerInitComplete(self):
-        print "nb01UpdateHoodInfoImager.OnServerInitComplete()"
+        print("nb01UpdateHoodInfoImager.OnServerInitComplete()")
 
         try:
             AmCCR = ptCCRMgr().getLevel()
@@ -284,19 +284,19 @@ class nb01UpdateHoodInfoImager(ptResponder):
             sname = "Join=%s" % (PtGetLocalPlayer().getPlayerName())
             self.ISendNotify(self.key, sname, 1.0)
 
-            print "nb01UpdateHoodInfoImager.OnServerInitComplete: Sent player join update notify"
+            print("nb01UpdateHoodInfoImager.OnServerInitComplete: Sent player join update notify")
 
     def OnNotify(self,state,id,events):
         for event in events:
             if event[0] == kVariableEvent:
                 if self.sceneobject.isLocallyOwned():
-                    print "nb01UpdateHoodInfoImager.OnNotify: I am owner so I'll update the imager"
+                    print("nb01UpdateHoodInfoImager.OnNotify: I am owner so I'll update the imager")
                     if event[1][:5] == "Join=":
                         playername = event[1][5:]
                         self.IUpdatePlayerList(playername)
-                        print "nb01UpdateHoodInfoImager.OnNotify: Updated player list"
+                        print("nb01UpdateHoodInfoImager.OnNotify: Updated player list")
                     elif event[1][:6] == "Score=":
                         playername = event[1][6:]
                         score = int(event[3])
                         self.IUpdatePelletScores(playername, score)
-                        print "nb01UpdateHoodInfoImager.OnNotify: Updated pellet scores"
+                        print("nb01UpdateHoodInfoImager.OnNotify: Updated pellet scores")

--- a/Python/nb01UpdateHoodInfoImager.py
+++ b/Python/nb01UpdateHoodInfoImager.py
@@ -59,7 +59,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
         self.id = 5262
 
         self.version = 2
-        print("__init__nb01UpdateHoodInfoImager v.", self.version)
+        PtDebugPrint("__init__nb01UpdateHoodInfoImager v.", self.version)
 
     def IGetDeviceInbox(self):
         deviceNode = None
@@ -249,10 +249,10 @@ class nb01UpdateHoodInfoImager(ptResponder):
 
             if pelletscores and pelletscores.getID() > 0:
                 sname = "Update=%d" % (pelletscores.getID())
-                print("Sending notify to update node: ", pelletscores.getID())
+                PtDebugPrint("Sending notify to update node: ", pelletscores.getID())
                 self.ISendNotify(HoodInfoImagerScript.value, sname, 1.0)
             else:
-                print("Not sending notify because we don't have a valid pelletscore node")
+                PtDebugPrint("Not sending notify because we don't have a valid pelletscore node")
 
             self.IUpdateHoodImager()
 
@@ -271,7 +271,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
         notify.send()
 
     def OnServerInitComplete(self):
-        print("nb01UpdateHoodInfoImager.OnServerInitComplete()")
+        PtDebugPrint("nb01UpdateHoodInfoImager.OnServerInitComplete()")
 
         try:
             AmCCR = ptCCRMgr().getLevel()
@@ -284,19 +284,19 @@ class nb01UpdateHoodInfoImager(ptResponder):
             sname = "Join=%s" % (PtGetLocalPlayer().getPlayerName())
             self.ISendNotify(self.key, sname, 1.0)
 
-            print("nb01UpdateHoodInfoImager.OnServerInitComplete: Sent player join update notify")
+            PtDebugPrint("nb01UpdateHoodInfoImager.OnServerInitComplete: Sent player join update notify")
 
     def OnNotify(self,state,id,events):
         for event in events:
             if event[0] == kVariableEvent:
                 if self.sceneobject.isLocallyOwned():
-                    print("nb01UpdateHoodInfoImager.OnNotify: I am owner so I'll update the imager")
+                    PtDebugPrint("nb01UpdateHoodInfoImager.OnNotify: I am owner so I'll update the imager")
                     if event[1][:5] == "Join=":
                         playername = event[1][5:]
                         self.IUpdatePlayerList(playername)
-                        print("nb01UpdateHoodInfoImager.OnNotify: Updated player list")
+                        PtDebugPrint("nb01UpdateHoodInfoImager.OnNotify: Updated player list")
                     elif event[1][:6] == "Score=":
                         playername = event[1][6:]
                         score = int(event[3])
                         self.IUpdatePelletScores(playername, score)
-                        print("nb01UpdateHoodInfoImager.OnNotify: Updated pellet scores")
+                        PtDebugPrint("nb01UpdateHoodInfoImager.OnNotify: Updated pellet scores")

--- a/Python/nglnFogTweener.py
+++ b/Python/nglnFogTweener.py
@@ -122,7 +122,7 @@ class nglnFogTweener(ptMultiModifier):
         self.id = 5243
         version = 3
         self.version = version
-        print "__init__nglnFogTweener v.", version        
+        print("__init__nglnFogTweener v.", version)        
         
         self.SunriseRGBList = []
         self.SunriseDensityList = []
@@ -205,8 +205,8 @@ class nglnFogTweener(ptMultiModifier):
         MidnightE = string.atof(self.MidnightDensityList[1])
         MidnightD = string.atof(self.MidnightDensityList[2])        
         
-        print "nglnFogTweener.OnFirstUpdate: SunriseRGB=(%s,%s,%s), NoonRGB=(%s,%s,%s), SunsetRGB=(%s,%s,%s), MidnightRGB=(%s,%s,%s) " % (SunriseR, SunriseG, SunriseB, NoonR, NoonG, NoonB, SunsetR, SunsetG, SunsetB, MidnightR, MidnightG, MidnightB)
-        print "nglnFogTweener.OnFirstUpdate: SunriseDensity=(%s,%s,%s), NoonDensity=(%s,%s,%s), SunsetDensity=(%s,%s,%s), MidnightDensity=(%s,%s,%s) " % (SunriseS, SunriseE, SunriseD, NoonS, NoonE, NoonD, SunsetS, SunsetE, SunsetD, MidnightS, MidnightE, MidnightD)
+        print("nglnFogTweener.OnFirstUpdate: SunriseRGB=(%s,%s,%s), NoonRGB=(%s,%s,%s), SunsetRGB=(%s,%s,%s), MidnightRGB=(%s,%s,%s) " % (SunriseR, SunriseG, SunriseB, NoonR, NoonG, NoonB, SunsetR, SunsetG, SunsetB, MidnightR, MidnightG, MidnightB))
+        print("nglnFogTweener.OnFirstUpdate: SunriseDensity=(%s,%s,%s), NoonDensity=(%s,%s,%s), SunsetDensity=(%s,%s,%s), MidnightDensity=(%s,%s,%s) " % (SunriseS, SunriseE, SunriseD, NoonS, NoonE, NoonD, SunsetS, SunsetE, SunsetD, MidnightS, MidnightE, MidnightD))
         
             
     def OnServerInitComplete(self):
@@ -243,7 +243,7 @@ class nglnFogTweener(ptMultiModifier):
         
         AgeTimeOfDayPercent = PtGetAgeTimeOfDayPercent()      
         
-        print "nglnFogTweener: The day is %.2f%% through its complete cycle."  % (AgeTimeOfDayPercent*100) 
+        print("nglnFogTweener: The day is %.2f%% through its complete cycle."  % (AgeTimeOfDayPercent*100)) 
         if AgeTimeOfDayPercent > kSunrisePct and AgeTimeOfDayPercent < kNoonPct:
             StartR = SunriseR
             EndR = NoonR
@@ -260,7 +260,7 @@ class nglnFogTweener(ptMultiModifier):
             
             TweenPct = (AgeTimeOfDayPercent - kSunrisePct) / (kNoonPct - kSunrisePct)
             
-            print "\tIt's after Sunrise and before Noon. (%.2f%% through this quadrant)" % (TweenPct*100)
+            print("\tIt's after Sunrise and before Noon. (%.2f%% through this quadrant)" % (TweenPct*100))
 
             
         elif AgeTimeOfDayPercent > kNoonPct and AgeTimeOfDayPercent < kSunsetPct:
@@ -279,7 +279,7 @@ class nglnFogTweener(ptMultiModifier):
             EndD = SunsetD
             
             TweenPct = (AgeTimeOfDayPercent - kNoonPct) / (kSunsetPct - kNoonPct)
-            print "\tIt's after Noon and before Sunset. (%.2f%% this quadrant)" % (TweenPct*100)
+            print("\tIt's after Noon and before Sunset. (%.2f%% this quadrant)" % (TweenPct*100))
             
         elif AgeTimeOfDayPercent > kSunsetPct and AgeTimeOfDayPercent < kMidnightPct:
             StartR = SunsetR
@@ -297,7 +297,7 @@ class nglnFogTweener(ptMultiModifier):
             EndD = MidnightD
             
             TweenPct = (AgeTimeOfDayPercent - kSunsetPct) / (kMidnightPct - kSunsetPct)
-            print "\tIt's after Sunset and before Midnight. (%.2f%% this quadrant)" % (TweenPct*100)
+            print("\tIt's after Sunset and before Midnight. (%.2f%% this quadrant)" % (TweenPct*100))
             
         elif AgeTimeOfDayPercent > kMidnightPct and AgeTimeOfDayPercent < 1:
             StartR = MidnightR
@@ -315,10 +315,10 @@ class nglnFogTweener(ptMultiModifier):
             EndD = SunriseD
             
             TweenPct = (AgeTimeOfDayPercent - kMidnightPct) / (1 - kMidnightPct)
-            print "\tIt's after Midnight and before Sunrise. (%.2f%% this quadrant)" % (TweenPct*100)
+            print("\tIt's after Midnight and before Sunrise. (%.2f%% this quadrant)" % (TweenPct*100))
             
         else: 
-            print "ERROR: I can't tell what time it is."
+            print("ERROR: I can't tell what time it is.")
         
         #~ print "OnSDLNotify: StartR=%s, EndR=%s, StartG=%s, EndG==%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB)
         
@@ -326,8 +326,8 @@ class nglnFogTweener(ptMultiModifier):
     
     def UpdateFog(self, StartR, EndR, StartG, EndG, StartB, EndB, StartS, EndS, StartE, EndE, StartD, EndD, TweenPct):
         #~ print "TweenPct = ", TweenPct
-        print "UpdateFog: StartR=%s, EndR=%s, StartG=%s, EndG=%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB)
-        print "UpdateFog: StartS=%s, EndS=%s, StartE=%s, EndE=%s, StartD=%s, EndD=%s" % (StartS, EndS, StartE, EndE, StartD, EndD)
+        print("UpdateFog: StartR=%s, EndR=%s, StartG=%s, EndG=%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB))
+        print("UpdateFog: StartS=%s, EndS=%s, StartE=%s, EndE=%s, StartD=%s, EndD=%s" % (StartS, EndS, StartE, EndE, StartD, EndD))
 
 
         NewR = StartR + ((EndR - StartR) * TweenPct)
@@ -338,8 +338,8 @@ class nglnFogTweener(ptMultiModifier):
         NewE = StartE + ((EndE - StartE) * TweenPct)
         NewD = StartD + ((EndD - StartD) * TweenPct)
 
-        print "UpdateFog: The new fog RGB is (%.3f, %.3f, %.3f)" % (NewR, NewG, NewB)
-        print "UpdateFog: The new fog Density is (%.3f, %.3f, %.3f)" % (NewS, NewE, NewD)
+        print("UpdateFog: The new fog RGB is (%.3f, %.3f, %.3f)" % (NewR, NewG, NewB))
+        print("UpdateFog: The new fog Density is (%.3f, %.3f, %.3f)" % (NewS, NewE, NewD))
         
         newfogcolor = ptColor(red=NewR, green=NewG, blue=NewB)
         

--- a/Python/nglnFogTweener.py
+++ b/Python/nglnFogTweener.py
@@ -122,7 +122,7 @@ class nglnFogTweener(ptMultiModifier):
         self.id = 5243
         version = 3
         self.version = version
-        print("__init__nglnFogTweener v.", version)        
+        PtDebugPrint("__init__nglnFogTweener v.", version)        
         
         self.SunriseRGBList = []
         self.SunriseDensityList = []
@@ -205,8 +205,8 @@ class nglnFogTweener(ptMultiModifier):
         MidnightE = string.atof(self.MidnightDensityList[1])
         MidnightD = string.atof(self.MidnightDensityList[2])        
         
-        print("nglnFogTweener.OnFirstUpdate: SunriseRGB=(%s,%s,%s), NoonRGB=(%s,%s,%s), SunsetRGB=(%s,%s,%s), MidnightRGB=(%s,%s,%s) " % (SunriseR, SunriseG, SunriseB, NoonR, NoonG, NoonB, SunsetR, SunsetG, SunsetB, MidnightR, MidnightG, MidnightB))
-        print("nglnFogTweener.OnFirstUpdate: SunriseDensity=(%s,%s,%s), NoonDensity=(%s,%s,%s), SunsetDensity=(%s,%s,%s), MidnightDensity=(%s,%s,%s) " % (SunriseS, SunriseE, SunriseD, NoonS, NoonE, NoonD, SunsetS, SunsetE, SunsetD, MidnightS, MidnightE, MidnightD))
+        PtDebugPrint("nglnFogTweener.OnFirstUpdate: SunriseRGB=(%s,%s,%s), NoonRGB=(%s,%s,%s), SunsetRGB=(%s,%s,%s), MidnightRGB=(%s,%s,%s) " % (SunriseR, SunriseG, SunriseB, NoonR, NoonG, NoonB, SunsetR, SunsetG, SunsetB, MidnightR, MidnightG, MidnightB))
+        PtDebugPrint("nglnFogTweener.OnFirstUpdate: SunriseDensity=(%s,%s,%s), NoonDensity=(%s,%s,%s), SunsetDensity=(%s,%s,%s), MidnightDensity=(%s,%s,%s) " % (SunriseS, SunriseE, SunriseD, NoonS, NoonE, NoonD, SunsetS, SunsetE, SunsetD, MidnightS, MidnightE, MidnightD))
         
             
     def OnServerInitComplete(self):
@@ -239,11 +239,11 @@ class nglnFogTweener(ptMultiModifier):
         global EndD
         
             
-        #~ print "nglnFogTweener.CalculateNewFogValues: The battery was updated. Time to update the Fog."
+        #~ PtDebugPrint("nglnFogTweener.CalculateNewFogValues: The battery was updated. Time to update the Fog.")
         
         AgeTimeOfDayPercent = PtGetAgeTimeOfDayPercent()      
         
-        print("nglnFogTweener: The day is %.2f%% through its complete cycle."  % (AgeTimeOfDayPercent*100)) 
+        PtDebugPrint("nglnFogTweener: The day is %.2f%% through its complete cycle."  % (AgeTimeOfDayPercent*100)) 
         if AgeTimeOfDayPercent > kSunrisePct and AgeTimeOfDayPercent < kNoonPct:
             StartR = SunriseR
             EndR = NoonR
@@ -260,7 +260,7 @@ class nglnFogTweener(ptMultiModifier):
             
             TweenPct = (AgeTimeOfDayPercent - kSunrisePct) / (kNoonPct - kSunrisePct)
             
-            print("\tIt's after Sunrise and before Noon. (%.2f%% through this quadrant)" % (TweenPct*100))
+            PtDebugPrint("\tIt's after Sunrise and before Noon. (%.2f%% through this quadrant)" % (TweenPct*100))
 
             
         elif AgeTimeOfDayPercent > kNoonPct and AgeTimeOfDayPercent < kSunsetPct:
@@ -279,7 +279,7 @@ class nglnFogTweener(ptMultiModifier):
             EndD = SunsetD
             
             TweenPct = (AgeTimeOfDayPercent - kNoonPct) / (kSunsetPct - kNoonPct)
-            print("\tIt's after Noon and before Sunset. (%.2f%% this quadrant)" % (TweenPct*100))
+            PtDebugPrint("\tIt's after Noon and before Sunset. (%.2f%% this quadrant)" % (TweenPct*100))
             
         elif AgeTimeOfDayPercent > kSunsetPct and AgeTimeOfDayPercent < kMidnightPct:
             StartR = SunsetR
@@ -297,7 +297,7 @@ class nglnFogTweener(ptMultiModifier):
             EndD = MidnightD
             
             TweenPct = (AgeTimeOfDayPercent - kSunsetPct) / (kMidnightPct - kSunsetPct)
-            print("\tIt's after Sunset and before Midnight. (%.2f%% this quadrant)" % (TweenPct*100))
+            PtDebugPrint("\tIt's after Sunset and before Midnight. (%.2f%% this quadrant)" % (TweenPct*100))
             
         elif AgeTimeOfDayPercent > kMidnightPct and AgeTimeOfDayPercent < 1:
             StartR = MidnightR
@@ -315,19 +315,19 @@ class nglnFogTweener(ptMultiModifier):
             EndD = SunriseD
             
             TweenPct = (AgeTimeOfDayPercent - kMidnightPct) / (1 - kMidnightPct)
-            print("\tIt's after Midnight and before Sunrise. (%.2f%% this quadrant)" % (TweenPct*100))
+            PtDebugPrint("\tIt's after Midnight and before Sunrise. (%.2f%% this quadrant)" % (TweenPct*100))
             
         else: 
-            print("ERROR: I can't tell what time it is.")
+            PtDebugPrint("ERROR: I can't tell what time it is.")
         
-        #~ print "OnSDLNotify: StartR=%s, EndR=%s, StartG=%s, EndG==%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB)
+        #~ PtDebugPrint("OnSDLNotify: StartR=%s, EndR=%s, StartG=%s, EndG==%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB))
         
         self.UpdateFog(StartR, EndR, StartG, EndG, StartB, EndB, StartS, EndS, StartE, EndE, StartD, EndD, TweenPct)
     
     def UpdateFog(self, StartR, EndR, StartG, EndG, StartB, EndB, StartS, EndS, StartE, EndE, StartD, EndD, TweenPct):
-        #~ print "TweenPct = ", TweenPct
-        print("UpdateFog: StartR=%s, EndR=%s, StartG=%s, EndG=%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB))
-        print("UpdateFog: StartS=%s, EndS=%s, StartE=%s, EndE=%s, StartD=%s, EndD=%s" % (StartS, EndS, StartE, EndE, StartD, EndD))
+        #~ PtDebugPrint("TweenPct = ", TweenPct)
+        PtDebugPrint("UpdateFog: StartR=%s, EndR=%s, StartG=%s, EndG=%s, StartB=%s, EndB=%s" % (StartR, EndR, StartG, EndG, StartB, EndB))
+        PtDebugPrint("UpdateFog: StartS=%s, EndS=%s, StartE=%s, EndE=%s, StartD=%s, EndD=%s" % (StartS, EndS, StartE, EndE, StartD, EndD))
 
 
         NewR = StartR + ((EndR - StartR) * TweenPct)
@@ -338,8 +338,8 @@ class nglnFogTweener(ptMultiModifier):
         NewE = StartE + ((EndE - StartE) * TweenPct)
         NewD = StartD + ((EndD - StartD) * TweenPct)
 
-        print("UpdateFog: The new fog RGB is (%.3f, %.3f, %.3f)" % (NewR, NewG, NewB))
-        print("UpdateFog: The new fog Density is (%.3f, %.3f, %.3f)" % (NewS, NewE, NewD))
+        PtDebugPrint("UpdateFog: The new fog RGB is (%.3f, %.3f, %.3f)" % (NewR, NewG, NewB))
+        PtDebugPrint("UpdateFog: The new fog Density is (%.3f, %.3f, %.3f)" % (NewS, NewE, NewD))
         
         newfogcolor = ptColor(red=NewR, green=NewG, blue=NewB)
         

--- a/Python/nglnTreeMonkey.py
+++ b/Python/nglnTreeMonkey.py
@@ -81,7 +81,7 @@ class nglnTreeMonkey(ptResponder):
         self.id = 5241
         version = 3
         self.version = version
-        print("__init__nglnTreeMonkey v.", version,".0")
+        PtDebugPrint("__init__nglnTreeMonkey v.", version,".0")
         random.seed()
 
     ###########################
@@ -89,7 +89,7 @@ class nglnTreeMonkey(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("nglnTreeMonkey:\tERROR---Cannot find the Negilahn Age SDL")
+            PtDebugPrint("nglnTreeMonkey:\tERROR---Cannot find the Negilahn Age SDL")
             self.InitNewSDLVars()
 
         ageSDL.sendToClients("MonkeyLastUpdated")
@@ -103,10 +103,10 @@ class nglnTreeMonkey(ptResponder):
         lastDay = int(ageSDL["MonkeyLastUpdated"][0] / kDayLengthInSeconds)
 
         if (thisDay - lastDay) > 0:
-            print("nglnTreeMonkey: It's been at least a day since the last update, running new numbers now.")
+            PtDebugPrint("nglnTreeMonkey: It's been at least a day since the last update, running new numbers now.")
             self.InitNewSDLVars()
         else:
-            print("nglnTreeMonkey: It's been less than a day since the last update, doing nothing")
+            PtDebugPrint("nglnTreeMonkey: It's been less than a day since the last update, doing nothing")
             self.SetMonkeyTimers()
 
         if not len(PtGetPlayerList()):
@@ -120,47 +120,47 @@ class nglnTreeMonkey(ptResponder):
     ###########################
     def OnNotify(self,state,id,events):
         global stackList
-        print("nglnTreeMonkey.OnNotify:  state=%f id=%d events=" % (state,id),events)
+        PtDebugPrint("nglnTreeMonkey.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if id == (-1):
-            print("Need to store event: %s" % (events[0][1]))
+            PtDebugPrint("Need to store event: %s" % (events[0][1]))
             stackList.append(events[0][1])
-            print("New list is: %s" % (str(stackList)))
+            PtDebugPrint("New list is: %s" % (str(stackList)))
             if len(stackList) == 1:
-                print("List is only one command long, so I'm playing it")
+                PtDebugPrint("List is only one command long, so I'm playing it")
                 code = stackList[0]
-                print("Playing command: %s" % (code))
+                PtDebugPrint("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         elif id == respMonkeyAct.id and self.sceneobject.isLocallyOwned():
-            print("Callback was from responder, and I own the age, so Logic Time")
+            PtDebugPrint("Callback was from responder, and I own the age, so Logic Time")
             old = stackList.pop(0)
-            print("Popping off: %s" % (old))
+            PtDebugPrint("Popping off: %s" % (old))
             self.RandomBehavior()
 
         elif id == respMonkeyOff.id and self.sceneobject.isLocallyOwned():
-            print("Callback was from 'Off' responder")
+            PtDebugPrint("Callback was from 'Off' responder")
             old = stackList.pop(0)
-            print("Popping off: %s" % (old))
+            PtDebugPrint("Popping off: %s" % (old))
 
         elif (id == respMonkeyAct.id or id == respMonkeyOff.id) and not self.sceneobject.isLocallyOwned():
-            print("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
+            PtDebugPrint("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
             old = stackList.pop(0)
-            print("Popping off: %s" % (old))
+            PtDebugPrint("Popping off: %s" % (old))
             if len(stackList):
-                print("List has at least one item ready to play")
+                PtDebugPrint("List has at least one item ready to play")
                 code = stackList[0]
-                print("Playing command: %s" % (code))
+                PtDebugPrint("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         else:
-            print("Callback from something else?")
+            PtDebugPrint("Callback from something else?")
 
     ###########################
     def RandomBehavior(self):
         ageSDL = PtGetAgeSDL()
         PickABehavior = random.randint(1,100)
-        #~ print "PickABehavior = ",PickABehavior
+        #~ PtDebugPrint("PickABehavior = ",PickABehavior)
         LightsOn = ageSDL["nglnPodLights"][0]
         posMonkeyStates = ['Idle','Eat','Alarmed','Vocalize','Off']
         Cumulative = 0
@@ -173,10 +173,10 @@ class nglnTreeMonkey(ptResponder):
                 else:
                     respString = ("respMonkeyAct;%s" % (MonkeyState))
                     self.SendNote(respString)
-                print("nglnTreeMonkey: Attempting Tree Monkey Anim: %s" % (MonkeyState))
+                PtDebugPrint("nglnTreeMonkey: Attempting Tree Monkey Anim: %s" % (MonkeyState))
                 if LightsOn:
                     respMonkeySfx.run(self.key, state=str(MonkeyState))
-                    print("nglnTreeMonkey: Attempting Tree Monkey SFX: %s" % (MonkeyState))
+                    PtDebugPrint("nglnTreeMonkey: Attempting Tree Monkey SFX: %s" % (MonkeyState))
                 return
             Cumulative = eval("Cumulative + " + MonkeyState +"Pct")
             
@@ -204,11 +204,11 @@ class nglnTreeMonkey(ptResponder):
         whichtree = random.randint(0,2)
         respSpawnPt.run(self.key, state=str(whichtree))
         self.SendNote("respMonkeyAct;Up")
-        print("nglnTreeMonkey: Tree Monkey is climbing Tree: %d" % (whichtree))
+        PtDebugPrint("nglnTreeMonkey: Tree Monkey is climbing Tree: %d" % (whichtree))
 
     ###########################
     def OnTimer(self,TimerID):
-        print("nglnTreeMonkey.OnTimer: callback id=%d" % (TimerID))
+        PtDebugPrint("nglnTreeMonkey.OnTimer: callback id=%d" % (TimerID))
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
                 self.MonkeyAppears()
@@ -223,7 +223,7 @@ class nglnTreeMonkey(ptResponder):
 
         beginningOfToday = PtGetDniTime() - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
         endOfToday = int(kDayLengthInSeconds / 2) + beginningOfToday
-        #print "Dawn: %d  Dusk: %d" % (beginningOfToday, endOfToday)
+        #PtDebugPrint("Dawn: %d  Dusk: %d" % (beginningOfToday, endOfToday))
 
         # We need a random times in the first 5 hours of the day
         # which is in the first 31.8 percent of the day. So we're
@@ -231,20 +231,20 @@ class nglnTreeMonkey(ptResponder):
         # something roughly in that timeframe.
         randnum = float(random.randint(0,318))
         firstTime = int((randnum / 1000.0) * kDayLengthInSeconds) + beginningOfToday
-        print("nglnTreeMonkey: Generated a valid spawn time: %d" % (firstTime))
+        PtDebugPrint("nglnTreeMonkey: Generated a valid spawn time: %d" % (firstTime))
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
-                print("nglnTreeMonkey: Generated a valid spawn time: %d" % (newTime))
+                PtDebugPrint("nglnTreeMonkey: Generated a valid spawn time: %d" % (newTime))
                 spawnTimes.append(newTime)
             else:
-                print("nglnTreeMonkey: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
+                PtDebugPrint("nglnTreeMonkey: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
                 break
         else:
-            print("nglnTreeMonkey:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
+            PtDebugPrint("nglnTreeMonkey:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
             spawnTimes = [0]
 
         while len(spawnTimes) < 20:
@@ -260,24 +260,24 @@ class nglnTreeMonkey(ptResponder):
             for timer in ageSDL["MonkeySpawnTimes"]:
                 if timer:
                     timeTillSpawn = timer - PtGetDniTime()
-                    print("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
+                    PtDebugPrint("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
                     if timeTillSpawn > 0:
-                        print("nglnTreeMonkey: Setting timer for %d seconds" % (timeTillSpawn))
+                        PtDebugPrint("nglnTreeMonkey: Setting timer for %d seconds" % (timeTillSpawn))
                         PtAtTimeCallback(self.key, timeTillSpawn, 1)
 
             # precision error FTW!
             timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
             timeLeftToday += 1 # because we want it to go off right AFTER the day flips
-            print("nglnTreeMonkey: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
+            PtDebugPrint("nglnTreeMonkey: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
             PtAtTimeCallback(self.key, timeLeftToday, 2)
         else:
-            print("nglnTreeMonkey: Timer array was empty!")
+            PtDebugPrint("nglnTreeMonkey: Timer array was empty!")
 
     ###########################
     def OnBackdoorMsg(self, target, param):
         if target == "monkey":
             if self.sceneobject.isLocallyOwned():
-                print("nglnTreeMonkey.OnBackdoorMsg: Work!")
+                PtDebugPrint("nglnTreeMonkey.OnBackdoorMsg: Work!")
                 if param == "up":
                     self.SendNote("respMonkeyAct;Up")
                 elif param == "tree":
@@ -292,8 +292,8 @@ class nglnTreeMonkey(ptResponder):
                 ecMonkeyState = chunks[1]
                 respMonkeyAct.run(self.key, state=ecMonkeyState)
             except:
-                print("nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code))
+                PtDebugPrint("nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code))
                 stackList.pop(0)
         else:
-            print("nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code))
             stackList.pop(0)

--- a/Python/nglnTreeMonkey.py
+++ b/Python/nglnTreeMonkey.py
@@ -81,7 +81,7 @@ class nglnTreeMonkey(ptResponder):
         self.id = 5241
         version = 3
         self.version = version
-        print "__init__nglnTreeMonkey v.", version,".0"
+        print("__init__nglnTreeMonkey v.", version,".0")
         random.seed()
 
     ###########################
@@ -89,7 +89,7 @@ class nglnTreeMonkey(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "nglnTreeMonkey:\tERROR---Cannot find the Negilahn Age SDL"
+            print("nglnTreeMonkey:\tERROR---Cannot find the Negilahn Age SDL")
             self.InitNewSDLVars()
 
         ageSDL.sendToClients("MonkeyLastUpdated")
@@ -103,10 +103,10 @@ class nglnTreeMonkey(ptResponder):
         lastDay = int(ageSDL["MonkeyLastUpdated"][0] / kDayLengthInSeconds)
 
         if (thisDay - lastDay) > 0:
-            print "nglnTreeMonkey: It's been at least a day since the last update, running new numbers now."
+            print("nglnTreeMonkey: It's been at least a day since the last update, running new numbers now.")
             self.InitNewSDLVars()
         else:
-            print "nglnTreeMonkey: It's been less than a day since the last update, doing nothing"
+            print("nglnTreeMonkey: It's been less than a day since the last update, doing nothing")
             self.SetMonkeyTimers()
 
         if not len(PtGetPlayerList()):
@@ -120,41 +120,41 @@ class nglnTreeMonkey(ptResponder):
     ###########################
     def OnNotify(self,state,id,events):
         global stackList
-        print "nglnTreeMonkey.OnNotify:  state=%f id=%d events=" % (state,id),events
+        print("nglnTreeMonkey.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if id == (-1):
-            print "Need to store event: %s" % (events[0][1])
+            print("Need to store event: %s" % (events[0][1]))
             stackList.append(events[0][1])
-            print "New list is: %s" % (str(stackList))
+            print("New list is: %s" % (str(stackList)))
             if len(stackList) == 1:
-                print "List is only one command long, so I'm playing it"
+                print("List is only one command long, so I'm playing it")
                 code = stackList[0]
-                print "Playing command: %s" % (code)
+                print("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         elif id == respMonkeyAct.id and self.sceneobject.isLocallyOwned():
-            print "Callback was from responder, and I own the age, so Logic Time"
+            print("Callback was from responder, and I own the age, so Logic Time")
             old = stackList.pop(0)
-            print "Popping off: %s" % (old)
+            print("Popping off: %s" % (old))
             self.RandomBehavior()
 
         elif id == respMonkeyOff.id and self.sceneobject.isLocallyOwned():
-            print "Callback was from 'Off' responder"
+            print("Callback was from 'Off' responder")
             old = stackList.pop(0)
-            print "Popping off: %s" % (old)
+            print("Popping off: %s" % (old))
 
         elif (id == respMonkeyAct.id or id == respMonkeyOff.id) and not self.sceneobject.isLocallyOwned():
-            print "Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list"
+            print("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
             old = stackList.pop(0)
-            print "Popping off: %s" % (old)
+            print("Popping off: %s" % (old))
             if len(stackList):
-                print "List has at least one item ready to play"
+                print("List has at least one item ready to play")
                 code = stackList[0]
-                print "Playing command: %s" % (code)
+                print("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         else:
-            print "Callback from something else?"
+            print("Callback from something else?")
 
     ###########################
     def RandomBehavior(self):
@@ -173,10 +173,10 @@ class nglnTreeMonkey(ptResponder):
                 else:
                     respString = ("respMonkeyAct;%s" % (MonkeyState))
                     self.SendNote(respString)
-                print "nglnTreeMonkey: Attempting Tree Monkey Anim: %s" % (MonkeyState)
+                print("nglnTreeMonkey: Attempting Tree Monkey Anim: %s" % (MonkeyState))
                 if LightsOn:
                     respMonkeySfx.run(self.key, state=str(MonkeyState))
-                    print "nglnTreeMonkey: Attempting Tree Monkey SFX: %s" % (MonkeyState)
+                    print("nglnTreeMonkey: Attempting Tree Monkey SFX: %s" % (MonkeyState))
                 return
             Cumulative = eval("Cumulative + " + MonkeyState +"Pct")
             
@@ -204,11 +204,11 @@ class nglnTreeMonkey(ptResponder):
         whichtree = random.randint(0,2)
         respSpawnPt.run(self.key, state=str(whichtree))
         self.SendNote("respMonkeyAct;Up")
-        print "nglnTreeMonkey: Tree Monkey is climbing Tree: %d" % (whichtree)
+        print("nglnTreeMonkey: Tree Monkey is climbing Tree: %d" % (whichtree))
 
     ###########################
     def OnTimer(self,TimerID):
-        print "nglnTreeMonkey.OnTimer: callback id=%d" % (TimerID)
+        print("nglnTreeMonkey.OnTimer: callback id=%d" % (TimerID))
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
                 self.MonkeyAppears()
@@ -231,20 +231,20 @@ class nglnTreeMonkey(ptResponder):
         # something roughly in that timeframe.
         randnum = float(random.randint(0,318))
         firstTime = int((randnum / 1000.0) * kDayLengthInSeconds) + beginningOfToday
-        print "nglnTreeMonkey: Generated a valid spawn time: %d" % (firstTime)
+        print("nglnTreeMonkey: Generated a valid spawn time: %d" % (firstTime))
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
-                print "nglnTreeMonkey: Generated a valid spawn time: %d" % (newTime)
+                print("nglnTreeMonkey: Generated a valid spawn time: %d" % (newTime))
                 spawnTimes.append(newTime)
             else:
-                print "nglnTreeMonkey: Generated a spawn time after dusk, exiting loop: %d" % (newTime)
+                print("nglnTreeMonkey: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
                 break
         else:
-            print "nglnTreeMonkey:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes
+            print("nglnTreeMonkey:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
             spawnTimes = [0]
 
         while len(spawnTimes) < 20:
@@ -260,24 +260,24 @@ class nglnTreeMonkey(ptResponder):
             for timer in ageSDL["MonkeySpawnTimes"]:
                 if timer:
                     timeTillSpawn = timer - PtGetDniTime()
-                    print "timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn)
+                    print("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
                     if timeTillSpawn > 0:
-                        print "nglnTreeMonkey: Setting timer for %d seconds" % (timeTillSpawn)
+                        print("nglnTreeMonkey: Setting timer for %d seconds" % (timeTillSpawn))
                         PtAtTimeCallback(self.key, timeTillSpawn, 1)
 
             # precision error FTW!
             timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
             timeLeftToday += 1 # because we want it to go off right AFTER the day flips
-            print "nglnTreeMonkey: Setting EndOfDay timer for %d seconds" % (timeLeftToday)
+            print("nglnTreeMonkey: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
             PtAtTimeCallback(self.key, timeLeftToday, 2)
         else:
-            print "nglnTreeMonkey: Timer array was empty!"
+            print("nglnTreeMonkey: Timer array was empty!")
 
     ###########################
     def OnBackdoorMsg(self, target, param):
         if target == "monkey":
             if self.sceneobject.isLocallyOwned():
-                print "nglnTreeMonkey.OnBackdoorMsg: Work!"
+                print("nglnTreeMonkey.OnBackdoorMsg: Work!")
                 if param == "up":
                     self.SendNote("respMonkeyAct;Up")
                 elif param == "tree":
@@ -292,8 +292,8 @@ class nglnTreeMonkey(ptResponder):
                 ecMonkeyState = chunks[1]
                 respMonkeyAct.run(self.key, state=ecMonkeyState)
             except:
-                print "nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code)
+                print("nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code))
                 stackList.pop(0)
         else:
-            print "nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("nglnTreeMonkey.ExecCode(): ERROR! Invalid code '%s'." % (code))
             stackList.pop(0)

--- a/Python/nglnUrwinBrain.py
+++ b/Python/nglnUrwinBrain.py
@@ -90,7 +90,7 @@ class nglnUrwinBrain(ptResponder):
         self.id = 5244
         version = 4
         self.version = version
-        print("__init__nglnUrwinBrain v.", version,".0")
+        PtDebugPrint("__init__nglnUrwinBrain v.", version,".0")
         random.seed()
 
     ############################
@@ -98,7 +98,7 @@ class nglnUrwinBrain(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("nglnUrwinBrain:\tERROR---Cannot find the Negilahn Age SDL")
+            PtDebugPrint("nglnUrwinBrain:\tERROR---Cannot find the Negilahn Age SDL")
             self.InitNewSDLVars()
 
         ageSDL.sendToClients("UrwinLastUpdated")
@@ -117,10 +117,10 @@ class nglnUrwinBrain(ptResponder):
         lastDay = int(ageSDL["UrwinLastUpdated"][0] / kDayLengthInSeconds)
 
         if (thisDay - lastDay) > 0:
-            print("nglnUrwinBrain: It's been at least a day since the last update, running new numbers now.")
+            PtDebugPrint("nglnUrwinBrain: It's been at least a day since the last update, running new numbers now.")
             self.InitNewSDLVars()
         else:
-            print("nglnUrwinBrain: It's been less than a day since the last update, doing nothing")
+            PtDebugPrint("nglnUrwinBrain: It's been less than a day since the last update, doing nothing")
             self.SetUrwinTimers()
 
         if not len(PtGetPlayerList()):
@@ -143,27 +143,27 @@ class nglnUrwinBrain(ptResponder):
         global stackList
 
         ageSDL = PtGetAgeSDL()
-        print("nglnUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events)
+        PtDebugPrint("nglnUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events)
 
         if id == (-1):
-            print("Need to store event: %s" % (events[0][1]))
+            PtDebugPrint("Need to store event: %s" % (events[0][1]))
             stackList.append(events[0][1])
-            print("New list is: %s" % (str(stackList)))
+            PtDebugPrint("New list is: %s" % (str(stackList)))
             if len(stackList) == 1:
-                print("List is only one command long, so I'm playing it")
+                PtDebugPrint("List is only one command long, so I'm playing it")
                 code = stackList[0]
-                print("Playing command: %s" % (code))
+                PtDebugPrint("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         elif state and self.sceneobject.isLocallyOwned() and ageSDL["UrwinOnTheProwl"][0]:
             if id == respUrwinSfx.id:
-                print("Callback was from Appearance SFX, and I own the age, so start walking")
+                PtDebugPrint("Callback was from Appearance SFX, and I own the age, so start walking")
                 self.StartToWalk()
 
             else:
-                print("Callback was from responder, and I own the age, so Logic Time")
+                PtDebugPrint("Callback was from responder, and I own the age, so Logic Time")
                 old = stackList.pop(0)
-                print("Popping off: %s" % (old))
+                PtDebugPrint("Popping off: %s" % (old))
                 boolBatteryChargedAndOn = ageSDL["nglnPodLights"][0]
                 
                 if id == respUrwinIdleToWalk.id:
@@ -174,25 +174,25 @@ class nglnUrwinBrain(ptResponder):
                     if StepsToTake:
                         # 90% chance of continuing walk loop
                         if random.randint(0,9):
-                            print("Urwin will take %d more steps..." % (StepsToTake))
+                            PtDebugPrint("Urwin will take %d more steps..." % (StepsToTake))
                             self.SendNote("respUrwinWalkLoop")
                             if boolBatteryChargedAndOn:
                                 respUrwinSfx.run(self.key, state="WalkLoop")
                         # 10% to eat
                         else:
-                            print("Urwin is hungry and decides to eat")
+                            PtDebugPrint("Urwin is hungry and decides to eat")
                             self.SendNote("respUrwinEat")
                             if boolBatteryChargedAndOn:
                                 respUrwinSfx.run(self.key, state="Eat")
                     else:
-                        print("Urwin is tired and stops walking")
+                        PtDebugPrint("Urwin is tired and stops walking")
                         PtAtTimeCallback(self.key, 0.666, 3)
                         self.SendNote("respUrwinWalkToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="WalkToIdle")
 
                 elif id == respUrwinEat.id:
-                    print("Urwin is done eating and continues walking")
+                    PtDebugPrint("Urwin is done eating and continues walking")
                     self.SendNote("respUrwinWalkLoop")
                     if boolBatteryChargedAndOn:
                         respUrwinSfx.run(self.key, state="WalkLoop")
@@ -206,14 +206,14 @@ class nglnUrwinBrain(ptResponder):
                         self.RandomBehavior()
                     # 33% to go back to walking
                     else:
-                        print("Urwin is rested and goes back to walking")
+                        PtDebugPrint("Urwin is rested and goes back to walking")
                         self.SendNote("respUrwinIdleToWalk")
                         UrwinMasterAnim.animation.resume()
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="IdleToWalk")
 
                 elif id == actUrwinPathEnd.id:
-                    print("End of the line, Urwin!")
+                    PtDebugPrint("End of the line, Urwin!")
                     UrwinMasterAnim.animation.stop()
                     UrwinMasterAnim.animation.skipToTime(0)
                     ageSDL["UrwinOnTheProwl"] = (0,)
@@ -221,17 +221,17 @@ class nglnUrwinBrain(ptResponder):
                         respUrwinSfx.run(self.key, state="Distance")
 
         elif id in range(2,8) and not self.sceneobject.isLocallyOwned():
-            print("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
+            PtDebugPrint("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
             old = stackList.pop(0)
-            print("Popping off: %s" % (old))
+            PtDebugPrint("Popping off: %s" % (old))
             if len(stackList):
-                print("List has at least one item ready to play")
+                PtDebugPrint("List has at least one item ready to play")
                 code = stackList[0]
-                print("Playing command: %s" % (code))
+                PtDebugPrint("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         else:
-            print("Callback from something else?")
+            PtDebugPrint("Callback from something else?")
 
     ############################
     def RandomBehavior(self):
@@ -241,13 +241,13 @@ class nglnUrwinBrain(ptResponder):
 
         # 66% chance of idling
         if random.randint(0,2):
-            print("Urwin is being lazy and just idling")
+            PtDebugPrint("Urwin is being lazy and just idling")
             self.SendNote("respUrwinIdle")
             if boolBatteryChargedAndOn:
                 respUrwinSfx.run(self.key, state="Idle")
         # 33% to vocalize
         else:
-            print("Urwin is calling home.")
+            PtDebugPrint("Urwin is calling home.")
             self.SendNote("respUrwinVocalize")
             if boolBatteryChargedAndOn:
                 respUrwinSfx.run(self.key, state="Vocalize")
@@ -260,7 +260,7 @@ class nglnUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["nglnPodLights"][0]
 
         StepsToTake = random.randint(minsteps, maxsteps)
-        print("Urwin has decided to take %d steps." % (StepsToTake))
+        PtDebugPrint("Urwin has decided to take %d steps." % (StepsToTake))
 
         self.SendNote("respUrwinWalkLoop")
         UrwinMasterAnim.animation.resume()
@@ -275,14 +275,14 @@ class nglnUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["nglnPodLights"][0]
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
-                print("UrwinBrain.OnTimer: Time for the Urwin to return.")
+                PtDebugPrint("UrwinBrain.OnTimer: Time for the Urwin to return.")
                 ageSDL["UrwinOnTheProwl"] = (1,)
                 if ageSDL["nglnPodLights"][0]:
                     respUrwinSfx.run(self.key, state="Appear")
                 else:
                     self.StartToWalk()
             elif TimerID == 2:
-                print("UrwinBrain.OnTimer: New day, let's renew the timers.")
+                PtDebugPrint("UrwinBrain.OnTimer: New day, let's renew the timers.")
                 self.InitNewSDLVars()
             elif TimerID == 3:
                 UrwinMasterAnim.animation.stop()
@@ -314,7 +314,7 @@ class nglnUrwinBrain(ptResponder):
 
         beginningOfToday = PtGetDniTime() - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
         endOfToday = int(kDayLengthInSeconds / 2) + beginningOfToday
-        #print "Dawn: %d  Dusk: %d" % (beginningOfToday, endOfToday)
+        #PtDebugPrint("Dawn: %d  Dusk: %d" % (beginningOfToday, endOfToday))
 
         # We need a random times in the first 5 hours of the day
         # which is in the first 44.5 percent of the day. So we're
@@ -322,20 +322,20 @@ class nglnUrwinBrain(ptResponder):
         # something roughly in that timeframe.
         randnum = float(random.randint(0,kFirstMorningSpawn))
         firstTime = int((randnum / 1000.0) * kDayLengthInSeconds) + beginningOfToday
-        print("nglnUrwinBrain: Generated a valid spawn time: %d" % (firstTime))
+        PtDebugPrint("nglnUrwinBrain: Generated a valid spawn time: %d" % (firstTime))
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
-                print("nglnUrwinBrain: Generated a valid spawn time: %d" % (newTime))
+                PtDebugPrint("nglnUrwinBrain: Generated a valid spawn time: %d" % (newTime))
                 spawnTimes.append(newTime)
             else:
-                print("nglnUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
+                PtDebugPrint("nglnUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
                 break
         else:
-            print("nglnUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
+            PtDebugPrint("nglnUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
             spawnTimes = [0]
 
         while len(spawnTimes) < 20:
@@ -351,18 +351,18 @@ class nglnUrwinBrain(ptResponder):
             for timer in ageSDL["UrwinSpawnTimes"]:
                 if timer:
                     timeTillSpawn = timer - PtGetDniTime()
-                    print("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
+                    PtDebugPrint("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
                     if timeTillSpawn > 0:
-                        print("nglnUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn))
+                        PtDebugPrint("nglnUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn))
                         PtAtTimeCallback(self.key, timeTillSpawn, 1)
 
             # precision error FTW!
             timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
             timeLeftToday += 1 # because we want it to go off right AFTER the day flips
-            print("nglnUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
+            PtDebugPrint("nglnUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
             PtAtTimeCallback(self.key, timeLeftToday, 2)
         else:
-            print("nglnUrwinBrain: Timer array was empty!")
+            PtDebugPrint("nglnUrwinBrain: Timer array was empty!")
 
     ###########################
     def OnBackdoorMsg(self, target, param):
@@ -373,7 +373,7 @@ class nglnUrwinBrain(ptResponder):
         ageSDL = PtGetAgeSDL()
         if target == "urwin":
             if self.sceneobject.isLocallyOwned():
-                print("nglnUrwinBrain.OnBackdoorMsg: Backdoor!")
+                PtDebugPrint("nglnUrwinBrain.OnBackdoorMsg: Backdoor!")
                 if param == "walk":
                     ageSDL["UrwinOnTheProwl"] = (1,)                    
                     if ageSDL["nglnPodLights"][0]:
@@ -409,5 +409,5 @@ class nglnUrwinBrain(ptResponder):
         elif code == "respUrwinVocalize":
             respUrwinVocalize.run(self.key)
         else:
-            print("nglnUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("nglnUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
             stackList.pop(0)

--- a/Python/nglnUrwinBrain.py
+++ b/Python/nglnUrwinBrain.py
@@ -90,7 +90,7 @@ class nglnUrwinBrain(ptResponder):
         self.id = 5244
         version = 4
         self.version = version
-        print "__init__nglnUrwinBrain v.", version,".0"
+        print("__init__nglnUrwinBrain v.", version,".0")
         random.seed()
 
     ############################
@@ -98,7 +98,7 @@ class nglnUrwinBrain(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "nglnUrwinBrain:\tERROR---Cannot find the Negilahn Age SDL"
+            print("nglnUrwinBrain:\tERROR---Cannot find the Negilahn Age SDL")
             self.InitNewSDLVars()
 
         ageSDL.sendToClients("UrwinLastUpdated")
@@ -117,10 +117,10 @@ class nglnUrwinBrain(ptResponder):
         lastDay = int(ageSDL["UrwinLastUpdated"][0] / kDayLengthInSeconds)
 
         if (thisDay - lastDay) > 0:
-            print "nglnUrwinBrain: It's been at least a day since the last update, running new numbers now."
+            print("nglnUrwinBrain: It's been at least a day since the last update, running new numbers now.")
             self.InitNewSDLVars()
         else:
-            print "nglnUrwinBrain: It's been less than a day since the last update, doing nothing"
+            print("nglnUrwinBrain: It's been less than a day since the last update, doing nothing")
             self.SetUrwinTimers()
 
         if not len(PtGetPlayerList()):
@@ -143,27 +143,27 @@ class nglnUrwinBrain(ptResponder):
         global stackList
 
         ageSDL = PtGetAgeSDL()
-        print "nglnUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events
+        print("nglnUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events)
 
         if id == (-1):
-            print "Need to store event: %s" % (events[0][1])
+            print("Need to store event: %s" % (events[0][1]))
             stackList.append(events[0][1])
-            print "New list is: %s" % (str(stackList))
+            print("New list is: %s" % (str(stackList)))
             if len(stackList) == 1:
-                print "List is only one command long, so I'm playing it"
+                print("List is only one command long, so I'm playing it")
                 code = stackList[0]
-                print "Playing command: %s" % (code)
+                print("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         elif state and self.sceneobject.isLocallyOwned() and ageSDL["UrwinOnTheProwl"][0]:
             if id == respUrwinSfx.id:
-                print "Callback was from Appearance SFX, and I own the age, so start walking"
+                print("Callback was from Appearance SFX, and I own the age, so start walking")
                 self.StartToWalk()
 
             else:
-                print "Callback was from responder, and I own the age, so Logic Time"
+                print("Callback was from responder, and I own the age, so Logic Time")
                 old = stackList.pop(0)
-                print "Popping off: %s" % (old)
+                print("Popping off: %s" % (old))
                 boolBatteryChargedAndOn = ageSDL["nglnPodLights"][0]
                 
                 if id == respUrwinIdleToWalk.id:
@@ -174,25 +174,25 @@ class nglnUrwinBrain(ptResponder):
                     if StepsToTake:
                         # 90% chance of continuing walk loop
                         if random.randint(0,9):
-                            print "Urwin will take %d more steps..." % (StepsToTake)
+                            print("Urwin will take %d more steps..." % (StepsToTake))
                             self.SendNote("respUrwinWalkLoop")
                             if boolBatteryChargedAndOn:
                                 respUrwinSfx.run(self.key, state="WalkLoop")
                         # 10% to eat
                         else:
-                            print "Urwin is hungry and decides to eat"
+                            print("Urwin is hungry and decides to eat")
                             self.SendNote("respUrwinEat")
                             if boolBatteryChargedAndOn:
                                 respUrwinSfx.run(self.key, state="Eat")
                     else:
-                        print "Urwin is tired and stops walking"
+                        print("Urwin is tired and stops walking")
                         PtAtTimeCallback(self.key, 0.666, 3)
                         self.SendNote("respUrwinWalkToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="WalkToIdle")
 
                 elif id == respUrwinEat.id:
-                    print "Urwin is done eating and continues walking"
+                    print("Urwin is done eating and continues walking")
                     self.SendNote("respUrwinWalkLoop")
                     if boolBatteryChargedAndOn:
                         respUrwinSfx.run(self.key, state="WalkLoop")
@@ -206,14 +206,14 @@ class nglnUrwinBrain(ptResponder):
                         self.RandomBehavior()
                     # 33% to go back to walking
                     else:
-                        print "Urwin is rested and goes back to walking"
+                        print("Urwin is rested and goes back to walking")
                         self.SendNote("respUrwinIdleToWalk")
                         UrwinMasterAnim.animation.resume()
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="IdleToWalk")
 
                 elif id == actUrwinPathEnd.id:
-                    print "End of the line, Urwin!"
+                    print("End of the line, Urwin!")
                     UrwinMasterAnim.animation.stop()
                     UrwinMasterAnim.animation.skipToTime(0)
                     ageSDL["UrwinOnTheProwl"] = (0,)
@@ -221,17 +221,17 @@ class nglnUrwinBrain(ptResponder):
                         respUrwinSfx.run(self.key, state="Distance")
 
         elif id in range(2,8) and not self.sceneobject.isLocallyOwned():
-            print "Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list"
+            print("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
             old = stackList.pop(0)
-            print "Popping off: %s" % (old)
+            print("Popping off: %s" % (old))
             if len(stackList):
-                print "List has at least one item ready to play"
+                print("List has at least one item ready to play")
                 code = stackList[0]
-                print "Playing command: %s" % (code)
+                print("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         else:
-            print "Callback from something else?"
+            print("Callback from something else?")
 
     ############################
     def RandomBehavior(self):
@@ -241,13 +241,13 @@ class nglnUrwinBrain(ptResponder):
 
         # 66% chance of idling
         if random.randint(0,2):
-            print "Urwin is being lazy and just idling"
+            print("Urwin is being lazy and just idling")
             self.SendNote("respUrwinIdle")
             if boolBatteryChargedAndOn:
                 respUrwinSfx.run(self.key, state="Idle")
         # 33% to vocalize
         else:
-            print "Urwin is calling home."
+            print("Urwin is calling home.")
             self.SendNote("respUrwinVocalize")
             if boolBatteryChargedAndOn:
                 respUrwinSfx.run(self.key, state="Vocalize")
@@ -260,7 +260,7 @@ class nglnUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["nglnPodLights"][0]
 
         StepsToTake = random.randint(minsteps, maxsteps)
-        print "Urwin has decided to take %d steps." % (StepsToTake)
+        print("Urwin has decided to take %d steps." % (StepsToTake))
 
         self.SendNote("respUrwinWalkLoop")
         UrwinMasterAnim.animation.resume()
@@ -275,14 +275,14 @@ class nglnUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["nglnPodLights"][0]
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
-                print "UrwinBrain.OnTimer: Time for the Urwin to return."
+                print("UrwinBrain.OnTimer: Time for the Urwin to return.")
                 ageSDL["UrwinOnTheProwl"] = (1,)
                 if ageSDL["nglnPodLights"][0]:
                     respUrwinSfx.run(self.key, state="Appear")
                 else:
                     self.StartToWalk()
             elif TimerID == 2:
-                print "UrwinBrain.OnTimer: New day, let's renew the timers."
+                print("UrwinBrain.OnTimer: New day, let's renew the timers.")
                 self.InitNewSDLVars()
             elif TimerID == 3:
                 UrwinMasterAnim.animation.stop()
@@ -322,20 +322,20 @@ class nglnUrwinBrain(ptResponder):
         # something roughly in that timeframe.
         randnum = float(random.randint(0,kFirstMorningSpawn))
         firstTime = int((randnum / 1000.0) * kDayLengthInSeconds) + beginningOfToday
-        print "nglnUrwinBrain: Generated a valid spawn time: %d" % (firstTime)
+        print("nglnUrwinBrain: Generated a valid spawn time: %d" % (firstTime))
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
-                print "nglnUrwinBrain: Generated a valid spawn time: %d" % (newTime)
+                print("nglnUrwinBrain: Generated a valid spawn time: %d" % (newTime))
                 spawnTimes.append(newTime)
             else:
-                print "nglnUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime)
+                print("nglnUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
                 break
         else:
-            print "nglnUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes
+            print("nglnUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
             spawnTimes = [0]
 
         while len(spawnTimes) < 20:
@@ -351,18 +351,18 @@ class nglnUrwinBrain(ptResponder):
             for timer in ageSDL["UrwinSpawnTimes"]:
                 if timer:
                     timeTillSpawn = timer - PtGetDniTime()
-                    print "timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn)
+                    print("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
                     if timeTillSpawn > 0:
-                        print "nglnUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn)
+                        print("nglnUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn))
                         PtAtTimeCallback(self.key, timeTillSpawn, 1)
 
             # precision error FTW!
             timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
             timeLeftToday += 1 # because we want it to go off right AFTER the day flips
-            print "nglnUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday)
+            print("nglnUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
             PtAtTimeCallback(self.key, timeLeftToday, 2)
         else:
-            print "nglnUrwinBrain: Timer array was empty!"
+            print("nglnUrwinBrain: Timer array was empty!")
 
     ###########################
     def OnBackdoorMsg(self, target, param):
@@ -373,7 +373,7 @@ class nglnUrwinBrain(ptResponder):
         ageSDL = PtGetAgeSDL()
         if target == "urwin":
             if self.sceneobject.isLocallyOwned():
-                print "nglnUrwinBrain.OnBackdoorMsg: Backdoor!"
+                print("nglnUrwinBrain.OnBackdoorMsg: Backdoor!")
                 if param == "walk":
                     ageSDL["UrwinOnTheProwl"] = (1,)                    
                     if ageSDL["nglnPodLights"][0]:
@@ -409,5 +409,5 @@ class nglnUrwinBrain(ptResponder):
         elif code == "respUrwinVocalize":
             respUrwinVocalize.run(self.key)
         else:
-            print "nglnUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("nglnUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
             stackList.pop(0)

--- a/Python/nxusBookMachine.py
+++ b/Python/nxusBookMachine.py
@@ -320,7 +320,7 @@ class nxusBookMachine(ptModifier):
         self.id = 5017
         version = 5
         self.version = version
-        print "__init__nxusBookMachine v.", version
+        print("__init__nxusBookMachine v.", version)
         random.seed()
 
         self.guiState = kGUIDeactivated
@@ -443,10 +443,10 @@ class nxusBookMachine(ptModifier):
         if entry is not None:
             entryValue = entry.chronicleGetValue()
             if entryValue == "yes":
-                print "nxusBookMachine.OnServerInitComplete(): chron says you have the link to public Kveer, woo hoo"
+                print("nxusBookMachine.OnServerInitComplete(): chron says you have the link to public Kveer, woo hoo")
                 self.publicAges['Kveer'].linkVisible = True
         else:
-            print "nxusBookMachine.OnServerInitComplete(): chron says no link to public Kveer yet, so sorry"
+            print("nxusBookMachine.OnServerInitComplete(): chron says no link to public Kveer yet, so sorry")
 
 
     def __del__(self):
@@ -691,7 +691,7 @@ class nxusBookMachine(ptModifier):
 
     def IOnActKISlot(self, state, events): #click on KI Slot
         kiLevel = PtDetermineKILevel()
-        print "nxusBookMachine.OnNotify:\tplayer ki level is %d" % kiLevel
+        print("nxusBookMachine.OnNotify:\tplayer ki level is %d" % kiLevel)
         if kiLevel < kNormalKI:
             respKISlot.run(self.key, events = events) #Insert KI
         elif state:
@@ -1577,7 +1577,7 @@ class nxusBookMachine(ptModifier):
 
     #TODO: Not revised. I'm not sure about this stuff... Is it needed?
     def DoErcanaAndAhnonayStuff(self, panel):
-        print "nxusBookMachine.DoErcanaAndAhnonayStuff(): this age panel = ", panel
+        print("nxusBookMachine.DoErcanaAndAhnonayStuff(): this age panel = ", panel)
         if panel == "Ercana":
             ageFileName = "Ercana"
             ageInstanceName = "Er'cana"
@@ -1588,7 +1588,7 @@ class nxusBookMachine(ptModifier):
 
 
     def FindOrCreateGUIDChron(self, ageFileName):
-        print "FindOrCreateGUIDChron for: ", ageFileName
+        print("FindOrCreateGUIDChron for: ", ageFileName)
         GUIDChronFound = 0
         ageDataFolder = None
 
@@ -1610,7 +1610,7 @@ class nxusBookMachine(ptModifier):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "PelletCaveGUID":
                             GUIDChronFound = 1
-                            print "found pellet cave GUID: ", chron.getValue()
+                            print("found pellet cave GUID: ", chron.getValue())
                             return
 
         pelletCaveGUID = ""
@@ -1620,24 +1620,24 @@ class nxusBookMachine(ptModifier):
         if ageLinkNode:
             ageInfoNode = ageLinkNode.getAgeInfo()
             pelletCaveGUID = ageInfoNode.getAgeInstanceGuid()
-            print "found pelletCaveGUID age chron, = ", pelletCaveGUID
+            print("found pelletCaveGUID age chron, = ", pelletCaveGUID)
 
         if not ageDataFolder:
-            print "no ageDataFolder..."
+            print("no ageDataFolder...")
             ageStruct = ptAgeInfoStruct()
             ageStruct.setAgeFilename(ageFileName)
             ageLinkNode = vault.getOwnedAgeLink(ageStruct)
             if ageLinkNode:
-                print "got ageLinkNode, created AgeData folder"
+                print("got ageLinkNode, created AgeData folder")
                 ageInfoNode = ageLinkNode.getAgeInfo()
                 ageDataFolder = ptVaultFolderNode(0)
                 ageDataFolder.folderSetName("AgeData")
                 ageInfoNode.addNode(ageDataFolder)
 
         if not GUIDChronFound:
-            print "creating PelletCave GUID chron"
+            print("creating PelletCave GUID chron")
             newNode = ptVaultChronicleNode(0)
             newNode.chronicleSetName("PelletCaveGUID")
             newNode.chronicleSetValue(pelletCaveGUID)
             ageDataFolder.addNode(newNode)
-            print "created pelletCaveGUID age chron, = ", pelletCaveGUID
+            print("created pelletCaveGUID age chron, = ", pelletCaveGUID)

--- a/Python/nxusBookMachine.py
+++ b/Python/nxusBookMachine.py
@@ -320,7 +320,7 @@ class nxusBookMachine(ptModifier):
         self.id = 5017
         version = 5
         self.version = version
-        print("__init__nxusBookMachine v.", version)
+        PtDebugPrint("__init__nxusBookMachine v.", version)
         random.seed()
 
         self.guiState = kGUIDeactivated
@@ -443,10 +443,10 @@ class nxusBookMachine(ptModifier):
         if entry is not None:
             entryValue = entry.chronicleGetValue()
             if entryValue == "yes":
-                print("nxusBookMachine.OnServerInitComplete(): chron says you have the link to public Kveer, woo hoo")
+                PtDebugPrint("nxusBookMachine.OnServerInitComplete(): chron says you have the link to public Kveer, woo hoo")
                 self.publicAges['Kveer'].linkVisible = True
         else:
-            print("nxusBookMachine.OnServerInitComplete(): chron says no link to public Kveer yet, so sorry")
+            PtDebugPrint("nxusBookMachine.OnServerInitComplete(): chron says no link to public Kveer yet, so sorry")
 
 
     def __del__(self):
@@ -691,7 +691,7 @@ class nxusBookMachine(ptModifier):
 
     def IOnActKISlot(self, state, events): #click on KI Slot
         kiLevel = PtDetermineKILevel()
-        print("nxusBookMachine.OnNotify:\tplayer ki level is %d" % kiLevel)
+        PtDebugPrint("nxusBookMachine.OnNotify:\tplayer ki level is %d" % kiLevel)
         if kiLevel < kNormalKI:
             respKISlot.run(self.key, events = events) #Insert KI
         elif state:
@@ -1577,7 +1577,7 @@ class nxusBookMachine(ptModifier):
 
     #TODO: Not revised. I'm not sure about this stuff... Is it needed?
     def DoErcanaAndAhnonayStuff(self, panel):
-        print("nxusBookMachine.DoErcanaAndAhnonayStuff(): this age panel = ", panel)
+        PtDebugPrint("nxusBookMachine.DoErcanaAndAhnonayStuff(): this age panel = ", panel)
         if panel == "Ercana":
             ageFileName = "Ercana"
             ageInstanceName = "Er'cana"
@@ -1588,7 +1588,7 @@ class nxusBookMachine(ptModifier):
 
 
     def FindOrCreateGUIDChron(self, ageFileName):
-        print("FindOrCreateGUIDChron for: ", ageFileName)
+        PtDebugPrint("FindOrCreateGUIDChron for: ", ageFileName)
         GUIDChronFound = 0
         ageDataFolder = None
 
@@ -1610,7 +1610,7 @@ class nxusBookMachine(ptModifier):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "PelletCaveGUID":
                             GUIDChronFound = 1
-                            print("found pellet cave GUID: ", chron.getValue())
+                            PtDebugPrint("found pellet cave GUID: ", chron.getValue())
                             return
 
         pelletCaveGUID = ""
@@ -1620,24 +1620,24 @@ class nxusBookMachine(ptModifier):
         if ageLinkNode:
             ageInfoNode = ageLinkNode.getAgeInfo()
             pelletCaveGUID = ageInfoNode.getAgeInstanceGuid()
-            print("found pelletCaveGUID age chron, = ", pelletCaveGUID)
+            PtDebugPrint("found pelletCaveGUID age chron, = ", pelletCaveGUID)
 
         if not ageDataFolder:
-            print("no ageDataFolder...")
+            PtDebugPrint("no ageDataFolder...")
             ageStruct = ptAgeInfoStruct()
             ageStruct.setAgeFilename(ageFileName)
             ageLinkNode = vault.getOwnedAgeLink(ageStruct)
             if ageLinkNode:
-                print("got ageLinkNode, created AgeData folder")
+                PtDebugPrint("got ageLinkNode, created AgeData folder")
                 ageInfoNode = ageLinkNode.getAgeInfo()
                 ageDataFolder = ptVaultFolderNode(0)
                 ageDataFolder.folderSetName("AgeData")
                 ageInfoNode.addNode(ageDataFolder)
 
         if not GUIDChronFound:
-            print("creating PelletCave GUID chron")
+            PtDebugPrint("creating PelletCave GUID chron")
             newNode = ptVaultChronicleNode(0)
             newNode.chronicleSetName("PelletCaveGUID")
             newNode.chronicleSetValue(pelletCaveGUID)
             ageDataFolder.addNode(newNode)
-            print("created pelletCaveGUID age chron, = ", pelletCaveGUID)
+            PtDebugPrint("created pelletCaveGUID age chron, = ", pelletCaveGUID)

--- a/Python/payiBahroSymbol.py
+++ b/Python/payiBahroSymbol.py
@@ -78,12 +78,12 @@ class payiBahroSymbol(ptResponder):
         self.id = 5251
         version = 1
         self.version = version
-        print "__init__payiBahroSymbol v.", version,".0"
+        print("__init__payiBahroSymbol v.", version,".0")
 
     ###########################
     def OnServerInitComplete(self):
         timeIntoMasterAnim = PtGetAgeTimeOfDayPercent() * (DayFrameSize.value / 30.0)
-        print "payiBahroSymbol.OnServerInitComplete: Anims skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed)
+        print("payiBahroSymbol.OnServerInitComplete: Anims skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed))
 
         animSkyDome.animation.skipToTime(timeIntoMasterAnim)
         animLightBoards.animation.skipToTime(timeIntoMasterAnim)

--- a/Python/payiBahroSymbol.py
+++ b/Python/payiBahroSymbol.py
@@ -78,12 +78,12 @@ class payiBahroSymbol(ptResponder):
         self.id = 5251
         version = 1
         self.version = version
-        print("__init__payiBahroSymbol v.", version,".0")
+        PtDebugPrint("__init__payiBahroSymbol v.", version,".0")
 
     ###########################
     def OnServerInitComplete(self):
         timeIntoMasterAnim = PtGetAgeTimeOfDayPercent() * (DayFrameSize.value / 30.0)
-        print("payiBahroSymbol.OnServerInitComplete: Anims skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed))
+        PtDebugPrint("payiBahroSymbol.OnServerInitComplete: Anims skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed))
 
         animSkyDome.animation.skipToTime(timeIntoMasterAnim)
         animLightBoards.animation.skipToTime(timeIntoMasterAnim)

--- a/Python/payiUrwinBrain.py
+++ b/Python/payiUrwinBrain.py
@@ -106,7 +106,7 @@ class payiUrwinBrain(ptResponder):
         self.id = 5253
         version = 1
         self.version = version
-        print "__init__payiUrwinBrain v.", version,".0"
+        print("__init__payiUrwinBrain v.", version,".0")
 
     ############################
     def OnFirstUpdate(self):
@@ -117,7 +117,7 @@ class payiUrwinBrain(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "payiUrwinBrain:\tERROR---Cannot find the Payiferen Age SDL"
+            print("payiUrwinBrain:\tERROR---Cannot find the Payiferen Age SDL")
             self.InitNewSDLVars()
 
         ageSDL.sendToClients("UrwinLastUpdated")
@@ -136,10 +136,10 @@ class payiUrwinBrain(ptResponder):
         lastDay = int(ageSDL["UrwinLastUpdated"][0] / kDayLengthInSeconds)
 
         if (thisDay - lastDay) > 0:
-            print "payiUrwinBrain: It's been at least a day since the last update, running new numbers now."
+            print("payiUrwinBrain: It's been at least a day since the last update, running new numbers now.")
             self.InitNewSDLVars()
         else:
-            print "payiUrwinBrain: It's been less than a day since the last update, doing nothing"
+            print("payiUrwinBrain: It's been less than a day since the last update, doing nothing")
             self.SetUrwinTimers()
 
         if not len(PtGetPlayerList()):
@@ -162,58 +162,58 @@ class payiUrwinBrain(ptResponder):
         global stackList
 
         ageSDL = PtGetAgeSDL()
-        print "payiUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events
+        print("payiUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events)
 
         if id == (-1):
-            print "Need to store event: %s" % (events[0][1])
+            print("Need to store event: %s" % (events[0][1]))
             stackList.append(events[0][1])
-            print "New list is: %s" % (str(stackList))
+            print("New list is: %s" % (str(stackList)))
             if len(stackList) == 1:
-                print "List is only one command long, so I'm playing it"
+                print("List is only one command long, so I'm playing it")
                 code = stackList[0]
-                print "Playing command: %s" % (code)
+                print("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         elif state and self.sceneobject.isLocallyOwned() and ageSDL["UrwinOnTheProwl"][0]:
             if id == respUrwinSfx.id:
-                print "Callback was from Appearance SFX, and I own the age, so start walking"
+                print("Callback was from Appearance SFX, and I own the age, so start walking")
                 self.StartToWalk()
 
             else:
-                print "Callback was from responder, and I own the age, so Logic Time"
+                print("Callback was from responder, and I own the age, so Logic Time")
                 old = stackList.pop(0)
-                print "Popping off: %s" % (old)
+                print("Popping off: %s" % (old))
                 boolBatteryChargedAndOn = ageSDL["payiPodLights"][0]
                 
                 if id == respUrwin_Walk_Loop01.id or id == respUrwin_Walk_Loop02.id or id == respUrwin_WalkSniff_ToWalk.id or id == respUrwin_Idle_ToWalk.id:
                     UrwinMasterAnim.animation.resume()
                     if StepsToTake == 0:
                         StepsToTake = random.randint(minsteps, maxsteps)
-                        print "We should have steps, so Urwin has decided to take %d steps." % (StepsToTake)
+                        print("We should have steps, so Urwin has decided to take %d steps." % (StepsToTake))
                     
                     StepsToTake = StepsToTake - 1
                     if StepsToTake:
                         if random.randint(0,9): # 90% chance of continuing walk loop
-                            print "Urwin will take %d more steps..." % (StepsToTake)
+                            print("Urwin will take %d more steps..." % (StepsToTake))
                             if random.randint(0,2):
-                                print "Urwin walks one way."
+                                print("Urwin walks one way.")
                                 self.SendNote("respUrwin_Walk_Loop01")
                                 if boolBatteryChargedAndOn:
                                     respUrwinSfx.run(self.key, state="Walk01")
                             else:
-                                print "Urwin walks the other way."
+                                print("Urwin walks the other way.")
                                 self.SendNote("respUrwin_Walk_Loop02")
                                 if boolBatteryChargedAndOn:
                                     respUrwinSfx.run(self.key, state="Walk02")
 
                         else: # 10% to Sniff
-                            print "Urwin smells something..."
+                            print("Urwin smells something...")
                             self.SendNote("respUrwin_Walk_ToWalkSniff")
                             if boolBatteryChargedAndOn:
                                 respUrwinSfx.run(self.key, state="Walk2Sniff")
 
                     else:
-                        print "Urwin is tired and stops walking"
+                        print("Urwin is tired and stops walking")
                         self.SendNote("respUrwin_Walk_ToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Walk2Idle")
@@ -222,19 +222,19 @@ class payiUrwinBrain(ptResponder):
                     UrwinMasterAnim.animation.resume()
                     pct = random.randint(0,2)
                     if pct == 2:
-                        print "Urwin smells something good!"
+                        print("Urwin smells something good!")
                         self.SendNote("respUrwin_WalkSniff")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Sniff")
 
                     elif pct == 1:
-                        print "Urwin found food!"
+                        print("Urwin found food!")
                         self.SendNote("respUrwin_WalkSniff_ToEat")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Sniff2Eat")
 
                     else:
-                        print "Urwin says nevermind, back to walking."
+                        print("Urwin says nevermind, back to walking.")
                         self.SendNote("respUrwin_WalkSniff_ToWalk")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Sniff2Walk")
@@ -243,19 +243,19 @@ class payiUrwinBrain(ptResponder):
                     UrwinMasterAnim.animation.stop()
                     pct = random.randint(0,2)
                     if pct == 2:
-                        print "Urwin lost interest in the food."
+                        print("Urwin lost interest in the food.")
                         self.SendNote("respUrwin_Eat_ToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Idle")
 
                     elif pct == 1:
-                        print "Urwin is still searching for the food."
+                        print("Urwin is still searching for the food.")
                         self.SendNote("respUrwin_Eat_ToWalkSniff")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Sniff")
 
                     else:
-                        print "Urwin scoops up the food!"
+                        print("Urwin scoops up the food!")
                         self.SendNote("respUrwin_Eat_Scoop")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Scoop")
@@ -263,31 +263,31 @@ class payiUrwinBrain(ptResponder):
                 elif id == respUrwin_Eat_Scoop.id or id == respUrwin_Eat_Shake.id or id == respUrwin_Eat_Swallow.id:
                     pct = random.randint(0,4)
                     if pct == 4:
-                        print "Urwin scoops up the food!"
+                        print("Urwin scoops up the food!")
                         self.SendNote("respUrwin_Eat_Scoop")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Scoop")
 
                     elif pct == 3:
-                        print "Urwin shakes the food!"
+                        print("Urwin shakes the food!")
                         self.SendNote("respUrwin_Eat_Shake")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Shake")
 
                     elif pct == 2:
-                        print "Urwin swallows the food!"
+                        print("Urwin swallows the food!")
                         self.SendNote("respUrwin_Eat_Swallow")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Swallow")
 
                     elif pct == 1:
-                        print "Urwin lost interest in the food."
+                        print("Urwin lost interest in the food.")
                         self.SendNote("respUrwin_Eat_ToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Idle")
 
                     else:
-                        print "Urwin is still searching for the food."
+                        print("Urwin is still searching for the food.")
                         self.SendNote("respUrwin_Eat_ToWalkSniff")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Sniff")
@@ -296,37 +296,37 @@ class payiUrwinBrain(ptResponder):
                     UrwinMasterAnim.animation.stop()
                     pct = random.randint(0,4)
                     if pct == 4:
-                        print "Urwin idles one way."
+                        print("Urwin idles one way.")
                         self.SendNote("respUrwin_Idle_01")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle01")
 
                     elif pct == 3:
-                        print "Urwin idles the other way."
+                        print("Urwin idles the other way.")
                         self.SendNote("respUrwin_Idle_02")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle02")
 
                     elif pct == 2:
-                        print "Urwin calls home!"
+                        print("Urwin calls home!")
                         self.SendNote("respUrwin_Idle_Vocalize")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Vocalize")
 
                     elif pct == 1:
-                        print "Urwin gets hungry."
+                        print("Urwin gets hungry.")
                         self.SendNote("respUrwin_Idle_ToEat")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle2Eat")
 
                     else:
-                        print "Urwin is done resting, back to walking."
+                        print("Urwin is done resting, back to walking.")
                         self.SendNote("respUrwin_Idle_ToWalk")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle2Walk")
 
                 elif id == actUrwinPathEnd.id:
-                    print "End of the line, Urwin!"
+                    print("End of the line, Urwin!")
                     UrwinMasterAnim.animation.stop()
                     UrwinMasterAnim.animation.skipToTime(0)
                     ageSDL["UrwinOnTheProwl"] = (0,)
@@ -334,17 +334,17 @@ class payiUrwinBrain(ptResponder):
                         respUrwinSfx.run(self.key, state="disappear")
 
         elif id in range(3,21) and not self.sceneobject.isLocallyOwned():
-            print "Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list"
+            print("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
             old = stackList.pop(0)
-            print "Popping off: %s" % (old)
+            print("Popping off: %s" % (old))
             if len(stackList):
-                print "List has at least one item ready to play"
+                print("List has at least one item ready to play")
                 code = stackList[0]
-                print "Playing command: %s" % (code)
+                print("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         else:
-            print "Callback from something else?"
+            print("Callback from something else?")
 
     ############################
     def StartToWalk(self):
@@ -354,7 +354,7 @@ class payiUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["payiPodLights"][0]
 
         StepsToTake = random.randint(minsteps, maxsteps)
-        print "Urwin has decided to take %d steps." % (StepsToTake)
+        print("Urwin has decided to take %d steps." % (StepsToTake))
 
         if random.randint(0,1):
             self.SendNote("respUrwin_Walk_Loop01")
@@ -374,7 +374,7 @@ class payiUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["payiPodLights"][0]
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
-                print "UrwinBrain.OnTimer: Time for the Urwin to return."
+                print("UrwinBrain.OnTimer: Time for the Urwin to return.")
                 ageSDL["UrwinOnTheProwl"] = (1,)
 
                 if random.randint(0,1):
@@ -387,7 +387,7 @@ class payiUrwinBrain(ptResponder):
                 else:
                     self.StartToWalk()
             elif TimerID == 2:
-                print "UrwinBrain.OnTimer: New day, let's renew the timers."
+                print("UrwinBrain.OnTimer: New day, let's renew the timers.")
                 self.InitNewSDLVars()
             elif TimerID == 3:
                 UrwinMasterAnim.animation.stop()
@@ -427,20 +427,20 @@ class payiUrwinBrain(ptResponder):
         # something roughly in that timeframe.
         randnum = float(random.randint(0,kFirstMorningSpawn))
         firstTime = int((randnum / 1000.0) * kDayLengthInSeconds) + beginningOfToday
-        print "payiUrwinBrain: Generated a valid spawn time: %d" % (firstTime)
+        print("payiUrwinBrain: Generated a valid spawn time: %d" % (firstTime))
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
-                print "payiUrwinBrain: Generated a valid spawn time: %d" % (newTime)
+                print("payiUrwinBrain: Generated a valid spawn time: %d" % (newTime))
                 spawnTimes.append(newTime)
             else:
-                print "payiUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime)
+                print("payiUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
                 break
         else:
-            print "payiUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes
+            print("payiUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
             spawnTimes = [0]
 
         while len(spawnTimes) < 20:
@@ -456,18 +456,18 @@ class payiUrwinBrain(ptResponder):
             for timer in ageSDL["UrwinSpawnTimes"]:
                 if timer:
                     timeTillSpawn = timer - PtGetDniTime()
-                    print "timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn)
+                    print("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
                     if timeTillSpawn > 0:
-                        print "payiUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn)
+                        print("payiUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn))
                         PtAtTimeCallback(self.key, timeTillSpawn, 1)
 
             # precision error FTW!
             timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
             timeLeftToday += 1 # because we want it to go off right AFTER the day flips
-            print "payiUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday)
+            print("payiUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
             PtAtTimeCallback(self.key, timeLeftToday, 2)
         else:
-            print "payiUrwinBrain: Timer array was empty!"
+            print("payiUrwinBrain: Timer array was empty!")
 
     ###########################
     def OnBackdoorMsg(self, target, param):
@@ -478,7 +478,7 @@ class payiUrwinBrain(ptResponder):
         ageSDL = PtGetAgeSDL()
         if target == "urwin":
             if self.sceneobject.isLocallyOwned():
-                print "payiUrwinBrain.OnBackdoorMsg: Backdoor!"
+                print("payiUrwinBrain.OnBackdoorMsg: Backdoor!")
                 if param == "walk":
                     ageSDL["UrwinOnTheProwl"] = (1,)                    
                     if ageSDL["payiPodLights"][0]:
@@ -521,7 +521,7 @@ class payiUrwinBrain(ptResponder):
                     elif ecAction == "ToWalk":
                         respUrwin_Idle_ToWalk.run(self.key)
                     else:            
-                        print "payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction)
+                        print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
                         stackList.pop(0)
                 elif ecState == "Walk":
                     if ecAction == "Loop01":
@@ -533,7 +533,7 @@ class payiUrwinBrain(ptResponder):
                     elif ecAction == "ToIdle":
                         respUrwin_Walk_ToIdle.run(self.key)
                     else:            
-                        print "payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction)
+                        print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
                         stackList.pop(0)
                 elif ecState == "WalkSniff":
                     if ecAction == "ToEat":
@@ -554,14 +554,14 @@ class payiUrwinBrain(ptResponder):
                     elif ecAction == "Swallow":
                         respUrwin_Eat_Swallow.run(self.key)
                     else:            
-                        print "payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction)
+                        print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
                         stackList.pop(0)
                 else:            
-                    print "payiUrwinBrain.ExecCode(): ERROR! Invalid ecState '%s'." % (ecState)
+                    print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecState '%s'." % (ecState))
                     stackList.pop(0)
             else:            
-                print "payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code)
+                print("payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
                 stackList.pop(0)
         except:
-            print "payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
             stackList.pop(0)

--- a/Python/payiUrwinBrain.py
+++ b/Python/payiUrwinBrain.py
@@ -106,7 +106,7 @@ class payiUrwinBrain(ptResponder):
         self.id = 5253
         version = 1
         self.version = version
-        print("__init__payiUrwinBrain v.", version,".0")
+        PtDebugPrint("__init__payiUrwinBrain v.", version,".0")
 
     ############################
     def OnFirstUpdate(self):
@@ -117,7 +117,7 @@ class payiUrwinBrain(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("payiUrwinBrain:\tERROR---Cannot find the Payiferen Age SDL")
+            PtDebugPrint("payiUrwinBrain:\tERROR---Cannot find the Payiferen Age SDL")
             self.InitNewSDLVars()
 
         ageSDL.sendToClients("UrwinLastUpdated")
@@ -136,10 +136,10 @@ class payiUrwinBrain(ptResponder):
         lastDay = int(ageSDL["UrwinLastUpdated"][0] / kDayLengthInSeconds)
 
         if (thisDay - lastDay) > 0:
-            print("payiUrwinBrain: It's been at least a day since the last update, running new numbers now.")
+            PtDebugPrint("payiUrwinBrain: It's been at least a day since the last update, running new numbers now.")
             self.InitNewSDLVars()
         else:
-            print("payiUrwinBrain: It's been less than a day since the last update, doing nothing")
+            PtDebugPrint("payiUrwinBrain: It's been less than a day since the last update, doing nothing")
             self.SetUrwinTimers()
 
         if not len(PtGetPlayerList()):
@@ -162,58 +162,58 @@ class payiUrwinBrain(ptResponder):
         global stackList
 
         ageSDL = PtGetAgeSDL()
-        print("payiUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events)
+        PtDebugPrint("payiUrwinBrain.OnNotify:  state=%f id=%d owned=%s prowl=%s events=" % (state,id,str(self.sceneobject.isLocallyOwned()),str(ageSDL["UrwinOnTheProwl"][0])),events)
 
         if id == (-1):
-            print("Need to store event: %s" % (events[0][1]))
+            PtDebugPrint("Need to store event: %s" % (events[0][1]))
             stackList.append(events[0][1])
-            print("New list is: %s" % (str(stackList)))
+            PtDebugPrint("New list is: %s" % (str(stackList)))
             if len(stackList) == 1:
-                print("List is only one command long, so I'm playing it")
+                PtDebugPrint("List is only one command long, so I'm playing it")
                 code = stackList[0]
-                print("Playing command: %s" % (code))
+                PtDebugPrint("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         elif state and self.sceneobject.isLocallyOwned() and ageSDL["UrwinOnTheProwl"][0]:
             if id == respUrwinSfx.id:
-                print("Callback was from Appearance SFX, and I own the age, so start walking")
+                PtDebugPrint("Callback was from Appearance SFX, and I own the age, so start walking")
                 self.StartToWalk()
 
             else:
-                print("Callback was from responder, and I own the age, so Logic Time")
+                PtDebugPrint("Callback was from responder, and I own the age, so Logic Time")
                 old = stackList.pop(0)
-                print("Popping off: %s" % (old))
+                PtDebugPrint("Popping off: %s" % (old))
                 boolBatteryChargedAndOn = ageSDL["payiPodLights"][0]
                 
                 if id == respUrwin_Walk_Loop01.id or id == respUrwin_Walk_Loop02.id or id == respUrwin_WalkSniff_ToWalk.id or id == respUrwin_Idle_ToWalk.id:
                     UrwinMasterAnim.animation.resume()
                     if StepsToTake == 0:
                         StepsToTake = random.randint(minsteps, maxsteps)
-                        print("We should have steps, so Urwin has decided to take %d steps." % (StepsToTake))
+                        PtDebugPrint("We should have steps, so Urwin has decided to take %d steps." % (StepsToTake))
                     
                     StepsToTake = StepsToTake - 1
                     if StepsToTake:
                         if random.randint(0,9): # 90% chance of continuing walk loop
-                            print("Urwin will take %d more steps..." % (StepsToTake))
+                            PtDebugPrint("Urwin will take %d more steps..." % (StepsToTake))
                             if random.randint(0,2):
-                                print("Urwin walks one way.")
+                                PtDebugPrint("Urwin walks one way.")
                                 self.SendNote("respUrwin_Walk_Loop01")
                                 if boolBatteryChargedAndOn:
                                     respUrwinSfx.run(self.key, state="Walk01")
                             else:
-                                print("Urwin walks the other way.")
+                                PtDebugPrint("Urwin walks the other way.")
                                 self.SendNote("respUrwin_Walk_Loop02")
                                 if boolBatteryChargedAndOn:
                                     respUrwinSfx.run(self.key, state="Walk02")
 
                         else: # 10% to Sniff
-                            print("Urwin smells something...")
+                            PtDebugPrint("Urwin smells something...")
                             self.SendNote("respUrwin_Walk_ToWalkSniff")
                             if boolBatteryChargedAndOn:
                                 respUrwinSfx.run(self.key, state="Walk2Sniff")
 
                     else:
-                        print("Urwin is tired and stops walking")
+                        PtDebugPrint("Urwin is tired and stops walking")
                         self.SendNote("respUrwin_Walk_ToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Walk2Idle")
@@ -222,19 +222,19 @@ class payiUrwinBrain(ptResponder):
                     UrwinMasterAnim.animation.resume()
                     pct = random.randint(0,2)
                     if pct == 2:
-                        print("Urwin smells something good!")
+                        PtDebugPrint("Urwin smells something good!")
                         self.SendNote("respUrwin_WalkSniff")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Sniff")
 
                     elif pct == 1:
-                        print("Urwin found food!")
+                        PtDebugPrint("Urwin found food!")
                         self.SendNote("respUrwin_WalkSniff_ToEat")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Sniff2Eat")
 
                     else:
-                        print("Urwin says nevermind, back to walking.")
+                        PtDebugPrint("Urwin says nevermind, back to walking.")
                         self.SendNote("respUrwin_WalkSniff_ToWalk")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Sniff2Walk")
@@ -243,19 +243,19 @@ class payiUrwinBrain(ptResponder):
                     UrwinMasterAnim.animation.stop()
                     pct = random.randint(0,2)
                     if pct == 2:
-                        print("Urwin lost interest in the food.")
+                        PtDebugPrint("Urwin lost interest in the food.")
                         self.SendNote("respUrwin_Eat_ToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Idle")
 
                     elif pct == 1:
-                        print("Urwin is still searching for the food.")
+                        PtDebugPrint("Urwin is still searching for the food.")
                         self.SendNote("respUrwin_Eat_ToWalkSniff")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Sniff")
 
                     else:
-                        print("Urwin scoops up the food!")
+                        PtDebugPrint("Urwin scoops up the food!")
                         self.SendNote("respUrwin_Eat_Scoop")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Scoop")
@@ -263,31 +263,31 @@ class payiUrwinBrain(ptResponder):
                 elif id == respUrwin_Eat_Scoop.id or id == respUrwin_Eat_Shake.id or id == respUrwin_Eat_Swallow.id:
                     pct = random.randint(0,4)
                     if pct == 4:
-                        print("Urwin scoops up the food!")
+                        PtDebugPrint("Urwin scoops up the food!")
                         self.SendNote("respUrwin_Eat_Scoop")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Scoop")
 
                     elif pct == 3:
-                        print("Urwin shakes the food!")
+                        PtDebugPrint("Urwin shakes the food!")
                         self.SendNote("respUrwin_Eat_Shake")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Shake")
 
                     elif pct == 2:
-                        print("Urwin swallows the food!")
+                        PtDebugPrint("Urwin swallows the food!")
                         self.SendNote("respUrwin_Eat_Swallow")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Swallow")
 
                     elif pct == 1:
-                        print("Urwin lost interest in the food.")
+                        PtDebugPrint("Urwin lost interest in the food.")
                         self.SendNote("respUrwin_Eat_ToIdle")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Idle")
 
                     else:
-                        print("Urwin is still searching for the food.")
+                        PtDebugPrint("Urwin is still searching for the food.")
                         self.SendNote("respUrwin_Eat_ToWalkSniff")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Eat2Sniff")
@@ -296,37 +296,37 @@ class payiUrwinBrain(ptResponder):
                     UrwinMasterAnim.animation.stop()
                     pct = random.randint(0,4)
                     if pct == 4:
-                        print("Urwin idles one way.")
+                        PtDebugPrint("Urwin idles one way.")
                         self.SendNote("respUrwin_Idle_01")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle01")
 
                     elif pct == 3:
-                        print("Urwin idles the other way.")
+                        PtDebugPrint("Urwin idles the other way.")
                         self.SendNote("respUrwin_Idle_02")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle02")
 
                     elif pct == 2:
-                        print("Urwin calls home!")
+                        PtDebugPrint("Urwin calls home!")
                         self.SendNote("respUrwin_Idle_Vocalize")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Vocalize")
 
                     elif pct == 1:
-                        print("Urwin gets hungry.")
+                        PtDebugPrint("Urwin gets hungry.")
                         self.SendNote("respUrwin_Idle_ToEat")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle2Eat")
 
                     else:
-                        print("Urwin is done resting, back to walking.")
+                        PtDebugPrint("Urwin is done resting, back to walking.")
                         self.SendNote("respUrwin_Idle_ToWalk")
                         if boolBatteryChargedAndOn:
                             respUrwinSfx.run(self.key, state="Idle2Walk")
 
                 elif id == actUrwinPathEnd.id:
-                    print("End of the line, Urwin!")
+                    PtDebugPrint("End of the line, Urwin!")
                     UrwinMasterAnim.animation.stop()
                     UrwinMasterAnim.animation.skipToTime(0)
                     ageSDL["UrwinOnTheProwl"] = (0,)
@@ -334,17 +334,17 @@ class payiUrwinBrain(ptResponder):
                         respUrwinSfx.run(self.key, state="disappear")
 
         elif id in range(3,21) and not self.sceneobject.isLocallyOwned():
-            print("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
+            PtDebugPrint("Callback was from responder, and I DON'T own the age, so I'll try playing the next item in list")
             old = stackList.pop(0)
-            print("Popping off: %s" % (old))
+            PtDebugPrint("Popping off: %s" % (old))
             if len(stackList):
-                print("List has at least one item ready to play")
+                PtDebugPrint("List has at least one item ready to play")
                 code = stackList[0]
-                print("Playing command: %s" % (code))
+                PtDebugPrint("Playing command: %s" % (code))
                 self.ExecCode(code)
 
         else:
-            print("Callback from something else?")
+            PtDebugPrint("Callback from something else?")
 
     ############################
     def StartToWalk(self):
@@ -354,7 +354,7 @@ class payiUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["payiPodLights"][0]
 
         StepsToTake = random.randint(minsteps, maxsteps)
-        print("Urwin has decided to take %d steps." % (StepsToTake))
+        PtDebugPrint("Urwin has decided to take %d steps." % (StepsToTake))
 
         if random.randint(0,1):
             self.SendNote("respUrwin_Walk_Loop01")
@@ -374,7 +374,7 @@ class payiUrwinBrain(ptResponder):
         boolBatteryChargedAndOn = ageSDL["payiPodLights"][0]
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
-                print("UrwinBrain.OnTimer: Time for the Urwin to return.")
+                PtDebugPrint("UrwinBrain.OnTimer: Time for the Urwin to return.")
                 ageSDL["UrwinOnTheProwl"] = (1,)
 
                 if random.randint(0,1):
@@ -387,7 +387,7 @@ class payiUrwinBrain(ptResponder):
                 else:
                     self.StartToWalk()
             elif TimerID == 2:
-                print("UrwinBrain.OnTimer: New day, let's renew the timers.")
+                PtDebugPrint("UrwinBrain.OnTimer: New day, let's renew the timers.")
                 self.InitNewSDLVars()
             elif TimerID == 3:
                 UrwinMasterAnim.animation.stop()
@@ -419,7 +419,7 @@ class payiUrwinBrain(ptResponder):
 
         beginningOfToday = PtGetDniTime() - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
         endOfToday = int(kDayLengthInSeconds / 2) + beginningOfToday
-        #print "Dawn: %d  Dusk: %d" % (beginningOfToday, endOfToday)
+        #PtDebugPrint("Dawn: %d  Dusk: %d" % (beginningOfToday, endOfToday))
 
         # We need a random times in the first 5 hours of the day
         # which is in the first 44.5 percent of the day. So we're
@@ -427,20 +427,20 @@ class payiUrwinBrain(ptResponder):
         # something roughly in that timeframe.
         randnum = float(random.randint(0,kFirstMorningSpawn))
         firstTime = int((randnum / 1000.0) * kDayLengthInSeconds) + beginningOfToday
-        print("payiUrwinBrain: Generated a valid spawn time: %d" % (firstTime))
+        PtDebugPrint("payiUrwinBrain: Generated a valid spawn time: %d" % (firstTime))
         spawnTimes = [firstTime]
 
         while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
-                print("payiUrwinBrain: Generated a valid spawn time: %d" % (newTime))
+                PtDebugPrint("payiUrwinBrain: Generated a valid spawn time: %d" % (newTime))
                 spawnTimes.append(newTime)
             else:
-                print("payiUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
+                PtDebugPrint("payiUrwinBrain: Generated a spawn time after dusk, exiting loop: %d" % (newTime))
                 break
         else:
-            print("payiUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
+            PtDebugPrint("payiUrwinBrain:ERROR---Tried to add a spawn time that's not a number: " , spawnTimes)
             spawnTimes = [0]
 
         while len(spawnTimes) < 20:
@@ -456,18 +456,18 @@ class payiUrwinBrain(ptResponder):
             for timer in ageSDL["UrwinSpawnTimes"]:
                 if timer:
                     timeTillSpawn = timer - PtGetDniTime()
-                    print("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
+                    PtDebugPrint("timer: %d    time: %d    timeTillSpawn: %d" % (timer,PtGetDniTime(),timeTillSpawn))
                     if timeTillSpawn > 0:
-                        print("payiUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn))
+                        PtDebugPrint("payiUrwinBrain: Setting timer for %d seconds" % (timeTillSpawn))
                         PtAtTimeCallback(self.key, timeTillSpawn, 1)
 
             # precision error FTW!
             timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
             timeLeftToday += 1 # because we want it to go off right AFTER the day flips
-            print("payiUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
+            PtDebugPrint("payiUrwinBrain: Setting EndOfDay timer for %d seconds" % (timeLeftToday))
             PtAtTimeCallback(self.key, timeLeftToday, 2)
         else:
-            print("payiUrwinBrain: Timer array was empty!")
+            PtDebugPrint("payiUrwinBrain: Timer array was empty!")
 
     ###########################
     def OnBackdoorMsg(self, target, param):
@@ -478,7 +478,7 @@ class payiUrwinBrain(ptResponder):
         ageSDL = PtGetAgeSDL()
         if target == "urwin":
             if self.sceneobject.isLocallyOwned():
-                print("payiUrwinBrain.OnBackdoorMsg: Backdoor!")
+                PtDebugPrint("payiUrwinBrain.OnBackdoorMsg: Backdoor!")
                 if param == "walk":
                     ageSDL["UrwinOnTheProwl"] = (1,)                    
                     if ageSDL["payiPodLights"][0]:
@@ -521,7 +521,7 @@ class payiUrwinBrain(ptResponder):
                     elif ecAction == "ToWalk":
                         respUrwin_Idle_ToWalk.run(self.key)
                     else:            
-                        print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
+                        PtDebugPrint("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
                         stackList.pop(0)
                 elif ecState == "Walk":
                     if ecAction == "Loop01":
@@ -533,7 +533,7 @@ class payiUrwinBrain(ptResponder):
                     elif ecAction == "ToIdle":
                         respUrwin_Walk_ToIdle.run(self.key)
                     else:            
-                        print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
+                        PtDebugPrint("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
                         stackList.pop(0)
                 elif ecState == "WalkSniff":
                     if ecAction == "ToEat":
@@ -554,14 +554,14 @@ class payiUrwinBrain(ptResponder):
                     elif ecAction == "Swallow":
                         respUrwin_Eat_Swallow.run(self.key)
                     else:            
-                        print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
+                        PtDebugPrint("payiUrwinBrain.ExecCode(): ERROR! Invalid ecAction '%s'." % (ecAction))
                         stackList.pop(0)
                 else:            
-                    print("payiUrwinBrain.ExecCode(): ERROR! Invalid ecState '%s'." % (ecState))
+                    PtDebugPrint("payiUrwinBrain.ExecCode(): ERROR! Invalid ecState '%s'." % (ecState))
                     stackList.pop(0)
             else:            
-                print("payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
+                PtDebugPrint("payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
                 stackList.pop(0)
         except:
-            print("payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("payiUrwinBrain.ExecCode(): ERROR! Invalid code '%s'." % (code))
             stackList.pop(0)

--- a/Python/philBookshelf.py
+++ b/Python/philBookshelf.py
@@ -76,7 +76,7 @@ class philBookshelf(ptModifier):
         self.id = 5327
         self.version = 1
         minor = 1
-        print(('__init__philBookshelf v. %d.%d' % (self.version, minor)))
+        PtDebugPrint(('__init__philBookshelf v. %d.%d' % (self.version, minor)))
 
 
 
@@ -91,7 +91,7 @@ class philBookshelf(ptModifier):
 
     def OnNotify(self,state,id,events):
         boolLinkerIsMe = PtWasLocallyNotified(self.key)
-        print(('philBookshelf.OnNotify(): state = %d, id = %d, me = %s' % (state, id, boolLinkerIsMe)))
+        PtDebugPrint(('philBookshelf.OnNotify(): state = %d, id = %d, me = %s' % (state, id, boolLinkerIsMe)))
         
         if id == actBookshelfExit.id:
             self.IDisengageShelf(boolLinkerIsMe)
@@ -102,7 +102,7 @@ class philBookshelf(ptModifier):
                 avatar = PtFindAvatar(events)
                 if event[0] == kMultiStageEvent and event[1] == 0 and LocalAvatar == avatar: # Smart seek completed. Exit multistage, and show GUI.
                     SeekBehavior.gotoStage(avatar, -1) 
-                    print("philBookshelf.OnNotify():\tengaging bookshelf")
+                    PtDebugPrint("philBookshelf.OnNotify():\tengaging bookshelf")
                     avatar.draw.disable()
                     # set camera to Shelf Camera
                     virtCam = ptCamera()
@@ -162,7 +162,7 @@ class philBookshelf(ptModifier):
     
 
     def IDisengageShelf(self, boolLinkerIsMe = False):
-        print(('philBookshelf.IDisengageShelf(): me = %s' % boolLinkerIsMe))
+        PtDebugPrint(('philBookshelf.IDisengageShelf(): me = %s' % boolLinkerIsMe))
         actBookshelfExit.disable()
         # fastforward removed because it disables netPropagate
         respMoveShelf.run(self.key, state = "lower")

--- a/Python/philBookshelf.py
+++ b/Python/philBookshelf.py
@@ -76,7 +76,7 @@ class philBookshelf(ptModifier):
         self.id = 5327
         self.version = 1
         minor = 1
-        print ('__init__philBookshelf v. %d.%d' % (self.version, minor))
+        print(('__init__philBookshelf v. %d.%d' % (self.version, minor)))
 
 
 
@@ -91,7 +91,7 @@ class philBookshelf(ptModifier):
 
     def OnNotify(self,state,id,events):
         boolLinkerIsMe = PtWasLocallyNotified(self.key)
-        print ('philBookshelf.OnNotify(): state = %d, id = %d, me = %s' % (state, id, boolLinkerIsMe))
+        print(('philBookshelf.OnNotify(): state = %d, id = %d, me = %s' % (state, id, boolLinkerIsMe)))
         
         if id == actBookshelfExit.id:
             self.IDisengageShelf(boolLinkerIsMe)
@@ -102,7 +102,7 @@ class philBookshelf(ptModifier):
                 avatar = PtFindAvatar(events)
                 if event[0] == kMultiStageEvent and event[1] == 0 and LocalAvatar == avatar: # Smart seek completed. Exit multistage, and show GUI.
                     SeekBehavior.gotoStage(avatar, -1) 
-                    print "philBookshelf.OnNotify():\tengaging bookshelf"
+                    print("philBookshelf.OnNotify():\tengaging bookshelf")
                     avatar.draw.disable()
                     # set camera to Shelf Camera
                     virtCam = ptCamera()
@@ -162,7 +162,7 @@ class philBookshelf(ptModifier):
     
 
     def IDisengageShelf(self, boolLinkerIsMe = False):
-        print ('philBookshelf.IDisengageShelf(): me = %s' % boolLinkerIsMe)
+        print(('philBookshelf.IDisengageShelf(): me = %s' % boolLinkerIsMe))
         actBookshelfExit.disable()
         # fastforward removed because it disables netPropagate
         respMoveShelf.run(self.key, state = "lower")

--- a/Python/plasma/PlasmaTypes.py
+++ b/Python/plasma/PlasmaTypes.py
@@ -196,7 +196,7 @@ def PtAddEvent(notify,event):
     elif event[0] == kResponderStateEvent:
         notify.addResponderState(event[1])
     else:
-        print("Unrecognized event type %d" % (event[0]))
+        PtDebugPrint("Unrecognized event type %d" % (event[0]))
         
 # add a list of events into a ptNotify message
 def PtAddEvents(notify, events):

--- a/Python/plasma/PlasmaTypes.py
+++ b/Python/plasma/PlasmaTypes.py
@@ -196,7 +196,7 @@ def PtAddEvent(notify,event):
     elif event[0] == kResponderStateEvent:
         notify.addResponderState(event[1])
     else:
-        print "Unrecognized event type %d" % (event[0])
+        print("Unrecognized event type %d" % (event[0]))
         
 # add a list of events into a ptNotify message
 def PtAddEvents(notify, events):
@@ -489,16 +489,16 @@ class ptAttribResponder(ptAttributeKeyList):
                 nt.netForce(1)
             # see if the state is specified
             if isinstance(state, int):
-                raise ptResponderStateError,"Specifying state as a number is no longer supported"
+                raise ptResponderStateError("Specifying state as a number is no longer supported")
             elif isinstance(state, str):
                 if self.state_list is not None:
                     try:
                         idx = self.state_list.index(state)
                         nt.addResponderState(idx)
                     except ValueError:
-                        raise ptResponderStateError, "There is no state called '%s'"%(state)
+                        raise ptResponderStateError("There is no state called '%s'"%(state))
                 else:
-                    raise ptResponderStateError,"There is no state list provided"
+                    raise ptResponderStateError("There is no state list provided")
             # see if there are events to pass on
             if events is not None:
                 PtAddEvents(nt,events)
@@ -532,16 +532,16 @@ class ptAttribResponder(ptAttributeKeyList):
                 nt.netForce(1)
             # see if the state is specified
             if isinstance(state, int):
-                raise ptResponderStateError,"Specifying state as a number is no longer supported"
+                raise ptResponderStateError("Specifying state as a number is no longer supported")
             elif isinstance(state, str):
                 if self.state_list is not None:
                     try:
                         idx = self.state_list.index(state)
                         nt.addResponderState(idx)
                     except ValueError:
-                        raise ptResponderStateError, "There is no state called '%s'"%(state)
+                        raise ptResponderStateError("There is no state called '%s'"%(state))
                 else:
-                    raise ptResponderStateError,"There is no state list provided"
+                    raise ptResponderStateError("There is no state list provided")
             # see if there are events to pass on
             nt.setType(PtNotificationType.kResponderChangeState)
             nt.setActivate(1.0)

--- a/Python/plasma/glue.py
+++ b/Python/plasma/glue.py
@@ -61,13 +61,13 @@ def glue_getClass():
                 glue_cl = cl
             else:
                 if glue_verbose:
-                    print("Class %s is not derived from modifier" % (cl.__name__))
+                    PtDebugPrint("Class %s is not derived from modifier" % (cl.__name__))
         except:
             if glue_verbose:
                 try:
-                    print("Could not find class %s" % (glue_name))
+                    PtDebugPrint("Could not find class %s" % (glue_name))
                 except NameError:
-                    print("Filename/classname not set!")
+                    PtDebugPrint("Filename/classname not set!")
     return glue_cl
 def glue_getInst():
     global glue_inst
@@ -96,8 +96,8 @@ def glue_findAndAddAttribs(obj, glue_params):
     if isinstance(obj,ptAttribute):
         if obj.id in glue_params:
             if glue_verbose:
-                print("WARNING: Duplicate attribute ids!")
-                print("%s has id %d which is already defined in %s" % (obj.name, obj.id, glue_params[obj.id].name))
+                PtDebugPrint("WARNING: Duplicate attribute ids!")
+                PtDebugPrint("%s has id %d which is already defined in %s" % (obj.name, obj.id, glue_params[obj.id].name))
         else:
             glue_params[obj.id] = obj
     elif isinstance(obj, list):
@@ -128,21 +128,21 @@ def glue_getClassName():
     if cl != None:
         return cl.__name__
     if glue_verbose:
-        print("Class not found in %s.py" % (glue_name))
+        PtDebugPrint("Class not found in %s.py" % (glue_name))
     return None
 def glue_getBlockID():
     inst = glue_getInst()
     if inst != None:
         return inst.id
     if glue_verbose:
-        print("Instance could not be created in %s.py" % (glue_name))
+        PtDebugPrint("Instance could not be created in %s.py" % (glue_name))
     return None
 def glue_getNumParams():
     pd = glue_getParamDict()
     if pd != None:
         return len(pd)
     if glue_verbose:
-        print("No attributes found in %s.py" % (glue_name))
+        PtDebugPrint("No attributes found in %s.py" % (glue_name))
     return 0
 def glue_getParam(number):
     global glue_paramKeys
@@ -153,16 +153,16 @@ def glue_getParam(number):
             if number >= 0 and number < len(glue_paramKeys):
                 return pd[glue_paramKeys[number]].getdef()
             else:
-                print("glue_getParam: Error! %d out of range of attribute list" % (number))
+                PtDebugPrint("glue_getParam: Error! %d out of range of attribute list" % (number))
         else:
             pl = pd.values()
             if number >= 0 and number < len(pl):
                 return pl[number].getdef()
             else:
                 if glue_verbose:
-                    print("glue_getParam: Error! %d out of range of attribute list" % (number))
+                    PtDebugPrint("glue_getParam: Error! %d out of range of attribute list" % (number))
     if glue_verbose:
-        print("GLUE: Attribute list error")
+        PtDebugPrint("GLUE: Attribute list error")
     return None
 def glue_setParam(id,value):
     pd = glue_getParamDict()
@@ -183,9 +183,9 @@ def glue_setParam(id,value):
                     pd[id].value = value
         else:
             if glue_verbose:
-                print("setParam: can't find id=",id)
+                PtDebugPrint("setParam: can't find id=",id)
     else:
-        print("setParma: Something terribly has gone wrong. Head for the cover.")
+        PtDebugPrint("setParma: Something terribly has gone wrong. Head for the cover.")
 def glue_isNamedAttribute(id):
     pd = glue_getParamDict()
     if pd != None:
@@ -196,7 +196,7 @@ def glue_isNamedAttribute(id):
                 return 2
         except KeyError:
             if glue_verbose:
-                print("Could not find id=%d attribute" % (id))
+                PtDebugPrint("Could not find id=%d attribute" % (id))
     return 0
 def glue_isMultiModifier():
     inst = glue_getInst()
@@ -212,14 +212,14 @@ def glue_getVisInfo(number):
             if number >= 0 and number < len(glue_paramKeys):
                 return pd[glue_paramKeys[number]].getVisInfo()
             else:
-                print("glue_getVisInfo: Error! %d out of range of attribute list" % (number))
+                PtDebugPrint("glue_getVisInfo: Error! %d out of range of attribute list" % (number))
         else:
             pl = pd.values()
             if number >= 0 and number < len(pl):
                 return pl[number].getVisInfo()
             else:
                 if glue_verbose:
-                    print("glue_getVisInfo: Error! %d out of range of attribute list" % (number))
+                    PtDebugPrint("glue_getVisInfo: Error! %d out of range of attribute list" % (number))
     if glue_verbose:
-        print("GLUE: Attribute list error")
+        PtDebugPrint("GLUE: Attribute list error")
     return None

--- a/Python/plasma/glue.py
+++ b/Python/plasma/glue.py
@@ -61,13 +61,13 @@ def glue_getClass():
                 glue_cl = cl
             else:
                 if glue_verbose:
-                    print "Class %s is not derived from modifier" % (cl.__name__)
+                    print("Class %s is not derived from modifier" % (cl.__name__))
         except:
             if glue_verbose:
                 try:
-                    print "Could not find class %s" % (glue_name)
+                    print("Could not find class %s" % (glue_name))
                 except NameError:
-                    print "Filename/classname not set!"
+                    print("Filename/classname not set!")
     return glue_cl
 def glue_getInst():
     global glue_inst
@@ -94,10 +94,10 @@ def glue_getVersion():
     return ver
 def glue_findAndAddAttribs(obj, glue_params):
     if isinstance(obj,ptAttribute):
-        if glue_params.has_key(obj.id):
+        if obj.id in glue_params:
             if glue_verbose:
-                print "WARNING: Duplicate attribute ids!"
-                print "%s has id %d which is already defined in %s" % (obj.name, obj.id, glue_params[obj.id].name)
+                print("WARNING: Duplicate attribute ids!")
+                print("%s has id %d which is already defined in %s" % (obj.name, obj.id, glue_params[obj.id].name))
         else:
             glue_params[obj.id] = obj
     elif isinstance(obj, list):
@@ -128,21 +128,21 @@ def glue_getClassName():
     if cl != None:
         return cl.__name__
     if glue_verbose:
-        print "Class not found in %s.py" % (glue_name)
+        print("Class not found in %s.py" % (glue_name))
     return None
 def glue_getBlockID():
     inst = glue_getInst()
     if inst != None:
         return inst.id
     if glue_verbose:
-        print "Instance could not be created in %s.py" % (glue_name)
+        print("Instance could not be created in %s.py" % (glue_name))
     return None
 def glue_getNumParams():
     pd = glue_getParamDict()
     if pd != None:
         return len(pd)
     if glue_verbose:
-        print "No attributes found in %s.py" % (glue_name)
+        print("No attributes found in %s.py" % (glue_name))
     return 0
 def glue_getParam(number):
     global glue_paramKeys
@@ -153,21 +153,21 @@ def glue_getParam(number):
             if number >= 0 and number < len(glue_paramKeys):
                 return pd[glue_paramKeys[number]].getdef()
             else:
-                print "glue_getParam: Error! %d out of range of attribute list" % (number)
+                print("glue_getParam: Error! %d out of range of attribute list" % (number))
         else:
             pl = pd.values()
             if number >= 0 and number < len(pl):
                 return pl[number].getdef()
             else:
                 if glue_verbose:
-                    print "glue_getParam: Error! %d out of range of attribute list" % (number)
+                    print("glue_getParam: Error! %d out of range of attribute list" % (number))
     if glue_verbose:
-        print "GLUE: Attribute list error"
+        print("GLUE: Attribute list error")
     return None
 def glue_setParam(id,value):
     pd = glue_getParamDict()
     if pd != None:
-        if pd.has_key(id):
+        if id in pd:
             # first try to set the attribute via function call (if there is one)
             try:
                 pd[id].__setvalue__(value)
@@ -183,9 +183,9 @@ def glue_setParam(id,value):
                     pd[id].value = value
         else:
             if glue_verbose:
-                print "setParam: can't find id=",id
+                print("setParam: can't find id=",id)
     else:
-        print "setParma: Something terribly has gone wrong. Head for the cover."
+        print("setParma: Something terribly has gone wrong. Head for the cover.")
 def glue_isNamedAttribute(id):
     pd = glue_getParamDict()
     if pd != None:
@@ -196,7 +196,7 @@ def glue_isNamedAttribute(id):
                 return 2
         except KeyError:
             if glue_verbose:
-                print "Could not find id=%d attribute" % (id)
+                print("Could not find id=%d attribute" % (id))
     return 0
 def glue_isMultiModifier():
     inst = glue_getInst()
@@ -212,14 +212,14 @@ def glue_getVisInfo(number):
             if number >= 0 and number < len(glue_paramKeys):
                 return pd[glue_paramKeys[number]].getVisInfo()
             else:
-                print "glue_getVisInfo: Error! %d out of range of attribute list" % (number)
+                print("glue_getVisInfo: Error! %d out of range of attribute list" % (number))
         else:
             pl = pd.values()
             if number >= 0 and number < len(pl):
                 return pl[number].getVisInfo()
             else:
                 if glue_verbose:
-                    print "glue_getVisInfo: Error! %d out of range of attribute list" % (number)
+                    print("glue_getVisInfo: Error! %d out of range of attribute list" % (number))
     if glue_verbose:
-        print "GLUE: Attribute list error"
+        print("GLUE: Attribute list error")
     return None

--- a/Python/plasma/pch.py
+++ b/Python/plasma/pch.py
@@ -56,55 +56,55 @@ __selattr = 0
 # help!
 def help():
     "display help"
-    print "functions:"
-    print "  getmods()  - gets all the modules available"
-    print "  showmods() - show the modules (and the current selected module)"
-    print "  selmod(i)  - selects module 'i'; returns module object"
-    print "  showmod()  - shows detail of the module selected"
-    print "  showdoc()  - shows the doc field of the module selected"
-    print "  showattribs() - shows all the plasma attributes of the module selected"
-    print "  selattrib(id) - selects attribute 'id' in the selected module;"
-    print "                  returns attribute object"
-    print "  setattrib(value) - sets the selected attribute to 'value'"
-    print "  showglobals() - shows the globals for the selected module"
-    print "  setglobal(name,value) - set global 'name' to 'value' in selected module"
-    print "  getglobal(name)  - returns global object"
-    print "  showinst()  - shows the instance of the ptModifier class for the selected"
-    print "                module"
-    print "  getinst()   - returns the instance object"
-    print "  showvars(inst)  - shows the instance variables of the ptModifier class of"
-    print "                    the selected module"
-    print "  showmethods(inst) - shows the methods of the ptModifier class of the"
-    print "                      selected module"
-    print "  showfunc(method)  - decompiles a method or function and shows source"
-    print "  setvar(name,value) - sets instance variable 'name' to 'value' in the"
-    print "                       selected module"
-    print "  getvar(name) - returns the instance variable object (in selected module)"
+    print("functions:")
+    print("  getmods()  - gets all the modules available")
+    print("  showmods() - show the modules (and the current selected module)")
+    print("  selmod(i)  - selects module 'i'; returns module object")
+    print("  showmod()  - shows detail of the module selected")
+    print("  showdoc()  - shows the doc field of the module selected")
+    print("  showattribs() - shows all the plasma attributes of the module selected")
+    print("  selattrib(id) - selects attribute 'id' in the selected module;")
+    print("                  returns attribute object")
+    print("  setattrib(value) - sets the selected attribute to 'value'")
+    print("  showglobals() - shows the globals for the selected module")
+    print("  setglobal(name,value) - set global 'name' to 'value' in selected module")
+    print("  getglobal(name)  - returns global object")
+    print("  showinst()  - shows the instance of the ptModifier class for the selected")
+    print("                module")
+    print("  getinst()   - returns the instance object")
+    print("  showvars(inst)  - shows the instance variables of the ptModifier class of")
+    print("                    the selected module")
+    print("  showmethods(inst) - shows the methods of the ptModifier class of the")
+    print("                      selected module")
+    print("  showfunc(method)  - decompiles a method or function and shows source")
+    print("  setvar(name,value) - sets instance variable 'name' to 'value' in the")
+    print("                       selected module")
+    print("  getvar(name) - returns the instance variable object (in selected module)")
 # modules
 def getmods():
     "get all the PythonFileComponent modules"
     global __pmods,__sel
     __pmods = []  # wipe the module list clean
-    print "Plasma modules:"
+    print("Plasma modules:")
     for modname in sys.modules.viewkeys():
         mod = sys.modules[modname]
         if hasattr(mod,"glue_inst"):
             if __sel == len(__pmods):
-                print "*%d. %s" % (len(__pmods),modname[:-13])
+                print("*%d. %s" % (len(__pmods),modname[:-13]))
             else:
-                print " %d. %s" % (len(__pmods),modname[:-13])
+                print(" %d. %s" % (len(__pmods),modname[:-13]))
             __pmods.append([modname,mod])
 def showmods():
     "show all the PythonFileComponent modules"
     global __pmods
     global __sel
     idx = 0
-    print "Plasma modules:"
+    print("Plasma modules:")
     for mod in __pmods:
         if idx == __sel:
-            print "*%d. %s" % (idx,mod[0][:-13])
+            print("*%d. %s" % (idx,mod[0][:-13]))
         else:
-            print " %d. %s" % (idx,mod[0][:-13])
+            print(" %d. %s" % (idx,mod[0][:-13]))
         idx += 1
 def selmod(idx=None):
     "select a module from the list"
@@ -121,21 +121,21 @@ def selmod(idx=None):
             i += 1
         # if we didn't find the module
         if i == len(__pmods):
-            print "Module %s not found" % idx
+            print("Module %s not found" % idx)
             return
         idx = i
     if idx < len(__pmods):
         __sel = idx
-        print "%s selected" % (__pmods[idx][0][:-13])
+        print("%s selected" % (__pmods[idx][0][:-13]))
         return __pmods[__sel][1]
     else:
-        print "Error: index not valid. There are %d modules" % (len(__pmods))
+        print("Error: index not valid. There are %d modules" % (len(__pmods)))
 # find attributes
 def showmod():
     "show details of the selected module"
     global __pmods
     global __sel
-    print "Module: %s" % (__pmods[__sel][0][:-13])
+    print("Module: %s" % (__pmods[__sel][0][:-13]))
     showdoc()
     showattribs()
     showglobals()
@@ -144,21 +144,21 @@ def showdoc():
     "show the doc of the module selected"
     global __pmods
     global __sel
-    print "Doc:"
-    print __pmods[__sel][1].__doc__
+    print("Doc:")
+    print(__pmods[__sel][1].__doc__)
 def showattribs():
     "show the plasma attributes of the module selected"
     global __pmods
     global __sel
     global __selattr
-    print "Attributes in %s:" % (__pmods[__sel][0][:-13])
+    print("Attributes in %s:" % (__pmods[__sel][0][:-13]))
     for name in __pmods[__sel][1].__dict__.viewkeys():
         ist = __pmods[__sel][1].__dict__[name]
         if isinstance(ist,PlasmaTypes.ptAttribute):
             if __selattr == ist.id:
-                print "*(%d) %s(%s) =" % (ist.id,name,ist.__class__.__name__),ist.value
+                print("*(%d) %s(%s) =" % (ist.id,name,ist.__class__.__name__),ist.value)
             else:
-                print " (%d) %s(%s) =" % (ist.id,name,ist.__class__.__name__),ist.value
+                print(" (%d) %s(%s) =" % (ist.id,name,ist.__class__.__name__),ist.value)
 def selattrib(id=None):
     "select a plasma attribute by id in the selected module"
     global __pmods
@@ -171,9 +171,9 @@ def selattrib(id=None):
         if isinstance(ist,PlasmaTypes.ptAttribute):
             if id == ist.id:
                 __selattr = ist.id
-                print "%s(%s) =" % (name,ist.__class__.__name__),ist.value
+                print("%s(%s) =" % (name,ist.__class__.__name__),ist.value)
                 return ist
-    print "Error: Attribute ID %d not found" % (id)
+    print("Error: Attribute ID %d not found" % (id))
 def setattrib(value):
     "set the value of the selected plasma attribute in the selected module"
     global __pmods
@@ -190,15 +190,15 @@ def setattrib(value):
                     except AttributeError:
                         ist.value = value
                 else:
-                    print "Error: value is not same type as attribute"
+                    print("Error: value is not same type as attribute")
                 return
-    print "Error: Attribute ID %d not found" % (id)
+    print("Error: Attribute ID %d not found" % (id))
 # find globals
 def showglobals():
     "show the global variables of the selected module"
     global __pmods
     global __sel
-    print "Globals:"
+    print("Globals:")
     for name in __pmods[__sel][1].__dict__.viewkeys():
         ist = __pmods[__sel][1].__dict__[name]
         # make sure that its not something we already know about
@@ -206,16 +206,16 @@ def showglobals():
             if not isinstance(ist,PlasmaTypes.ptAttribute) and not isinstance(ist,PlasmaTypes.ptModifier):
                 if name[:2] != '__' and name[:4] != 'glue':
                     if not isinstance(ist, type(sys)) and not isinstance(ist, type(PlasmaTypes.ptAttribute)):
-                        print "  %s =" % (name),ist
+                        print("  %s =" % (name),ist)
 def setglobal(name,value):
     "set a global variable to a value with in the selected module"
     global __pmods
     global __sel
     # first see if there is already a glabal by that name
-    if not __pmods[__sel][1].__dict__.has_key(name):
-        print "Warning: creating new global!"
+    if name not in __pmods[__sel][1].__dict__:
+        print("Warning: creating new global!")
     __pmods[__sel][1].__dict__[name] = value
-    print "%s = " % (name),__pmods[__sel][1].__dict__[name]
+    print("%s = " % (name),__pmods[__sel][1].__dict__[name])
 def getglobal(name):
     "get a global variable with in the selected module"
     global __pmods
@@ -229,8 +229,8 @@ def showinst():
     for name in __pmods[__sel][1].__dict__.viewkeys():
         ist = __pmods[__sel][1].__dict__[name]
         if isinstance(ist,PlasmaTypes.ptModifier):
-            print "Instance of %s in module %s:" % (ist.__class__.__name__,__pmods[__sel][1].__name__[:-13])
-            print "  Doc: ",ist.__doc__
+            print("Instance of %s in module %s:" % (ist.__class__.__name__,__pmods[__sel][1].__name__[:-13]))
+            print("  Doc: ",ist.__doc__)
             showvars(ist)
             showmethods(ist)
 def getinst():
@@ -243,28 +243,28 @@ def getinst():
             return ist
 def showvars(instance):
     "shows the variables of the instance"
-    print "  Variables:"
+    print("  Variables:")
     if len(instance.__dict__) > 0:
         for vname in instance.__dict__.viewkeys():
-            print "    %s =" % (vname),instance.__dict__[vname]
+            print("    %s =" % (vname),instance.__dict__[vname])
     else:
-        print "    (none)"
+        print("    (none)")
 def showmethods(instance):
     "shows the methods of the instance"
-    print "  Methods:"
+    print("  Methods:")
     for mname in instance.__class__.__dict__.viewkeys():
         mist = instance.__class__.__dict__[mname]
         # is it a function... see if it has code
         if hasattr(mist,'func_code'):
             # gather arguments
             args = "("
-            for i in range(mist.func_code.co_argcount):
-                args += mist.func_code.co_varnames[i]
-                if i+1 < mist.func_code.co_argcount:
+            for i in range(mist.__code__.co_argcount):
+                args += mist.__code__.co_varnames[i]
+                if i+1 < mist.__code__.co_argcount:
                     args += ","
             args += ")"
-            print "    %s%s" % (mist.__name__,args)
-            print "      Doc:", mist.__doc__
+            print("    %s%s" % (mist.__name__,args))
+            print("      Doc:", mist.__doc__)
 def showfunc(f):
     "decompiles function"
     import decompyle
@@ -272,15 +272,15 @@ def showfunc(f):
         # create the argument list
         argstr = "("
         argcount = 0
-        for arg in f.func_code.co_varnames[:f.func_code.co_argcount]:
+        for arg in f.__code__.co_varnames[:f.__code__.co_argcount]:
             argstr += arg
             argcount += 1
-            if argcount < f.func_code.co_argcount:
+            if argcount < f.__code__.co_argcount:
                 argstr += ","
         argstr += ")"
-        print "%s%s" % (f.func_name,argstr)
-        print "    Doc:",f.__doc__
-        decompyle.decompyle(f.func_code)
+        print("%s%s" % (f.__name__,argstr))
+        print("    Doc:",f.__doc__)
+        decompyle.decompyle(f.__code__)
 def setvar(vname,value):
     "set a variable within the instance of the ptModifier class in the selected module"
     global __pmods
@@ -289,10 +289,10 @@ def setvar(vname,value):
         ist = __pmods[__sel][1].__dict__[name]
         if isinstance(ist,PlasmaTypes.ptModifier):
             # first see if there is already a glabal by that name
-            if not ist.__dict__.has_key(vname):
-                print "Warning: creating new class variable!"
+            if vname not in ist.__dict__:
+                print("Warning: creating new class variable!")
             ist.__dict__[vname] = value
-            print "%s = " % (vname),ist.__dict__[vname]
+            print("%s = " % (vname),ist.__dict__[vname])
 def getvar(vname):
     "get the variable in the instance of the ptModifier class in the selected module"
     global __pmods

--- a/Python/psnlBahroPoles.py
+++ b/Python/psnlBahroPoles.py
@@ -230,9 +230,9 @@ class psnlBahroPoles(ptModifier):
 
         try:
             boolCleftSolved = ageSDL["psnlCleftSolved"][0]
-            print "psnlBahroPoles.OnServerInitComplete(): boolCleftSolved = ",boolCleftSolved
+            print("psnlBahroPoles.OnServerInitComplete(): boolCleftSolved = ",boolCleftSolved)
         except:
-            print "ERROR: psnlBahroPoles.OnServerInitComplete():\tNo SDL for boolCleftSolved, using 0"
+            print("ERROR: psnlBahroPoles.OnServerInitComplete():\tNo SDL for boolCleftSolved, using 0")
 
         if not boolCleftSolved:
             vault = ptVault()
@@ -246,9 +246,9 @@ class psnlBahroPoles(ptModifier):
         if boolCleftTotem:
             if boolCleftSolved:
                 ageSDL[sdlCleftTotem.value] = (0,)
-                print "psnlBahroPoles.OnServerInitComplete(): Cleft totem was open but Cleft is solved, setting SDL to closed"
+                print("psnlBahroPoles.OnServerInitComplete(): Cleft totem was open but Cleft is solved, setting SDL to closed")
             else:
-                print "psnlBahroPoles.OnServerInitComplete(): Cleft not solved yet, will open the Cleft totem"
+                print("psnlBahroPoles.OnServerInitComplete(): Cleft not solved yet, will open the Cleft totem")
                 respChangeCleftTotem.run(self.key,state="open",fastforward=1)
         else:
             respChangeCleftTotem.run(self.key,state="close",fastforward=1)
@@ -287,7 +287,7 @@ class psnlBahroPoles(ptModifier):
             PtDebugPrint("no BahroCave solution found, attempting to create")
             self.CreateBahroCaveSolution()
         else:
-            print "found BahroCave solution: ",self.GetBahroCaveSolution()
+            print("found BahroCave solution: ",self.GetBahroCaveSolution())
         
         interestingVarList = [("TeledahnPoleState", BahroPoles.Teledahn), ("KadishPoleState", BahroPoles.Kadish), ("GardenPoleState", BahroPoles.Garden), ("GarrisonPoleState", BahroPoles.Garrison)]
         #ageSDL = PtGetAgeSDL()
@@ -333,7 +333,7 @@ class psnlBahroPoles(ptModifier):
             if sdlVal == 9:
                 state9 += 1
                 if state9 == 4:
-                    print "scream started on init"
+                    print("scream started on init")
                     respBahroScream.run(self.key, state = "start")
                     self.screamStarted = 1
 
@@ -404,7 +404,7 @@ class psnlBahroPoles(ptModifier):
             link.setAgeInfo(info)
 
             ptVault().registerOwnedAge(link)
-            print "Registered pellet bahro cave"
+            print("Registered pellet bahro cave")
         
         self.CheckPelletCaveSolution()
 
@@ -422,11 +422,11 @@ class psnlBahroPoles(ptModifier):
             ageSDL = PtGetAgeSDL()
             boolCleftTotem = ageSDL[sdlCleftTotem.value][0]
             if boolCleftTotem:
-                print "psnlBahroPoles.OnSDLNotify(): now opening Cleft totem..."
+                print("psnlBahroPoles.OnSDLNotify(): now opening Cleft totem...")
                 respChangeCleftTotem.run(self.key,state="open")
                 #PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
             else:
-                print "psnlBahroPoles.OnSDLNotify(): now closing Cleft totem..."
+                print("psnlBahroPoles.OnSDLNotify(): now closing Cleft totem...")
                 if HidingPoles:
                     respChangeCleftTotem.run(self.key,state="close")
                 else:
@@ -467,7 +467,7 @@ class psnlBahroPoles(ptModifier):
                         self.screamStarted = 0
                 elif sdlVal == 9 and not self.screamStarted:
                     if self.Poles["Teledahn"]["State"] == 9 and self.Poles["Garrison"]["State"] == 9 and self.Poles["Garden"]["State"] == 9 and self.Poles["Kadish"]["State"] == 9:
-                        print "Starting bahro scream responder"
+                        print("Starting bahro scream responder")
                         respBahroScream.run(self.key, state = "start")
                         self.screamStarted = 1
 
@@ -520,13 +520,13 @@ class psnlBahroPoles(ptModifier):
                     progress = self.GetJCProgress("Cleft")
                     if progress > 0 and progress < 8:
                         respCleftHandGlow.run(self.key, state=str(progress) )
-                        print "psnlBahroPoles.OnNotify(): touch responder done, have %s JCs and will play correct hand glow" % (str(progress))
+                        print("psnlBahroPoles.OnNotify(): touch responder done, have %s JCs and will play correct hand glow" % (str(progress)))
                         PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
                     elif progress == 0:
-                        print "psnlBahroPoles.OnNotify(): touch responder done, but have no JCs so no glow"
+                        print("psnlBahroPoles.OnNotify(): touch responder done, but have no JCs so no glow")
                         PtAtTimeCallback(self.key,1,kTimerCleftTotemClk)
                 else:
-                    print "psnlBahroPoles.OnNotify(): touch responder done, will now open Cleft totem"
+                    print("psnlBahroPoles.OnNotify(): touch responder done, will now open Cleft totem")
                     respCleftHandGlow.run(self.key, state="7")
                     PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
                     ageSDL = PtGetAgeSDL()
@@ -534,7 +534,7 @@ class psnlBahroPoles(ptModifier):
             else:
                 respCleftHandGlow.run(self.key, state="7")
                 PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
-                print "psnlBahroPoles.OnNotify(): touch responder done, and Cleft is done, so play entire hand glow"
+                print("psnlBahroPoles.OnNotify(): touch responder done, and Cleft is done, so play entire hand glow")
 
 
         elif id == clickTeledahnPole.id:
@@ -681,7 +681,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def UpdatePoleStates(self):
-        print "psnlBahroPoles.UpdatePoleStates()"
+        print("psnlBahroPoles.UpdatePoleStates()")
         try:
             #ageSDL = PtGetAgeSDL()
             ageSDL = xPsnlVaultSDL(1)
@@ -710,7 +710,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def SetCurrentState(self, age, state):
-        print "psnlBahroPoles.SetCurrentState()"
+        print("psnlBahroPoles.SetCurrentState()")
         #ageSDL = PtGetAgeSDL()
         ageSDL = xPsnlVaultSDL(1)
 
@@ -740,7 +740,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def PoleHandle(self, age):
-        print "psnlBahroPoles.PoleHandle()"
+        print("psnlBahroPoles.PoleHandle()")
         if age == "Gira":
             age = "Garden"
             
@@ -779,7 +779,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def ClickHandle(self, age, events):
-        print "psnlBahroPoles.ClickHandle()"
+        print("psnlBahroPoles.ClickHandle()")
         vault = ptAgeVault()
         
         avatar = PtFindAvatar(events)
@@ -795,7 +795,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def BookClickHandle(self, age):
-        print "psnlBahroPoles.BookClickHandle()"
+        print("psnlBahroPoles.BookClickHandle()")
         # this has been changed so that the state gets updated either when linking back into the personal age
         # or when linking into the bahro cave
         if PtWasLocallyNotified(self.key):
@@ -808,7 +808,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def PostOneShot(self, age):
-        print "psnlBahroPoles.PostOneShot()"
+        print("psnlBahroPoles.PostOneShot()")
         vault = ptVault()
         IamOwner = vault.amOwnerOfCurrentAge()
         
@@ -852,7 +852,7 @@ class psnlBahroPoles(ptModifier):
 
         for var in self.Poles.viewkeys():
             val = self.Poles[var]["State"]
-            print val
+            print(val)
 
             if val == 7:
                 state7 = state7 + 1
@@ -980,7 +980,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def ResetSheath(self, age, fforward = 1):
-        print "psnlBahroPoles.ResetSheath()"
+        print("psnlBahroPoles.ResetSheath()")
         if age == "Gira":
             age = "Garden"
 
@@ -992,7 +992,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def PostHandGlowResp(self, age):
-        print "psnlBahroPoles.PostHandGlowResp()"
+        print("psnlBahroPoles.PostHandGlowResp()")
         if age == "Gira":
             age = "Garden"
 
@@ -1012,7 +1012,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def OpenSheath(self, age, fforward = 1):
-        print "psnlBahroPoles.OpenSheath()"
+        print("psnlBahroPoles.OpenSheath()")
         if age == "Gira":
             age = "Garden"
 
@@ -1036,7 +1036,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def GetStateFrequencyList(self):
-        print "psnlBahroPoles.GetStateFrequencyList()"
+        print("psnlBahroPoles.GetStateFrequencyList()")
         statefreq = [0,0,0,0,0,0,0,0,0,0]
 
         for age in ["Teledahn", "Garrison", "Garden", "Kadish"]:
@@ -1047,7 +1047,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def ValidityCheck(self):
-        print "psnlBahroPoles.ValidityCheck()"
+        print("psnlBahroPoles.ValidityCheck()")
         self.UpdateToState2()
         freq = self.GetStateFrequencyList()
 
@@ -1093,7 +1093,7 @@ class psnlBahroPoles(ptModifier):
                 for spawnPoint in spawnPoints:
                     if spawnPoint.getName() == "LinkInPointDefault":
                         if self.Poles[ageName]["State"] < 2:
-                            print "psnlBahroPoles.UpdateToState2(): updating ",ageName," to state 2"
+                            print("psnlBahroPoles.UpdateToState2(): updating ",ageName," to state 2")
                             self.SetCurrentState(ageName, 2)
                             self.UpdatePoleStates()
                         break
@@ -1132,14 +1132,14 @@ class psnlBahroPoles(ptModifier):
             vault.addChronicleEntry("BahroCave",0,"0")
 
         agelist = ["Teledahn", "Garden", "Garrison", "Kadish"]
-        print "creating BahroCave solution in the chronicle..."
+        print("creating BahroCave solution in the chronicle...")
         for v in range(len(agelist)):
             newnode = ptVaultChronicleNode(0)
             newnode.chronicleSetName(agelist[v])
             newnode.chronicleSetValue("0," + str(bahroSolList[v]) + ",0")
             entry = vault.findChronicleEntry("BahroCave")
             entry.addNode(newnode)
-        print "new bahro cave solution = ",self.GetBahroCaveSolution()
+        print("new bahro cave solution = ",self.GetBahroCaveSolution())
 
 
     def AreListsEquiv(self, list1, list2):
@@ -1208,7 +1208,7 @@ class psnlBahroPoles(ptModifier):
                             pelletSolution = []
                             for sol in chronString:
                                 pelletSolution.append(string.atoi(sol))
-                            print "found pellet cave solution: ", chron.getValue()
+                            print("found pellet cave solution: ", chron.getValue())
                             break
                     break
 
@@ -1239,7 +1239,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def CreatePelletCaveSolution(self):
-        print "psnlBahroPoles.CreatePelletCaveSolution():  creating pellet cave solution..."
+        print("psnlBahroPoles.CreatePelletCaveSolution():  creating pellet cave solution...")
         bahroSolList = self.GetBahroCaveSolution()
         cleftSolList = [3,2,5,0]
         pelletSolList = [3,2,5,0]
@@ -1251,7 +1251,7 @@ class psnlBahroPoles(ptModifier):
                 if not newint in pelletSolList:
                     pelletSolList.append(newint)
 
-        print "pellet cave solution = ",pelletSolList
+        print("pellet cave solution = ",pelletSolList)
         return pelletSolList
 
 

--- a/Python/psnlBahroPoles.py
+++ b/Python/psnlBahroPoles.py
@@ -230,9 +230,9 @@ class psnlBahroPoles(ptModifier):
 
         try:
             boolCleftSolved = ageSDL["psnlCleftSolved"][0]
-            print("psnlBahroPoles.OnServerInitComplete(): boolCleftSolved = ",boolCleftSolved)
+            PtDebugPrint("psnlBahroPoles.OnServerInitComplete(): boolCleftSolved = ",boolCleftSolved)
         except:
-            print("ERROR: psnlBahroPoles.OnServerInitComplete():\tNo SDL for boolCleftSolved, using 0")
+            PtDebugPrint("ERROR: psnlBahroPoles.OnServerInitComplete():\tNo SDL for boolCleftSolved, using 0")
 
         if not boolCleftSolved:
             vault = ptVault()
@@ -246,9 +246,9 @@ class psnlBahroPoles(ptModifier):
         if boolCleftTotem:
             if boolCleftSolved:
                 ageSDL[sdlCleftTotem.value] = (0,)
-                print("psnlBahroPoles.OnServerInitComplete(): Cleft totem was open but Cleft is solved, setting SDL to closed")
+                PtDebugPrint("psnlBahroPoles.OnServerInitComplete(): Cleft totem was open but Cleft is solved, setting SDL to closed")
             else:
-                print("psnlBahroPoles.OnServerInitComplete(): Cleft not solved yet, will open the Cleft totem")
+                PtDebugPrint("psnlBahroPoles.OnServerInitComplete(): Cleft not solved yet, will open the Cleft totem")
                 respChangeCleftTotem.run(self.key,state="open",fastforward=1)
         else:
             respChangeCleftTotem.run(self.key,state="close",fastforward=1)
@@ -287,7 +287,7 @@ class psnlBahroPoles(ptModifier):
             PtDebugPrint("no BahroCave solution found, attempting to create")
             self.CreateBahroCaveSolution()
         else:
-            print("found BahroCave solution: ",self.GetBahroCaveSolution())
+            PtDebugPrint("found BahroCave solution: ",self.GetBahroCaveSolution())
         
         interestingVarList = [("TeledahnPoleState", BahroPoles.Teledahn), ("KadishPoleState", BahroPoles.Kadish), ("GardenPoleState", BahroPoles.Garden), ("GarrisonPoleState", BahroPoles.Garrison)]
         #ageSDL = PtGetAgeSDL()
@@ -333,7 +333,7 @@ class psnlBahroPoles(ptModifier):
             if sdlVal == 9:
                 state9 += 1
                 if state9 == 4:
-                    print("scream started on init")
+                    PtDebugPrint("scream started on init")
                     respBahroScream.run(self.key, state = "start")
                     self.screamStarted = 1
 
@@ -404,7 +404,7 @@ class psnlBahroPoles(ptModifier):
             link.setAgeInfo(info)
 
             ptVault().registerOwnedAge(link)
-            print("Registered pellet bahro cave")
+            PtDebugPrint("Registered pellet bahro cave")
         
         self.CheckPelletCaveSolution()
 
@@ -422,11 +422,11 @@ class psnlBahroPoles(ptModifier):
             ageSDL = PtGetAgeSDL()
             boolCleftTotem = ageSDL[sdlCleftTotem.value][0]
             if boolCleftTotem:
-                print("psnlBahroPoles.OnSDLNotify(): now opening Cleft totem...")
+                PtDebugPrint("psnlBahroPoles.OnSDLNotify(): now opening Cleft totem...")
                 respChangeCleftTotem.run(self.key,state="open")
                 #PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
             else:
-                print("psnlBahroPoles.OnSDLNotify(): now closing Cleft totem...")
+                PtDebugPrint("psnlBahroPoles.OnSDLNotify(): now closing Cleft totem...")
                 if HidingPoles:
                     respChangeCleftTotem.run(self.key,state="close")
                 else:
@@ -467,7 +467,7 @@ class psnlBahroPoles(ptModifier):
                         self.screamStarted = 0
                 elif sdlVal == 9 and not self.screamStarted:
                     if self.Poles["Teledahn"]["State"] == 9 and self.Poles["Garrison"]["State"] == 9 and self.Poles["Garden"]["State"] == 9 and self.Poles["Kadish"]["State"] == 9:
-                        print("Starting bahro scream responder")
+                        PtDebugPrint("Starting bahro scream responder")
                         respBahroScream.run(self.key, state = "start")
                         self.screamStarted = 1
 
@@ -520,13 +520,13 @@ class psnlBahroPoles(ptModifier):
                     progress = self.GetJCProgress("Cleft")
                     if progress > 0 and progress < 8:
                         respCleftHandGlow.run(self.key, state=str(progress) )
-                        print("psnlBahroPoles.OnNotify(): touch responder done, have %s JCs and will play correct hand glow" % (str(progress)))
+                        PtDebugPrint("psnlBahroPoles.OnNotify(): touch responder done, have %s JCs and will play correct hand glow" % (str(progress)))
                         PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
                     elif progress == 0:
-                        print("psnlBahroPoles.OnNotify(): touch responder done, but have no JCs so no glow")
+                        PtDebugPrint("psnlBahroPoles.OnNotify(): touch responder done, but have no JCs so no glow")
                         PtAtTimeCallback(self.key,1,kTimerCleftTotemClk)
                 else:
-                    print("psnlBahroPoles.OnNotify(): touch responder done, will now open Cleft totem")
+                    PtDebugPrint("psnlBahroPoles.OnNotify(): touch responder done, will now open Cleft totem")
                     respCleftHandGlow.run(self.key, state="7")
                     PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
                     ageSDL = PtGetAgeSDL()
@@ -534,7 +534,7 @@ class psnlBahroPoles(ptModifier):
             else:
                 respCleftHandGlow.run(self.key, state="7")
                 PtAtTimeCallback(self.key,10.7,kTimerCleftTotemClk)
-                print("psnlBahroPoles.OnNotify(): touch responder done, and Cleft is done, so play entire hand glow")
+                PtDebugPrint("psnlBahroPoles.OnNotify(): touch responder done, and Cleft is done, so play entire hand glow")
 
 
         elif id == clickTeledahnPole.id:
@@ -681,7 +681,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def UpdatePoleStates(self):
-        print("psnlBahroPoles.UpdatePoleStates()")
+        PtDebugPrint("psnlBahroPoles.UpdatePoleStates()")
         try:
             #ageSDL = PtGetAgeSDL()
             ageSDL = xPsnlVaultSDL(1)
@@ -710,7 +710,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def SetCurrentState(self, age, state):
-        print("psnlBahroPoles.SetCurrentState()")
+        PtDebugPrint("psnlBahroPoles.SetCurrentState()")
         #ageSDL = PtGetAgeSDL()
         ageSDL = xPsnlVaultSDL(1)
 
@@ -740,7 +740,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def PoleHandle(self, age):
-        print("psnlBahroPoles.PoleHandle()")
+        PtDebugPrint("psnlBahroPoles.PoleHandle()")
         if age == "Gira":
             age = "Garden"
             
@@ -779,7 +779,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def ClickHandle(self, age, events):
-        print("psnlBahroPoles.ClickHandle()")
+        PtDebugPrint("psnlBahroPoles.ClickHandle()")
         vault = ptAgeVault()
         
         avatar = PtFindAvatar(events)
@@ -795,7 +795,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def BookClickHandle(self, age):
-        print("psnlBahroPoles.BookClickHandle()")
+        PtDebugPrint("psnlBahroPoles.BookClickHandle()")
         # this has been changed so that the state gets updated either when linking back into the personal age
         # or when linking into the bahro cave
         if PtWasLocallyNotified(self.key):
@@ -808,7 +808,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def PostOneShot(self, age):
-        print("psnlBahroPoles.PostOneShot()")
+        PtDebugPrint("psnlBahroPoles.PostOneShot()")
         vault = ptVault()
         IamOwner = vault.amOwnerOfCurrentAge()
         
@@ -852,7 +852,7 @@ class psnlBahroPoles(ptModifier):
 
         for var in self.Poles.viewkeys():
             val = self.Poles[var]["State"]
-            print(val)
+            PtDebugPrint(val)
 
             if val == 7:
                 state7 = state7 + 1
@@ -980,7 +980,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def ResetSheath(self, age, fforward = 1):
-        print("psnlBahroPoles.ResetSheath()")
+        PtDebugPrint("psnlBahroPoles.ResetSheath()")
         if age == "Gira":
             age = "Garden"
 
@@ -992,7 +992,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def PostHandGlowResp(self, age):
-        print("psnlBahroPoles.PostHandGlowResp()")
+        PtDebugPrint("psnlBahroPoles.PostHandGlowResp()")
         if age == "Gira":
             age = "Garden"
 
@@ -1012,7 +1012,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def OpenSheath(self, age, fforward = 1):
-        print("psnlBahroPoles.OpenSheath()")
+        PtDebugPrint("psnlBahroPoles.OpenSheath()")
         if age == "Gira":
             age = "Garden"
 
@@ -1036,7 +1036,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def GetStateFrequencyList(self):
-        print("psnlBahroPoles.GetStateFrequencyList()")
+        PtDebugPrint("psnlBahroPoles.GetStateFrequencyList()")
         statefreq = [0,0,0,0,0,0,0,0,0,0]
 
         for age in ["Teledahn", "Garrison", "Garden", "Kadish"]:
@@ -1047,7 +1047,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def ValidityCheck(self):
-        print("psnlBahroPoles.ValidityCheck()")
+        PtDebugPrint("psnlBahroPoles.ValidityCheck()")
         self.UpdateToState2()
         freq = self.GetStateFrequencyList()
 
@@ -1093,7 +1093,7 @@ class psnlBahroPoles(ptModifier):
                 for spawnPoint in spawnPoints:
                     if spawnPoint.getName() == "LinkInPointDefault":
                         if self.Poles[ageName]["State"] < 2:
-                            print("psnlBahroPoles.UpdateToState2(): updating ",ageName," to state 2")
+                            PtDebugPrint("psnlBahroPoles.UpdateToState2(): updating ",ageName," to state 2")
                             self.SetCurrentState(ageName, 2)
                             self.UpdatePoleStates()
                         break
@@ -1132,14 +1132,14 @@ class psnlBahroPoles(ptModifier):
             vault.addChronicleEntry("BahroCave",0,"0")
 
         agelist = ["Teledahn", "Garden", "Garrison", "Kadish"]
-        print("creating BahroCave solution in the chronicle...")
+        PtDebugPrint("creating BahroCave solution in the chronicle...")
         for v in range(len(agelist)):
             newnode = ptVaultChronicleNode(0)
             newnode.chronicleSetName(agelist[v])
             newnode.chronicleSetValue("0," + str(bahroSolList[v]) + ",0")
             entry = vault.findChronicleEntry("BahroCave")
             entry.addNode(newnode)
-        print("new bahro cave solution = ",self.GetBahroCaveSolution())
+        PtDebugPrint("new bahro cave solution = ",self.GetBahroCaveSolution())
 
 
     def AreListsEquiv(self, list1, list2):
@@ -1208,7 +1208,7 @@ class psnlBahroPoles(ptModifier):
                             pelletSolution = []
                             for sol in chronString:
                                 pelletSolution.append(string.atoi(sol))
-                            print("found pellet cave solution: ", chron.getValue())
+                            PtDebugPrint("found pellet cave solution: ", chron.getValue())
                             break
                     break
 
@@ -1239,7 +1239,7 @@ class psnlBahroPoles(ptModifier):
 
 
     def CreatePelletCaveSolution(self):
-        print("psnlBahroPoles.CreatePelletCaveSolution():  creating pellet cave solution...")
+        PtDebugPrint("psnlBahroPoles.CreatePelletCaveSolution():  creating pellet cave solution...")
         bahroSolList = self.GetBahroCaveSolution()
         cleftSolList = [3,2,5,0]
         pelletSolList = [3,2,5,0]
@@ -1251,7 +1251,7 @@ class psnlBahroPoles(ptModifier):
                 if not newint in pelletSolList:
                     pelletSolList.append(newint)
 
-        print("pellet cave solution = ",pelletSolList)
+        PtDebugPrint("pellet cave solution = ",pelletSolList)
         return pelletSolList
 
 

--- a/Python/psnlBookshelf.py
+++ b/Python/psnlBookshelf.py
@@ -128,7 +128,7 @@ class psnlBookshelf(ptModifier):
 
         version = 10
         self.version = version
-        print("__init__psnlBookshelf v.", version)
+        PtDebugPrint("__init__psnlBookshelf v.", version)
 
 
     def OnFirstUpdate(self):
@@ -218,9 +218,9 @@ class psnlBookshelf(ptModifier):
             ShelfABoolOperated = ageSDL["ShelfABoolOperated"][0]
             if not solo and ShelfABoolOperated:
                 actBookshelf.disable()
-                print("psnlBookshelf.Load():\tShelfABoolOperated=%d, disabling shelf clickable" % ShelfABoolOperated)
+                PtDebugPrint("psnlBookshelf.Load():\tShelfABoolOperated=%d, disabling shelf clickable" % ShelfABoolOperated)
             else:
-                print("psnlBookshelf.Load():\tShelfABoolOperated=%d but no one else here...correcting" % ShelfABoolOperated)
+                PtDebugPrint("psnlBookshelf.Load():\tShelfABoolOperated=%d but no one else here...correcting" % ShelfABoolOperated)
                 self.IResetShelf()
 
         self.initComplete = 1
@@ -239,7 +239,7 @@ class psnlBookshelf(ptModifier):
             try:
                 ageSDL = PtGetAgeSDL()
                 if avID == ageSDL["ShelfAUserID"][0]:
-                    print("psnlBookshelf.AvatarPage(): Bookshelf A operator paged out, reenabled Bookshelf.")
+                    PtDebugPrint("psnlBookshelf.AvatarPage(): Bookshelf A operator paged out, reenabled Bookshelf.")
                     self.IResetShelf()            
                 else:
                     return
@@ -251,33 +251,33 @@ class psnlBookshelf(ptModifier):
     def OnAgeVaultEvent(self,event,tupdata):
         PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t:OnAgeKIEvent recvd. Event=%d and data= " % (event),tupdata)
         if event == PtVaultCallbackTypes.kVaultConnected:
-            print("psnlBookshelf: kVaultConnected event")
+            PtDebugPrint("psnlBookshelf: kVaultConnected event")
             # tupdata is ()
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeSaved:
-            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeSaved event (id=%d,type=%d)" % (tupdata[0].getID(),tupdata[0].getType()))
+            PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeSaved event (id=%d,type=%d)" % (tupdata[0].getID(),tupdata[0].getType()))
             # tupdata is ( ptVaultNode )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeRefAdded:
-            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefAdded event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
+            PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefAdded event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
             # tupdata is ( ptVaultNodeRef )
             if self.initComplete:
                 self.IUpdateLinks()
                 self.IUpdateLocksAndTrays()
         elif event == PtVaultCallbackTypes.kVaultRemovingNodeRef:
-            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultRemovingNodeRef event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
+            PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t: kVaultRemovingNodeRef event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
             # tupdata is ( ptVaultNodeRef )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeRefRemoved:
-            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefRemoved event (childID,parentID) ",tupdata) 
+            PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefRemoved event (childID,parentID) ",tupdata) 
             # tupdata is ( childID, parentID )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeInitialized:
-            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeInitialized event (id=%d,type=%d)", (tupdata[0].getID(),tupdata[0].getType()))
+            PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeInitialized event (id=%d,type=%d)", (tupdata[0].getID(),tupdata[0].getType()))
             # tupdata is ( ptVaultNode )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultOperationFailed:
-            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultOperationFailed event  (operation,resultCode) ",tupdata)
+            PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t: kVaultOperationFailed event  (operation,resultCode) ",tupdata)
             #tupdata is ( operation, resultCode )
             #~ pass
         else:
@@ -304,7 +304,7 @@ class psnlBookshelf(ptModifier):
         global boolShelfInUse
         global stupidHackForLock
         
-        #~ print "state:",state," id:",id," events:",events
+        #~ PtDebugPrint("state:",state," id:",id," events:",events)
 
         if id == actBookshelfExit.id:
             self.IDisengageShelf()
@@ -317,7 +317,7 @@ class psnlBookshelf(ptModifier):
                 if event[0] == kMultiStageEvent and event[1] == 0: # Smart seek completed. Exit multistage, and show GUI.
                     LocalAvatar = PtFindAvatar(events)
                     SeekBehavior.gotoStage(LocalAvatar, -1) 
-                    print("psnlBookshelf.OnNotify():\tengaging bookshelf")
+                    PtDebugPrint("psnlBookshelf.OnNotify():\tengaging bookshelf")
 
                     #PtFadeLocalAvatar(1)
                     LocalAvatar.draw.disable()
@@ -338,12 +338,12 @@ class psnlBookshelf(ptModifier):
 ##        if id == actDisengageShelf.id:
 ##            theavatar = PtFindAvatar(events)
 ##            AvatarWhoWalkedAway = PtGetClientIDFromAvatarKey(theavatar.getKey())
-##            #~ print "psnlBookshelf.OnNotify: Avatar %s walked away from the shelf." % (AvatarWhoWalkedAway)
+##            #~ PtDebugPrint("psnlBookshelf.OnNotify: Avatar %s walked away from the shelf." % (AvatarWhoWalkedAway))
 ##
 ##            if AgeStartedIn == PtGetAgeName():
 ##                ageSDL = PtGetAgeSDL()
 ##                CurrentBookshelfUser = ageSDL["ShelfAUserID"][0]
-##                #~ print "psnlBookshelf.OnNotify: Player %s was previously using the shelf." % (CurrentBookshelfUser)
+##                #~ PtDebugPrint("psnlBookshelf.OnNotify: Player %s was previously using the shelf." % (CurrentBookshelfUser))
 ##    
 ##                if AvatarWhoWalkedAway == CurrentBookshelfUser:
 ##                    PtDebugPrint ("psnlBookshelf.OnNotify: Player %s is done with the bookshelf." % (CurrentBookshelfUser))
@@ -352,10 +352,10 @@ class psnlBookshelf(ptModifier):
 ##                    avatar = PtGetLocalAvatar()   
 ##                    myID = PtGetClientIDFromAvatarKey(avatar.getKey())
 ##        
-##                    #~ print "I think my ID is: ", myID
+##                    #~ PtDebugPrint("I think my ID is: ", myID)
 ##        
 ##                    if myID == AvatarWhoWalkedAway:
-##                        print "I was the Shelf User, and I'm done with the Shelf now."
+##                        PtDebugPrint("I was the Shelf User, and I'm done with the Shelf now.")
 ##        
 ##                        PtFadeLocalAvatar(0)
 ##                        #reeneable first person
@@ -370,7 +370,7 @@ class psnlBookshelf(ptModifier):
             
             for event in events:
                 if event[0] == kVariableEvent:
-                    print("psnlBookshelf: Received a message from the Book GUI: ", event[1])
+                    PtDebugPrint("psnlBookshelf: Received a message from the Book GUI: ", event[1])
                     if event[1] == "IShelveBook" and objBookPicked is not None:
                         self.IShelveBook()
                         
@@ -398,7 +398,7 @@ class psnlBookshelf(ptModifier):
                             SpawnPointName = event[1].split(",")[1]
                             SpawnPointTitle = event[1].split(",")[2]
                             
-                            print("psnlBookshelf: SpawnPointName = ", SpawnPointName," SpawnPointTitle = ", SpawnPointTitle)
+                            PtDebugPrint("psnlBookshelf: SpawnPointName = ", SpawnPointName," SpawnPointTitle = ", SpawnPointTitle)
 
                             self.IResetShelf()
                             self.SendNote(0)
@@ -412,12 +412,12 @@ class psnlBookshelf(ptModifier):
  
         if id == (-1):
             if events[0][1] == 'BookShelfBusy':
-                print("psnlBookShelf: Notified about bookshelf use.")
+                PtDebugPrint("psnlBookShelf: Notified about bookshelf use.")
                 boolShelfInUse = events[0][3]
             else:
                 for event in events:
                     if event[0] == kVariableEvent:
-                        print(event[1], event[3])
+                        PtDebugPrint(event[1], event[3])
                         if event[1] == "YesNo" and event[3] == 1:
                             link = self.IGetLinkFromBook()
                             
@@ -460,7 +460,7 @@ class psnlBookshelf(ptModifier):
                                     info = link.getAgeInfo()
                                     if info and info.getAgeFilename() == "AhnonayCathedral":
                                         # found our link
-                                        print("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
+                                        PtDebugPrint("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
                                         link.setVolatile(True)
                                         link.save()
 
@@ -474,7 +474,7 @@ class psnlBookshelf(ptModifier):
                                                 BookNumber = linkLibrary.index(bookAge)
                                                 ageSDL = PtGetAgeSDL()                                    
                                                 ageSDL.setIndex("CurrentPage",BookNumber,1)
-                                                print("Setting CurrentPage var of book %s to 1" % BookNumber)
+                                                PtDebugPrint("Setting CurrentPage var of book %s to 1" % BookNumber)
                                                 break
                                 objBookPicked = None
                                 return
@@ -497,7 +497,7 @@ class psnlBookshelf(ptModifier):
                                         BookNumber = linkLibrary.index(bookAge)
                                         ageSDL = PtGetAgeSDL()                                    
                                         ageSDL.setIndex("CurrentPage",BookNumber,1)
-                                        print("Setting CurrentPage var of book %s to 1" % BookNumber)
+                                        PtDebugPrint("Setting CurrentPage var of book %s to 1" % BookNumber)
                                         break
                             objBookPicked = None
                             return
@@ -512,8 +512,8 @@ class psnlBookshelf(ptModifier):
         if id==actBookshelf.id:
             if PtFindAvatar(events) == PtGetLocalAvatar() and PtWasLocallyNotified(self.key) and not boolShelfInUse:
                 actBookshelf.disable() # want the Shelf clickable to be disabled for all clients
-                print("psnlBookshelf: disabling clickable")
-                print("psnlBookshelf: Firing clickable responder")
+                PtDebugPrint("psnlBookshelf: disabling clickable")
+                PtDebugPrint("psnlBookshelf: Firing clickable responder")
                 respRaiseShelfClickable.run(self.key,netPropagate=0)
                 self.SendNote(1)
                 self.IUpdateLinks()
@@ -536,7 +536,7 @@ class psnlBookshelf(ptModifier):
                                 avID = PtGetClientIDFromAvatarKey(LocalAvatar.getKey())
                                 ageSDL["ShelfAUserID"] = (avID,)
                                 ShelfAUserID = avID
-                                print("psnlBookshelf.OnNotify:\twrote SDL - Bookshelf A user id = ", avID)
+                                PtDebugPrint("psnlBookshelf.OnNotify:\twrote SDL - Bookshelf A user id = ", avID)
                                 PtDisableMovementKeys()
                             #self.IUpdateLinks()
                             #PtShowDialog(kPALDialogName)
@@ -568,11 +568,11 @@ class psnlBookshelf(ptModifier):
                 if event[0]==kPickedEvent:
                     objBookPicked = event[3]
                     bookName = objBookPicked.getName()
-                    print("psnlBookshelf.OnNotify():\tplayer picked book named ", bookName)
+                    PtDebugPrint("psnlBookshelf.OnNotify():\tplayer picked book named ", bookName)
                     try:
                         index = objLibrary.value.index(objBookPicked)
                     except:
-                        print("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objBookPicked, " in objLibrary")
+                        PtDebugPrint("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objBookPicked, " in objLibrary")
                         return
 
                     if self.IGetAgeFromBook() == "city" and PtIsSinglePlayerMode():
@@ -773,7 +773,7 @@ class psnlBookshelf(ptModifier):
 
                 if locked:
                     lockName = objLockPicked.getName()
-                    print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
+                    PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
                     for rkey,rvalue in respCloseLock.byObject.viewitems():
                         parent = rvalue.getParentKey()
                         if parent:
@@ -818,7 +818,7 @@ class psnlBookshelf(ptModifier):
                     try:
                         index = objLocks.value.index(objLockPicked)
                     except:
-                        print("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objLockPicked, " in objLocks")
+                        PtDebugPrint("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objLockPicked, " in objLocks")
                         return
                     objBookPicked = objLibrary.value[index]
                     lockName = objLockPicked.getName()
@@ -888,7 +888,7 @@ class psnlBookshelf(ptModifier):
                             if stupidHackForLock != None:
                                 locked = stupidHackForLock
 
-                        print(locked)
+                        PtDebugPrint(locked)
                         if locked:
                             # find the corresponding open clasp responder modifier
                             for rkey,rvalue in respOpenLock.byObject.viewitems():
@@ -902,7 +902,7 @@ class psnlBookshelf(ptModifier):
                                 chron = ageDataChild.upcastToChronicleNode()
                                 if chron and chron.getName() == "AhnonayLocked":
                                     if ( vault.inMyPersonalAge() ):
-                                        print("setting lock to 0")
+                                        PtDebugPrint("setting lock to 0")
                                         chron.setValue("0")
                         else:
                             # find the corresponding close clasp responder modifier
@@ -917,7 +917,7 @@ class psnlBookshelf(ptModifier):
                                 chron = ageDataChild.upcastToChronicleNode()
                                 if chron and chron.getName() == "AhnonayLocked":
                                     if ( vault.inMyPersonalAge() ):
-                                        print("setting lock to 1")
+                                        PtDebugPrint("setting lock to 1")
                                         chron.setValue("1")
 
                         if not vault.inMyPersonalAge():
@@ -997,7 +997,7 @@ class psnlBookshelf(ptModifier):
             try:
                 index = objTrays.value.index(objTrayPicked)
             except:
-                print("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objTrayPicked, " in objTrays")
+                PtDebugPrint("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objTrayPicked, " in objTrays")
                 return
 
             objBookPicked = objLibrary.value[index]
@@ -1055,7 +1055,7 @@ class psnlBookshelf(ptModifier):
                         info = link.getAgeInfo()
                         if info and info.getAgeFilename() == "AhnonayCathedral":
                             # found our link
-                            print("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
+                            PtDebugPrint("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
                             link.setVolatile(False)
                             link.save()
 
@@ -1133,7 +1133,7 @@ class psnlBookshelf(ptModifier):
 
         
         ageName = self.IGetAgeFromBook()
-        print("psnlBookshelf.IGetLinkFromBook(): before city lookup, ageName = ",ageName)
+        PtDebugPrint("psnlBookshelf.IGetLinkFromBook(): before city lookup, ageName = ",ageName)
 
         isCityLink = 0
         if ageName == "city":
@@ -1142,14 +1142,14 @@ class psnlBookshelf(ptModifier):
                 if spTitle in splist:
                     ageName = age
                     break
-        print("psnlBookshelf.IGetLinkFromBook(): after city lookup, ageName = ",ageName)        	        
+        PtDebugPrint("psnlBookshelf.IGetLinkFromBook(): after city lookup, ageName = ",ageName)        	        
 
         if ageName is None:
-            print("psnlBookshelf.IGetLinkFromBook():\tERROR -- conversion from book to link element failed")
+            PtDebugPrint("psnlBookshelf.IGetLinkFromBook():\tERROR -- conversion from book to link element failed")
             return None
 
         if ageName == "Ahnonay":
-            print("psnlBookshelf.IGetLinkFromBook(): Going to Ahnonay... special case.")
+            PtDebugPrint("psnlBookshelf.IGetLinkFromBook(): Going to Ahnonay... special case.")
             return "Ahnonay"
 
         hoodInfo = self.IGetHoodInfoNode()
@@ -1168,7 +1168,7 @@ class psnlBookshelf(ptModifier):
                         continue
                     else:
                         # found our link
-                        print("psnlBookshelf.IGetLinkFromBook():\tfound Child link ", info.getAgeFilename())
+                        PtDebugPrint("psnlBookshelf.IGetLinkFromBook():\tfound Child link ", info.getAgeFilename())
                         IsChildLink = 1
                         return link
 
@@ -1195,14 +1195,14 @@ class psnlBookshelf(ptModifier):
             info = link.getAgeInfo()
             if info and info.getAgeFilename() == ageName:
                 # found our link
-                print("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
+                PtDebugPrint("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
                 IsChildLink = 0
                 return link
 
-        print("psnlBookshelf.IGetLinkFromBook():\tERROR -- couldn't find link to", ageName)
-        print("info = ",info)
-        print("info.getAgeFilename() = ",info.getAgeFilename())
-        print("spTitle = ",spTitle)
+        PtDebugPrint("psnlBookshelf.IGetLinkFromBook():\tERROR -- couldn't find link to", ageName)
+        PtDebugPrint("info = ",info)
+        PtDebugPrint("info.getAgeFilename() = ",info.getAgeFilename())
+        PtDebugPrint("spTitle = ",spTitle)
         return None
     
     def SendNote(self, bool):
@@ -1237,14 +1237,14 @@ class psnlBookshelf(ptModifier):
 
             # show as locked if both are locked, or one is locked and the other doesn't exist
             if ( citylinklocked is None or citylinklocked) and ( bcolinklocked is None or bcolinklocked):
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to locked: ",lockName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to locked: ",lockName)
                 for rkey,rvalue in respCloseLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         if lockName == parent.getName():
                             respCloseLock.run(self.key,objectName=rkey,fastforward=1)
             else:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to unlocked: ",lockName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to unlocked: ",lockName)
                 for rkey,rvalue in respOpenLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1261,7 +1261,7 @@ class psnlBookshelf(ptModifier):
             try:
                 index = linkLibrary.index(ageName)    
             except:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to:", ageName, "...skipping to next")
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to:", ageName, "...skipping to next")
                 continue
 
             if ((ageName == "city" or ageName == "BaronCityOffice") and PtIsSinglePlayerMode()) or (ageName in CityBookAges.viewkeys()):
@@ -1279,14 +1279,14 @@ class psnlBookshelf(ptModifier):
             objLock = objLocks.value[index]
             lockName = objLock.getName()
             if link.getLocked():
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
                 for rkey,rvalue in respCloseLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         if lockName == parent.getName():
                             respCloseLock.run(self.key,objectName=rkey,fastforward=1)
             else:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName)
                 for rkey,rvalue in respOpenLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1297,16 +1297,16 @@ class psnlBookshelf(ptModifier):
             objBook = objLibrary.value[index]
             bookName = objBook.getName()
             if link.getVolatile():
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName)
                 for rkey,rvalue in respDeleteBook.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
-                        #~ print trayName,"==",rkey#[:len(trayName)]
+                        #~ PtDebugPrint(trayName,"==",rkey#[:len(trayName)])
                         if bookName == parent.getName():
                             respDeleteBook.run(self.key,objectName=rkey,fastforward=1)
-                            #~ print "got here"
+                            #~ PtDebugPrint("got here")
             else:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName)
                 for rkey,rvalue in respReturnTray.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1340,20 +1340,20 @@ class psnlBookshelf(ptModifier):
             try:
                 index = linkLibrary.index("Ahnonay")    
             except:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next")
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next")
                 return
 
             objLock = objLocks.value[index]
             lockName = objLock.getName()
             if int(locked):
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
                 for rkey,rvalue in respCloseLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         if lockName == parent.getName():
                             respCloseLock.run(self.key,objectName=rkey,fastforward=1)
             else:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName)
                 for rkey,rvalue in respOpenLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1364,16 +1364,16 @@ class psnlBookshelf(ptModifier):
             objBook = objLibrary.value[index]
             bookName = objBook.getName()
             if int(volatile):
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName)
                 for rkey,rvalue in respDeleteBook.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
-                        #~ print trayName,"==",rkey#[:len(trayName)]
+                        #~ PtDebugPrint(trayName,"==",rkey#[:len(trayName)])
                         if bookName == parent.getName():
                             respDeleteBook.run(self.key,objectName=rkey,fastforward=1)
-                            #~ print "got here"
+                            #~ PtDebugPrint("got here")
             else:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName)
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName)
                 for rkey,rvalue in respReturnTray.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1452,13 +1452,13 @@ class psnlBookshelf(ptModifier):
 #                    parentinfo = parent.getAgeInfo()
 #                    parentname = parentinfo.getAgeFilename()
 #                    if parentname == "Neighborhood":
-#                        print "psnlBookshelf.IUpdateLinks(): link found for public Garrison, ignoring..."
+#                        PtDebugPrint("psnlBookshelf.IUpdateLinks(): link found for public Garrison, ignoring...")
 #                        continue
                 
                 try:
                     index = linkLibrary.index(ageName)    
                 except:
-                    print("psnlBookshelf.IUpdateLinks():\tno matching book for KI's link to:", ageName, "...skipping to next")
+                    PtDebugPrint("psnlBookshelf.IUpdateLinks():\tno matching book for KI's link to:", ageName, "...skipping to next")
                     continue
     
                 if ageName == "Cleft":
@@ -1476,14 +1476,14 @@ class psnlBookshelf(ptModifier):
                     return
 
                 # find and enable the corresponding clickable modifier for the book
-                print("psnlBookshelf.IUpdateLinks():\tageName: ",ageName," boolInMyAge: ",boolInMyAge," getLocked(): ",link.getLocked()," getVolatile(): ",link.getVolatile())
+                PtDebugPrint("psnlBookshelf.IUpdateLinks():\tageName: ",ageName," boolInMyAge: ",boolInMyAge," getLocked(): ",link.getLocked()," getVolatile(): ",link.getVolatile())
                 if link.getVolatile() or ((not boolInMyAge) and (link.getLocked() or ageName == "Cleft")):
                     bookName = objBook.getName()
                     for key,value in actBook.byObject.viewitems():
                         parent = value.getParentKey()
                         if parent:
                             if bookName == parent.getName():
-                                print("%s book: DISABLED" % (bookName))
+                                PtDebugPrint("%s book: DISABLED" % (bookName))
                                 actBook.disable(objectName=key)
                                 break
                     if (not boolInMyAge) and (link.getLocked() or ageName == "Cleft"):
@@ -1496,7 +1496,7 @@ class psnlBookshelf(ptModifier):
                         parent = value.getParentKey()
                         if parent:
                             if bookName == parent.getName():
-                                print("%s book: ENABLED" % (bookName))
+                                PtDebugPrint("%s book: ENABLED" % (bookName))
                                 actBook.enable(objectName=key)
                                 break
     
@@ -1527,7 +1527,7 @@ class psnlBookshelf(ptModifier):
                                 break
                     
         else:
-            print("psnlBookshelf: The PAL folder is missing")
+            PtDebugPrint("psnlBookshelf: The PAL folder is missing")
 
 
         ## Ahnonay Hackage!
@@ -1559,7 +1559,7 @@ class psnlBookshelf(ptModifier):
             try:
                 index = linkLibrary.index("Ahnonay")    
             except:
-                print("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next")
+                PtDebugPrint("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next")
                 return
 
             # show the book
@@ -1581,7 +1581,7 @@ class psnlBookshelf(ptModifier):
                     parent = value.getParentKey()
                     if parent:
                         if bookName == parent.getName():
-                            print("%s book: DISABLED" % (bookName))
+                            PtDebugPrint("%s book: DISABLED" % (bookName))
                             actBook.disable(objectName=key)
                             break
                 if (not boolInMyAge) and int(locked):
@@ -1594,7 +1594,7 @@ class psnlBookshelf(ptModifier):
                     parent = value.getParentKey()
                     if parent:
                         if bookName == parent.getName():
-                            print("%s book: ENABLED" % (bookName))
+                            PtDebugPrint("%s book: ENABLED" % (bookName))
                             actBook.enable(objectName=key)
                             break
 
@@ -1640,7 +1640,7 @@ class psnlBookshelf(ptModifier):
         
         link = self.IGetLinkFromBook(SpawnPointTitle)
         if link is None:
-            print("psnlBookshelf.ILink():\tERROR -- conversion from book to link failed -- aborting")
+            PtDebugPrint("psnlBookshelf.ILink():\tERROR -- conversion from book to link failed -- aborting")
             return
         elif link == "Ahnonay":
             info = ptAgeInfoStruct()
@@ -1661,7 +1661,7 @@ class psnlBookshelf(ptModifier):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "AhnonayLink":
                             guid = chron.getValue()
-                            print(guid)
+                            PtDebugPrint(guid)
                             break
                     break
             info.setAgeInstanceGuid(guid)
@@ -1673,9 +1673,9 @@ class psnlBookshelf(ptModifier):
         ageName = info.getAgeFilename()
 
         # do the link
-        print("psnlBookshelf.ILink():\tattempting link to %s(%s)" % (info.getAgeFilename(),info.getAgeInstanceName()))
+        PtDebugPrint("psnlBookshelf.ILink():\tattempting link to %s(%s)" % (info.getAgeFilename(),info.getAgeInstanceName()))
 
-        print("Ilink: SpawnPointTitle = ", SpawnPointTitle, "; SpawnPointName = ", SpawnPointName)
+        PtDebugPrint("Ilink: SpawnPointTitle = ", SpawnPointTitle, "; SpawnPointName = ", SpawnPointName)
         spnpnt = None
         
         if isinstance(link, ptAgeLinkStruct):
@@ -1686,9 +1686,9 @@ class psnlBookshelf(ptModifier):
             spawnPoints = link.getSpawnPoints()
             for sp in spawnPoints:
                 if (sp.getTitle() == SpawnPointTitle and sp.getName() == SpawnPointName) or self.CheckForCityBookSpawnPoint(ageName, SpawnPointTitle):
-                    print("found spawn point: %s, %s" % (sp.getTitle(), sp.getName()))
+                    PtDebugPrint("found spawn point: %s, %s" % (sp.getTitle(), sp.getName()))
                     if sp.getName() == "BigRoomLinkInPoint":
-                        print("oops, found spawnpt for GZ BigRoom, we don't want to link there via city book, so we'll ignore it")
+                        PtDebugPrint("oops, found spawnpt for GZ BigRoom, we don't want to link there via city book, so we'll ignore it")
                         break
                     spnpnt = sp
                     break
@@ -1696,8 +1696,8 @@ class psnlBookshelf(ptModifier):
         if not spnpnt:
             spnpnt = ptSpawnPointInfo(SpawnPointTitle, SpawnPointName)
             
-        print("spnpnt.getTitle() = ",spnpnt.getTitle())
-        print("spnpnt.getName() = ",spnpnt.getName())
+        PtDebugPrint("spnpnt.getTitle() = ",spnpnt.getTitle())
+        PtDebugPrint("spnpnt.getName() = ",spnpnt.getName())
         
         als.setSpawnPoint(spnpnt)
 
@@ -1709,11 +1709,11 @@ class psnlBookshelf(ptModifier):
             if ageName == "Ahnonay":
                 als.setLinkingRules( PtLinkingRules.kBasicLink )
             elif IsChildLink:
-                print("psnlBookshelf.ILink(): using kChildAgeBook rules for link to: ",ageName)
+                PtDebugPrint("psnlBookshelf.ILink(): using kChildAgeBook rules for link to: ",ageName)
                 als.setLinkingRules( PtLinkingRules.kChildAgeBook )
                 als.setParentAgeFilename("Neighborhood")
             else:
-                print("psnlBookshelf.ILink(): using kOwnedBook rules for link to: ",ageName)
+                PtDebugPrint("psnlBookshelf.ILink(): using kOwnedBook rules for link to: ",ageName)
                 als.setLinkingRules( PtLinkingRules.kOwnedBook )
         # Otherwise, always use kOriginalBook rules.
         #   The engine will handle whether player becomes co-owner or not.
@@ -1727,7 +1727,7 @@ class psnlBookshelf(ptModifier):
 
         linkMgr = ptNetLinkingMgr()         
         linkMgr.linkToAge(als)
-        print("ILink Done")
+        PtDebugPrint("ILink Done")
 
 
     def IShelveBook(self):
@@ -1753,9 +1753,9 @@ class psnlBookshelf(ptModifier):
         try:
             index = objLibrary.value.index(objBookPicked)
         except:
-            print("psnlBookshelf.IUpdateLinks():\tERROR -- couldn't find ", objBookPicked, " in objLibrary")
+            PtDebugPrint("psnlBookshelf.IUpdateLinks():\tERROR -- couldn't find ", objBookPicked, " in objLibrary")
             return None            
-        print("psnlBookshelf.IGetAgeFromBook():\tpicked book goes to ", linkLibrary[index])
+        PtDebugPrint("psnlBookshelf.IGetAgeFromBook():\tpicked book goes to ", linkLibrary[index])
         return linkLibrary[index]
 
 
@@ -1781,7 +1781,7 @@ class psnlBookshelf(ptModifier):
         if AgeStartedIn == PtGetAgeName() and not self.UsingBook:
             ageSDL = PtGetAgeSDL()
             CurrentBookshelfUser = ageSDL["ShelfAUserID"][0]
-            #~ print "psnlBookshelf.OnNotify: Player %s was previously using the shelf." % (CurrentBookshelfUser)
+            #~ PtDebugPrint("psnlBookshelf.OnNotify: Player %s was previously using the shelf." % (CurrentBookshelfUser))
     
             PtDebugPrint ("psnlBookshelf.OnNotify: Player %s is done with the bookshelf." % (CurrentBookshelfUser))
             self.IResetShelf()             
@@ -1789,10 +1789,10 @@ class psnlBookshelf(ptModifier):
             avatar = PtGetLocalAvatar()   
             myID = PtGetClientIDFromAvatarKey(avatar.getKey())
         
-            #~ print "I think my ID is: ", myID
+            #~ PtDebugPrint("I think my ID is: ", myID)
         
             if myID == CurrentBookshelfUser:
-                print("I was the Shelf User, and I'm done with the Shelf now.")
+                PtDebugPrint("I was the Shelf User, and I'm done with the Shelf now.")
     
                 #PtFadeLocalAvatar(0)
                 avatar.draw.enable()
@@ -1864,7 +1864,7 @@ class psnlBookshelf(ptModifier):
                     if not info:
                         continue
                     ageName = info.getAgeFilename()
-                    #print "name = ",name
+                    #PtDebugPrint("name = ",name)
                     if ageName == age:
                         return link
         return None    
@@ -1882,10 +1882,10 @@ class psnlBookshelf(ptModifier):
             ageSDL = PtGetAgeSDL()
             GotBook = ageSDL["psnlGotCityBook"][0]
             if GotBook:
-                print("psnlBookshelf.HasCityBook(): owner has the city book")
+                PtDebugPrint("psnlBookshelf.HasCityBook(): owner has the city book")
                 return 1
             else:
-                print("psnlBookshelf.HasCityBook(): owner does NOT have city book")
+                PtDebugPrint("psnlBookshelf.HasCityBook(): owner does NOT have city book")
                 return 0
 
         CityLinks = []
@@ -1893,14 +1893,14 @@ class psnlBookshelf(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print("valCityLinks = ",valCityLinks)
+            PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print("CityLinks = ",CityLinks)
+            PtDebugPrint("CityLinks = ",CityLinks)
             for tmpLink in CityLinks:
                 if tmpLink in xLinkingBookDefs.CityBookLinks:
                     return 1
         else:
-            print("can't find CityBookLinks chron entry")
+            PtDebugPrint("can't find CityBookLinks chron entry")
         return 0
 
         vault = ptAgeVault()
@@ -1908,39 +1908,39 @@ class psnlBookshelf(ptModifier):
         for age, splist in CityBookAges.viewitems():
             #agelink = self.GetOwnedAgeLink(vault, age)
             agelink = self.IGetHoodChildLink(age)
-            print("age = ",age)
-            print("agelink = ",agelink)
+            PtDebugPrint("age = ",age)
+            PtDebugPrint("agelink = ",agelink)
 
             if agelink is not None:
                 spawnPoints = agelink.getSpawnPoints()
 
                 for sp in spawnPoints:
-                    print("sp = ",sp)
-                    print("sp.getTitle = ",sp.getTitle())
-                    print("sp.getName = ",sp.getName())
+                    PtDebugPrint("sp = ",sp)
+                    PtDebugPrint("sp.getTitle = ",sp.getTitle())
+                    PtDebugPrint("sp.getName = ",sp.getName())
                     if sp.getTitle() in splist:
-                        print("found a city book link:", age, sp.getTitle())
+                        PtDebugPrint("found a city book link:", age, sp.getTitle())
                         return 1
 
         # look for a city treasure link, but it's a Hood childage now
         #agelink = self.GetOwnedAgeLink(vault, "city")
         agelink = self.IGetHoodChildLink(age)
-        print("age = the city")
-        print("agelink = ",agelink)
+        PtDebugPrint("age = the city")
+        PtDebugPrint("agelink = ",agelink)
 
         if agelink is not None:
             spawnPoints = agelink.getSpawnPoints()
 
             for sp in spawnPoints:
-                print("sp = ",sp)
-                print("sp.getTitle = ",sp.getTitle())
-                print("sp.getName = ",sp.getName())
+                PtDebugPrint("sp = ",sp)
+                PtDebugPrint("sp.getTitle = ",sp.getTitle())
+                PtDebugPrint("sp.getName = ",sp.getName())
                 if sp.getTitle() in xLinkingBookDefs.CityBookLinks:
-                    print("found a city book link: city", sp.getTitle())
+                    PtDebugPrint("found a city book link: city", sp.getTitle())
                     return 1
 
         # no BCO or city treasure link
-        print("found no city book links")
+        PtDebugPrint("found no city book links")
         return 0
 
 
@@ -1954,7 +1954,7 @@ class psnlBookshelf(ptModifier):
                 if not info:
                     continue
                 ageName = info.getAgeFilename()
-                print("found %s, looking for %s" % (ageName, age))
+                PtDebugPrint("found %s, looking for %s" % (ageName, age))
                 if ageName == age:
                     return link
 

--- a/Python/psnlBookshelf.py
+++ b/Python/psnlBookshelf.py
@@ -128,7 +128,7 @@ class psnlBookshelf(ptModifier):
 
         version = 10
         self.version = version
-        print "__init__psnlBookshelf v.", version
+        print("__init__psnlBookshelf v.", version)
 
 
     def OnFirstUpdate(self):
@@ -218,9 +218,9 @@ class psnlBookshelf(ptModifier):
             ShelfABoolOperated = ageSDL["ShelfABoolOperated"][0]
             if not solo and ShelfABoolOperated:
                 actBookshelf.disable()
-                print "psnlBookshelf.Load():\tShelfABoolOperated=%d, disabling shelf clickable" % ShelfABoolOperated
+                print("psnlBookshelf.Load():\tShelfABoolOperated=%d, disabling shelf clickable" % ShelfABoolOperated)
             else:
-                print "psnlBookshelf.Load():\tShelfABoolOperated=%d but no one else here...correcting" % ShelfABoolOperated
+                print("psnlBookshelf.Load():\tShelfABoolOperated=%d but no one else here...correcting" % ShelfABoolOperated)
                 self.IResetShelf()
 
         self.initComplete = 1
@@ -239,7 +239,7 @@ class psnlBookshelf(ptModifier):
             try:
                 ageSDL = PtGetAgeSDL()
                 if avID == ageSDL["ShelfAUserID"][0]:
-                    print "psnlBookshelf.AvatarPage(): Bookshelf A operator paged out, reenabled Bookshelf."
+                    print("psnlBookshelf.AvatarPage(): Bookshelf A operator paged out, reenabled Bookshelf.")
                     self.IResetShelf()            
                 else:
                     return
@@ -251,33 +251,33 @@ class psnlBookshelf(ptModifier):
     def OnAgeVaultEvent(self,event,tupdata):
         PtDebugPrint("psnlBookshelf.OnAgeVaultEvent()\t:OnAgeKIEvent recvd. Event=%d and data= " % (event),tupdata)
         if event == PtVaultCallbackTypes.kVaultConnected:
-            print "psnlBookshelf: kVaultConnected event"
+            print("psnlBookshelf: kVaultConnected event")
             # tupdata is ()
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeSaved:
-            print "psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeSaved event (id=%d,type=%d)" % (tupdata[0].getID(),tupdata[0].getType())
+            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeSaved event (id=%d,type=%d)" % (tupdata[0].getID(),tupdata[0].getType()))
             # tupdata is ( ptVaultNode )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeRefAdded:
-            print "psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefAdded event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID())
+            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefAdded event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
             # tupdata is ( ptVaultNodeRef )
             if self.initComplete:
                 self.IUpdateLinks()
                 self.IUpdateLocksAndTrays()
         elif event == PtVaultCallbackTypes.kVaultRemovingNodeRef:
-            print "psnlBookshelf.OnAgeVaultEvent()\t: kVaultRemovingNodeRef event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID())
+            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultRemovingNodeRef event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
             # tupdata is ( ptVaultNodeRef )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeRefRemoved:
-            print "psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefRemoved event (childID,parentID) ",tupdata 
+            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeRefRemoved event (childID,parentID) ",tupdata) 
             # tupdata is ( childID, parentID )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultNodeInitialized:
-            print "psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeInitialized event (id=%d,type=%d)", (tupdata[0].getID(),tupdata[0].getType())
+            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultNodeInitialized event (id=%d,type=%d)", (tupdata[0].getID(),tupdata[0].getType()))
             # tupdata is ( ptVaultNode )
             #~ pass
         elif event == PtVaultCallbackTypes.kVaultOperationFailed:
-            print "psnlBookshelf.OnAgeVaultEvent()\t: kVaultOperationFailed event  (operation,resultCode) ",tupdata
+            print("psnlBookshelf.OnAgeVaultEvent()\t: kVaultOperationFailed event  (operation,resultCode) ",tupdata)
             #tupdata is ( operation, resultCode )
             #~ pass
         else:
@@ -317,7 +317,7 @@ class psnlBookshelf(ptModifier):
                 if event[0] == kMultiStageEvent and event[1] == 0: # Smart seek completed. Exit multistage, and show GUI.
                     LocalAvatar = PtFindAvatar(events)
                     SeekBehavior.gotoStage(LocalAvatar, -1) 
-                    print "psnlBookshelf.OnNotify():\tengaging bookshelf"
+                    print("psnlBookshelf.OnNotify():\tengaging bookshelf")
 
                     #PtFadeLocalAvatar(1)
                     LocalAvatar.draw.disable()
@@ -370,7 +370,7 @@ class psnlBookshelf(ptModifier):
             
             for event in events:
                 if event[0] == kVariableEvent:
-                    print "psnlBookshelf: Received a message from the Book GUI: ", event[1]
+                    print("psnlBookshelf: Received a message from the Book GUI: ", event[1])
                     if event[1] == "IShelveBook" and objBookPicked is not None:
                         self.IShelveBook()
                         
@@ -398,7 +398,7 @@ class psnlBookshelf(ptModifier):
                             SpawnPointName = event[1].split(",")[1]
                             SpawnPointTitle = event[1].split(",")[2]
                             
-                            print "psnlBookshelf: SpawnPointName = ", SpawnPointName," SpawnPointTitle = ", SpawnPointTitle
+                            print("psnlBookshelf: SpawnPointName = ", SpawnPointName," SpawnPointTitle = ", SpawnPointTitle)
 
                             self.IResetShelf()
                             self.SendNote(0)
@@ -412,12 +412,12 @@ class psnlBookshelf(ptModifier):
  
         if id == (-1):
             if events[0][1] == 'BookShelfBusy':
-                print "psnlBookShelf: Notified about bookshelf use."
+                print("psnlBookShelf: Notified about bookshelf use.")
                 boolShelfInUse = events[0][3]
             else:
                 for event in events:
                     if event[0] == kVariableEvent:
-                        print event[1], event[3]
+                        print(event[1], event[3])
                         if event[1] == "YesNo" and event[3] == 1:
                             link = self.IGetLinkFromBook()
                             
@@ -460,7 +460,7 @@ class psnlBookshelf(ptModifier):
                                     info = link.getAgeInfo()
                                     if info and info.getAgeFilename() == "AhnonayCathedral":
                                         # found our link
-                                        print "psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename()
+                                        print("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
                                         link.setVolatile(True)
                                         link.save()
 
@@ -474,7 +474,7 @@ class psnlBookshelf(ptModifier):
                                                 BookNumber = linkLibrary.index(bookAge)
                                                 ageSDL = PtGetAgeSDL()                                    
                                                 ageSDL.setIndex("CurrentPage",BookNumber,1)
-                                                print "Setting CurrentPage var of book %s to 1" % BookNumber
+                                                print("Setting CurrentPage var of book %s to 1" % BookNumber)
                                                 break
                                 objBookPicked = None
                                 return
@@ -497,7 +497,7 @@ class psnlBookshelf(ptModifier):
                                         BookNumber = linkLibrary.index(bookAge)
                                         ageSDL = PtGetAgeSDL()                                    
                                         ageSDL.setIndex("CurrentPage",BookNumber,1)
-                                        print "Setting CurrentPage var of book %s to 1" % BookNumber
+                                        print("Setting CurrentPage var of book %s to 1" % BookNumber)
                                         break
                             objBookPicked = None
                             return
@@ -512,8 +512,8 @@ class psnlBookshelf(ptModifier):
         if id==actBookshelf.id:
             if PtFindAvatar(events) == PtGetLocalAvatar() and PtWasLocallyNotified(self.key) and not boolShelfInUse:
                 actBookshelf.disable() # want the Shelf clickable to be disabled for all clients
-                print "psnlBookshelf: disabling clickable"
-                print "psnlBookshelf: Firing clickable responder"
+                print("psnlBookshelf: disabling clickable")
+                print("psnlBookshelf: Firing clickable responder")
                 respRaiseShelfClickable.run(self.key,netPropagate=0)
                 self.SendNote(1)
                 self.IUpdateLinks()
@@ -536,7 +536,7 @@ class psnlBookshelf(ptModifier):
                                 avID = PtGetClientIDFromAvatarKey(LocalAvatar.getKey())
                                 ageSDL["ShelfAUserID"] = (avID,)
                                 ShelfAUserID = avID
-                                print "psnlBookshelf.OnNotify:\twrote SDL - Bookshelf A user id = ", avID
+                                print("psnlBookshelf.OnNotify:\twrote SDL - Bookshelf A user id = ", avID)
                                 PtDisableMovementKeys()
                             #self.IUpdateLinks()
                             #PtShowDialog(kPALDialogName)
@@ -568,11 +568,11 @@ class psnlBookshelf(ptModifier):
                 if event[0]==kPickedEvent:
                     objBookPicked = event[3]
                     bookName = objBookPicked.getName()
-                    print "psnlBookshelf.OnNotify():\tplayer picked book named ", bookName
+                    print("psnlBookshelf.OnNotify():\tplayer picked book named ", bookName)
                     try:
                         index = objLibrary.value.index(objBookPicked)
                     except:
-                        print "psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objBookPicked, " in objLibrary"
+                        print("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objBookPicked, " in objLibrary")
                         return
 
                     if self.IGetAgeFromBook() == "city" and PtIsSinglePlayerMode():
@@ -773,7 +773,7 @@ class psnlBookshelf(ptModifier):
 
                 if locked:
                     lockName = objLockPicked.getName()
-                    print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName
+                    print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
                     for rkey,rvalue in respCloseLock.byObject.viewitems():
                         parent = rvalue.getParentKey()
                         if parent:
@@ -818,7 +818,7 @@ class psnlBookshelf(ptModifier):
                     try:
                         index = objLocks.value.index(objLockPicked)
                     except:
-                        print "psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objLockPicked, " in objLocks"
+                        print("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objLockPicked, " in objLocks")
                         return
                     objBookPicked = objLibrary.value[index]
                     lockName = objLockPicked.getName()
@@ -888,7 +888,7 @@ class psnlBookshelf(ptModifier):
                             if stupidHackForLock != None:
                                 locked = stupidHackForLock
 
-                        print locked
+                        print(locked)
                         if locked:
                             # find the corresponding open clasp responder modifier
                             for rkey,rvalue in respOpenLock.byObject.viewitems():
@@ -902,7 +902,7 @@ class psnlBookshelf(ptModifier):
                                 chron = ageDataChild.upcastToChronicleNode()
                                 if chron and chron.getName() == "AhnonayLocked":
                                     if ( vault.inMyPersonalAge() ):
-                                        print "setting lock to 0"
+                                        print("setting lock to 0")
                                         chron.setValue("0")
                         else:
                             # find the corresponding close clasp responder modifier
@@ -917,7 +917,7 @@ class psnlBookshelf(ptModifier):
                                 chron = ageDataChild.upcastToChronicleNode()
                                 if chron and chron.getName() == "AhnonayLocked":
                                     if ( vault.inMyPersonalAge() ):
-                                        print "setting lock to 1"
+                                        print("setting lock to 1")
                                         chron.setValue("1")
 
                         if not vault.inMyPersonalAge():
@@ -997,7 +997,7 @@ class psnlBookshelf(ptModifier):
             try:
                 index = objTrays.value.index(objTrayPicked)
             except:
-                print "psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objTrayPicked, " in objTrays"
+                print("psnlBookshelf.OnNotify():\tERROR -- couldn't find ", objTrayPicked, " in objTrays")
                 return
 
             objBookPicked = objLibrary.value[index]
@@ -1055,7 +1055,7 @@ class psnlBookshelf(ptModifier):
                         info = link.getAgeInfo()
                         if info and info.getAgeFilename() == "AhnonayCathedral":
                             # found our link
-                            print "psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename()
+                            print("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
                             link.setVolatile(False)
                             link.save()
 
@@ -1133,7 +1133,7 @@ class psnlBookshelf(ptModifier):
 
         
         ageName = self.IGetAgeFromBook()
-        print "psnlBookshelf.IGetLinkFromBook(): before city lookup, ageName = ",ageName
+        print("psnlBookshelf.IGetLinkFromBook(): before city lookup, ageName = ",ageName)
 
         isCityLink = 0
         if ageName == "city":
@@ -1142,14 +1142,14 @@ class psnlBookshelf(ptModifier):
                 if spTitle in splist:
                     ageName = age
                     break
-        print "psnlBookshelf.IGetLinkFromBook(): after city lookup, ageName = ",ageName        	        
+        print("psnlBookshelf.IGetLinkFromBook(): after city lookup, ageName = ",ageName)        	        
 
         if ageName is None:
-            print "psnlBookshelf.IGetLinkFromBook():\tERROR -- conversion from book to link element failed"
+            print("psnlBookshelf.IGetLinkFromBook():\tERROR -- conversion from book to link element failed")
             return None
 
         if ageName == "Ahnonay":
-            print "psnlBookshelf.IGetLinkFromBook(): Going to Ahnonay... special case."
+            print("psnlBookshelf.IGetLinkFromBook(): Going to Ahnonay... special case.")
             return "Ahnonay"
 
         hoodInfo = self.IGetHoodInfoNode()
@@ -1168,7 +1168,7 @@ class psnlBookshelf(ptModifier):
                         continue
                     else:
                         # found our link
-                        print "psnlBookshelf.IGetLinkFromBook():\tfound Child link ", info.getAgeFilename()
+                        print("psnlBookshelf.IGetLinkFromBook():\tfound Child link ", info.getAgeFilename())
                         IsChildLink = 1
                         return link
 
@@ -1195,14 +1195,14 @@ class psnlBookshelf(ptModifier):
             info = link.getAgeInfo()
             if info and info.getAgeFilename() == ageName:
                 # found our link
-                print "psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename()
+                print("psnlBookshelf.IGetLinkFromBook():\tfound Owned link", info.getAgeFilename())
                 IsChildLink = 0
                 return link
 
-        print "psnlBookshelf.IGetLinkFromBook():\tERROR -- couldn't find link to", ageName
-        print "info = ",info
-        print "info.getAgeFilename() = ",info.getAgeFilename()
-        print "spTitle = ",spTitle
+        print("psnlBookshelf.IGetLinkFromBook():\tERROR -- couldn't find link to", ageName)
+        print("info = ",info)
+        print("info.getAgeFilename() = ",info.getAgeFilename())
+        print("spTitle = ",spTitle)
         return None
     
     def SendNote(self, bool):
@@ -1237,14 +1237,14 @@ class psnlBookshelf(ptModifier):
 
             # show as locked if both are locked, or one is locked and the other doesn't exist
             if ( citylinklocked is None or citylinklocked) and ( bcolinklocked is None or bcolinklocked):
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to locked: ",lockName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to locked: ",lockName)
                 for rkey,rvalue in respCloseLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         if lockName == parent.getName():
                             respCloseLock.run(self.key,objectName=rkey,fastforward=1)
             else:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to unlocked: ",lockName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to unlocked: ",lockName)
                 for rkey,rvalue in respOpenLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1261,7 +1261,7 @@ class psnlBookshelf(ptModifier):
             try:
                 index = linkLibrary.index(ageName)    
             except:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to:", ageName, "...skipping to next"
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to:", ageName, "...skipping to next")
                 continue
 
             if ((ageName == "city" or ageName == "BaronCityOffice") and PtIsSinglePlayerMode()) or (ageName in CityBookAges.viewkeys()):
@@ -1279,14 +1279,14 @@ class psnlBookshelf(ptModifier):
             objLock = objLocks.value[index]
             lockName = objLock.getName()
             if link.getLocked():
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
                 for rkey,rvalue in respCloseLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         if lockName == parent.getName():
                             respCloseLock.run(self.key,objectName=rkey,fastforward=1)
             else:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName)
                 for rkey,rvalue in respOpenLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1297,7 +1297,7 @@ class psnlBookshelf(ptModifier):
             objBook = objLibrary.value[index]
             bookName = objBook.getName()
             if link.getVolatile():
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName)
                 for rkey,rvalue in respDeleteBook.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1306,7 +1306,7 @@ class psnlBookshelf(ptModifier):
                             respDeleteBook.run(self.key,objectName=rkey,fastforward=1)
                             #~ print "got here"
             else:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName)
                 for rkey,rvalue in respReturnTray.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1340,20 +1340,20 @@ class psnlBookshelf(ptModifier):
             try:
                 index = linkLibrary.index("Ahnonay")    
             except:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next"
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next")
                 return
 
             objLock = objLocks.value[index]
             lockName = objLock.getName()
             if int(locked):
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to locked: ",lockName)
                 for rkey,rvalue in respCloseLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
                         if lockName == parent.getName():
                             respCloseLock.run(self.key,objectName=rkey,fastforward=1)
             else:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting clasp to unlocked: ",lockName)
                 for rkey,rvalue in respOpenLock.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1364,7 +1364,7 @@ class psnlBookshelf(ptModifier):
             objBook = objLibrary.value[index]
             bookName = objBook.getName()
             if int(volatile):
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to VOLATILE: ",bookName)
                 for rkey,rvalue in respDeleteBook.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1373,7 +1373,7 @@ class psnlBookshelf(ptModifier):
                             respDeleteBook.run(self.key,objectName=rkey,fastforward=1)
                             #~ print "got here"
             else:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tsetting booktray to NOT volatile: ",bookName)
                 for rkey,rvalue in respReturnTray.byObject.viewitems():
                     parent = rvalue.getParentKey()
                     if parent:
@@ -1458,7 +1458,7 @@ class psnlBookshelf(ptModifier):
                 try:
                     index = linkLibrary.index(ageName)    
                 except:
-                    print "psnlBookshelf.IUpdateLinks():\tno matching book for KI's link to:", ageName, "...skipping to next"
+                    print("psnlBookshelf.IUpdateLinks():\tno matching book for KI's link to:", ageName, "...skipping to next")
                     continue
     
                 if ageName == "Cleft":
@@ -1476,14 +1476,14 @@ class psnlBookshelf(ptModifier):
                     return
 
                 # find and enable the corresponding clickable modifier for the book
-                print "psnlBookshelf.IUpdateLinks():\tageName: ",ageName," boolInMyAge: ",boolInMyAge," getLocked(): ",link.getLocked()," getVolatile(): ",link.getVolatile()
+                print("psnlBookshelf.IUpdateLinks():\tageName: ",ageName," boolInMyAge: ",boolInMyAge," getLocked(): ",link.getLocked()," getVolatile(): ",link.getVolatile())
                 if link.getVolatile() or ((not boolInMyAge) and (link.getLocked() or ageName == "Cleft")):
                     bookName = objBook.getName()
                     for key,value in actBook.byObject.viewitems():
                         parent = value.getParentKey()
                         if parent:
                             if bookName == parent.getName():
-                                print "%s book: DISABLED" % (bookName)
+                                print("%s book: DISABLED" % (bookName))
                                 actBook.disable(objectName=key)
                                 break
                     if (not boolInMyAge) and (link.getLocked() or ageName == "Cleft"):
@@ -1496,7 +1496,7 @@ class psnlBookshelf(ptModifier):
                         parent = value.getParentKey()
                         if parent:
                             if bookName == parent.getName():
-                                print "%s book: ENABLED" % (bookName)
+                                print("%s book: ENABLED" % (bookName))
                                 actBook.enable(objectName=key)
                                 break
     
@@ -1527,7 +1527,7 @@ class psnlBookshelf(ptModifier):
                                 break
                     
         else:
-            print "psnlBookshelf: The PAL folder is missing"
+            print("psnlBookshelf: The PAL folder is missing")
 
 
         ## Ahnonay Hackage!
@@ -1559,7 +1559,7 @@ class psnlBookshelf(ptModifier):
             try:
                 index = linkLibrary.index("Ahnonay")    
             except:
-                print "psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next"
+                print("psnlBookshelf.IUpdateLocksAndTrays():\tno matching book for KI's link to: Ahnonay... skipping to next")
                 return
 
             # show the book
@@ -1581,7 +1581,7 @@ class psnlBookshelf(ptModifier):
                     parent = value.getParentKey()
                     if parent:
                         if bookName == parent.getName():
-                            print "%s book: DISABLED" % (bookName)
+                            print("%s book: DISABLED" % (bookName))
                             actBook.disable(objectName=key)
                             break
                 if (not boolInMyAge) and int(locked):
@@ -1594,7 +1594,7 @@ class psnlBookshelf(ptModifier):
                     parent = value.getParentKey()
                     if parent:
                         if bookName == parent.getName():
-                            print "%s book: ENABLED" % (bookName)
+                            print("%s book: ENABLED" % (bookName))
                             actBook.enable(objectName=key)
                             break
 
@@ -1640,7 +1640,7 @@ class psnlBookshelf(ptModifier):
         
         link = self.IGetLinkFromBook(SpawnPointTitle)
         if link is None:
-            print "psnlBookshelf.ILink():\tERROR -- conversion from book to link failed -- aborting"
+            print("psnlBookshelf.ILink():\tERROR -- conversion from book to link failed -- aborting")
             return
         elif link == "Ahnonay":
             info = ptAgeInfoStruct()
@@ -1661,7 +1661,7 @@ class psnlBookshelf(ptModifier):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "AhnonayLink":
                             guid = chron.getValue()
-                            print guid
+                            print(guid)
                             break
                     break
             info.setAgeInstanceGuid(guid)
@@ -1673,9 +1673,9 @@ class psnlBookshelf(ptModifier):
         ageName = info.getAgeFilename()
 
         # do the link
-        print "psnlBookshelf.ILink():\tattempting link to %s(%s)" % (info.getAgeFilename(),info.getAgeInstanceName())
+        print("psnlBookshelf.ILink():\tattempting link to %s(%s)" % (info.getAgeFilename(),info.getAgeInstanceName()))
 
-        print "Ilink: SpawnPointTitle = ", SpawnPointTitle, "; SpawnPointName = ", SpawnPointName
+        print("Ilink: SpawnPointTitle = ", SpawnPointTitle, "; SpawnPointName = ", SpawnPointName)
         spnpnt = None
         
         if isinstance(link, ptAgeLinkStruct):
@@ -1686,9 +1686,9 @@ class psnlBookshelf(ptModifier):
             spawnPoints = link.getSpawnPoints()
             for sp in spawnPoints:
                 if (sp.getTitle() == SpawnPointTitle and sp.getName() == SpawnPointName) or self.CheckForCityBookSpawnPoint(ageName, SpawnPointTitle):
-                    print "found spawn point: %s, %s" % (sp.getTitle(), sp.getName())
+                    print("found spawn point: %s, %s" % (sp.getTitle(), sp.getName()))
                     if sp.getName() == "BigRoomLinkInPoint":
-                        print "oops, found spawnpt for GZ BigRoom, we don't want to link there via city book, so we'll ignore it"
+                        print("oops, found spawnpt for GZ BigRoom, we don't want to link there via city book, so we'll ignore it")
                         break
                     spnpnt = sp
                     break
@@ -1696,8 +1696,8 @@ class psnlBookshelf(ptModifier):
         if not spnpnt:
             spnpnt = ptSpawnPointInfo(SpawnPointTitle, SpawnPointName)
             
-        print "spnpnt.getTitle() = ",spnpnt.getTitle()
-        print "spnpnt.getName() = ",spnpnt.getName()
+        print("spnpnt.getTitle() = ",spnpnt.getTitle())
+        print("spnpnt.getName() = ",spnpnt.getName())
         
         als.setSpawnPoint(spnpnt)
 
@@ -1709,11 +1709,11 @@ class psnlBookshelf(ptModifier):
             if ageName == "Ahnonay":
                 als.setLinkingRules( PtLinkingRules.kBasicLink )
             elif IsChildLink:
-                print "psnlBookshelf.ILink(): using kChildAgeBook rules for link to: ",ageName
+                print("psnlBookshelf.ILink(): using kChildAgeBook rules for link to: ",ageName)
                 als.setLinkingRules( PtLinkingRules.kChildAgeBook )
                 als.setParentAgeFilename("Neighborhood")
             else:
-                print "psnlBookshelf.ILink(): using kOwnedBook rules for link to: ",ageName
+                print("psnlBookshelf.ILink(): using kOwnedBook rules for link to: ",ageName)
                 als.setLinkingRules( PtLinkingRules.kOwnedBook )
         # Otherwise, always use kOriginalBook rules.
         #   The engine will handle whether player becomes co-owner or not.
@@ -1727,7 +1727,7 @@ class psnlBookshelf(ptModifier):
 
         linkMgr = ptNetLinkingMgr()         
         linkMgr.linkToAge(als)
-        print "ILink Done"
+        print("ILink Done")
 
 
     def IShelveBook(self):
@@ -1753,9 +1753,9 @@ class psnlBookshelf(ptModifier):
         try:
             index = objLibrary.value.index(objBookPicked)
         except:
-            print "psnlBookshelf.IUpdateLinks():\tERROR -- couldn't find ", objBookPicked, " in objLibrary"
+            print("psnlBookshelf.IUpdateLinks():\tERROR -- couldn't find ", objBookPicked, " in objLibrary")
             return None            
-        print "psnlBookshelf.IGetAgeFromBook():\tpicked book goes to ", linkLibrary[index]
+        print("psnlBookshelf.IGetAgeFromBook():\tpicked book goes to ", linkLibrary[index])
         return linkLibrary[index]
 
 
@@ -1792,7 +1792,7 @@ class psnlBookshelf(ptModifier):
             #~ print "I think my ID is: ", myID
         
             if myID == CurrentBookshelfUser:
-                print "I was the Shelf User, and I'm done with the Shelf now."
+                print("I was the Shelf User, and I'm done with the Shelf now.")
     
                 #PtFadeLocalAvatar(0)
                 avatar.draw.enable()
@@ -1882,10 +1882,10 @@ class psnlBookshelf(ptModifier):
             ageSDL = PtGetAgeSDL()
             GotBook = ageSDL["psnlGotCityBook"][0]
             if GotBook:
-                print "psnlBookshelf.HasCityBook(): owner has the city book"
+                print("psnlBookshelf.HasCityBook(): owner has the city book")
                 return 1
             else:
-                print "psnlBookshelf.HasCityBook(): owner does NOT have city book"
+                print("psnlBookshelf.HasCityBook(): owner does NOT have city book")
                 return 0
 
         CityLinks = []
@@ -1893,14 +1893,14 @@ class psnlBookshelf(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print "valCityLinks = ",valCityLinks
+            print("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print "CityLinks = ",CityLinks
+            print("CityLinks = ",CityLinks)
             for tmpLink in CityLinks:
                 if tmpLink in xLinkingBookDefs.CityBookLinks:
                     return 1
         else:
-            print "can't find CityBookLinks chron entry"
+            print("can't find CityBookLinks chron entry")
         return 0
 
         vault = ptAgeVault()
@@ -1908,39 +1908,39 @@ class psnlBookshelf(ptModifier):
         for age, splist in CityBookAges.viewitems():
             #agelink = self.GetOwnedAgeLink(vault, age)
             agelink = self.IGetHoodChildLink(age)
-            print "age = ",age
-            print "agelink = ",agelink
+            print("age = ",age)
+            print("agelink = ",agelink)
 
             if agelink is not None:
                 spawnPoints = agelink.getSpawnPoints()
 
                 for sp in spawnPoints:
-                    print "sp = ",sp
-                    print "sp.getTitle = ",sp.getTitle()
-                    print "sp.getName = ",sp.getName()
+                    print("sp = ",sp)
+                    print("sp.getTitle = ",sp.getTitle())
+                    print("sp.getName = ",sp.getName())
                     if sp.getTitle() in splist:
-                        print "found a city book link:", age, sp.getTitle()
+                        print("found a city book link:", age, sp.getTitle())
                         return 1
 
         # look for a city treasure link, but it's a Hood childage now
         #agelink = self.GetOwnedAgeLink(vault, "city")
         agelink = self.IGetHoodChildLink(age)
-        print "age = the city"
-        print "agelink = ",agelink
+        print("age = the city")
+        print("agelink = ",agelink)
 
         if agelink is not None:
             spawnPoints = agelink.getSpawnPoints()
 
             for sp in spawnPoints:
-                print "sp = ",sp
-                print "sp.getTitle = ",sp.getTitle()
-                print "sp.getName = ",sp.getName()
+                print("sp = ",sp)
+                print("sp.getTitle = ",sp.getTitle())
+                print("sp.getName = ",sp.getName())
                 if sp.getTitle() in xLinkingBookDefs.CityBookLinks:
-                    print "found a city book link: city", sp.getTitle()
+                    print("found a city book link: city", sp.getTitle())
                     return 1
 
         # no BCO or city treasure link
-        print "found no city book links"
+        print("found no city book links")
         return 0
 
 
@@ -1954,7 +1954,7 @@ class psnlBookshelf(ptModifier):
                 if not info:
                     continue
                 ageName = info.getAgeFilename()
-                print "found %s, looking for %s" % (ageName, age)
+                print("found %s, looking for %s" % (ageName, age))
                 if ageName == age:
                     return link
 

--- a/Python/psnlBugs.py
+++ b/Python/psnlBugs.py
@@ -85,20 +85,20 @@ class psnlBugs(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print("failed to get local avatar")
+            PtDebugPrint("failed to get local avatar")
             return
         
         self.bugCount = self.IGetBugCount()
-        print("psnl Bugs: ", self.bugCount)
+        PtDebugPrint("psnl Bugs: ", self.bugCount)
 
         thisAge = PtGetAgeName()
-        #print "psnlBugs.OnServerInitComplete(): thisAge = ",thisAge
+        #PtDebugPrint("psnlBugs.OnServerInitComplete(): thisAge = ",thisAge)
 
         if (self.bugCount != 0):
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             PtKillParticles(10.0,1,avatar.getKey())
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print("kill all bugs in age: ",thisAge)
+            PtDebugPrint("kill all bugs in age: ",thisAge)
             self.ISaveBugCount(0)
         
         if thisAge != "Personal":
@@ -111,22 +111,22 @@ class psnlBugs(ptResponder):
         sdl = PtGetAgeSDL()
         bugState = sdl["psnlBugsVis"]
         if rainState == 1 or (rainState == 4 and len(PtGetPlayerList()) == 0) or (rainState == 3 and len(PtGetPlayerList()) > 0):
-            print("turning off bugs")
+            PtDebugPrint("turning off bugs")
             if bugState != 0:
                 sdl["psnlBugsVis"] = (0,)
         else:
             if self.bugCount > 0:
-                print("turning on bugs")
+                PtDebugPrint("turning on bugs")
                 if bugState != 1:
                     sdl["psnlBugsVis"] = (1,)
 
 ##    def AvatarPage(self, avatar, pageIn, lastOut):
-##        print "in avatar page"
+##        PtDebugPrint("in avatar page")
 ##        self.bugCount = PtGetNumParticles(avatar.getKey())
-##        print "number of bugs:", self.bugCount
+##        PtDebugPrint("number of bugs:", self.bugCount)
 ##        if (self.bugCount > 0):
 ##            PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
 ##            PtKillParticles(10.0,1,avatar.getKey())
 ##            PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)     
-##            print "kill all bugs in psnl age"
+##            PtDebugPrint("kill all bugs in psnl age")
 ##            self.ISaveBugCount(0)

--- a/Python/psnlBugs.py
+++ b/Python/psnlBugs.py
@@ -85,11 +85,11 @@ class psnlBugs(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print"failed to get local avatar"
+            print("failed to get local avatar")
             return
         
         self.bugCount = self.IGetBugCount()
-        print"psnl Bugs: ", self.bugCount
+        print("psnl Bugs: ", self.bugCount)
 
         thisAge = PtGetAgeName()
         #print "psnlBugs.OnServerInitComplete(): thisAge = ",thisAge
@@ -98,7 +98,7 @@ class psnlBugs(ptResponder):
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             PtKillParticles(10.0,1,avatar.getKey())
             PtSetLightAnimStart(avatar.getKey(), bugLightObjectName, False)
-            print "kill all bugs in age: ",thisAge
+            print("kill all bugs in age: ",thisAge)
             self.ISaveBugCount(0)
         
         if thisAge != "Personal":
@@ -111,12 +111,12 @@ class psnlBugs(ptResponder):
         sdl = PtGetAgeSDL()
         bugState = sdl["psnlBugsVis"]
         if rainState == 1 or (rainState == 4 and len(PtGetPlayerList()) == 0) or (rainState == 3 and len(PtGetPlayerList()) > 0):
-            print "turning off bugs"
+            print("turning off bugs")
             if bugState != 0:
                 sdl["psnlBugsVis"] = (0,)
         else:
             if self.bugCount > 0:
-                print "turning on bugs"
+                print("turning on bugs")
                 if bugState != 1:
                     sdl["psnlBugsVis"] = (1,)
 

--- a/Python/psnlCalendarStones.py
+++ b/Python/psnlCalendarStones.py
@@ -124,10 +124,10 @@ class psnlCalendarStones(ptResponder):
                     PtDebugPrint("psnlCalendarStones.OnServerInitComplete():\tERROR reading age SDLVar for YeeshaPage20. Assuming value = 0")
                     CurrentValue = 0
                 if CurrentValue in [0, 2, 4]:
-                    print "psnlCalendarStones.OnServerInitComplete():  don't have YeeshaPage20 on, no FIRE for you!"
+                    print("psnlCalendarStones.OnServerInitComplete():  don't have YeeshaPage20 on, no FIRE for you!")
                     respCalStoneFire.run(self.key,state="off",fastforward=1)
                 else:
-                    print "psnlCalendarStones.OnServerInitComplete():  have all 12 calendar stones AND YeeshaPage20 is on, will give you FIRE!"
+                    print("psnlCalendarStones.OnServerInitComplete():  have all 12 calendar stones AND YeeshaPage20 is on, will give you FIRE!")
                     fireworks = 1
                     respCalStoneFire.run(self.key,state="on",fastforward=1)
                     if not self.sceneobject.isLocallyOwned():
@@ -137,7 +137,7 @@ class psnlCalendarStones(ptResponder):
                         self.DoFireworks(3,1)
                         self.DoFireworks(5,1)
         else:
-            print "psnlCalendarStones.OnServerInitComplete():  don't have all 12 calendar stones, no FIRE for you!"
+            print("psnlCalendarStones.OnServerInitComplete():  don't have all 12 calendar stones, no FIRE for you!")
             respCalStoneFire.run(self.key,state="off",fastforward=1)
 
 
@@ -203,25 +203,25 @@ class psnlCalendarStones(ptResponder):
         timer = float(param)
         if target == "fireworks1":
             respFireworksLaunch1.run(self.key)
-            print "launch rocket 1"
+            print("launch rocket 1")
             PtAtTimeCallback(self.key,timer,2)
         elif target == "fireworks2":
             respFireworksLaunch2.run(self.key)
-            print "launch rocket 2"
+            print("launch rocket 2")
             PtAtTimeCallback(self.key,timer,4)
         elif target == "fireworks3":
             respFireworksLaunch3.run(self.key)
-            print "launch rocket 3"
+            print("launch rocket 3")
             PtAtTimeCallback(self.key,timer,6)
         elif target == "fireworksall":
             respFireworksLaunch1.run(self.key)
-            print "launch rocket 1"
+            print("launch rocket 1")
             PtAtTimeCallback(self.key,timer,2)
             respFireworksLaunch2.run(self.key)
-            print "launch rocket 2"
+            print("launch rocket 2")
             PtAtTimeCallback(self.key,timer,4)
             respFireworksLaunch3.run(self.key)
-            print "launch rocket 3"
+            print("launch rocket 3")
             PtAtTimeCallback(self.key,timer,6)
 
 

--- a/Python/psnlCalendarStones.py
+++ b/Python/psnlCalendarStones.py
@@ -124,10 +124,10 @@ class psnlCalendarStones(ptResponder):
                     PtDebugPrint("psnlCalendarStones.OnServerInitComplete():\tERROR reading age SDLVar for YeeshaPage20. Assuming value = 0")
                     CurrentValue = 0
                 if CurrentValue in [0, 2, 4]:
-                    print("psnlCalendarStones.OnServerInitComplete():  don't have YeeshaPage20 on, no FIRE for you!")
+                    PtDebugPrint("psnlCalendarStones.OnServerInitComplete():  don't have YeeshaPage20 on, no FIRE for you!")
                     respCalStoneFire.run(self.key,state="off",fastforward=1)
                 else:
-                    print("psnlCalendarStones.OnServerInitComplete():  have all 12 calendar stones AND YeeshaPage20 is on, will give you FIRE!")
+                    PtDebugPrint("psnlCalendarStones.OnServerInitComplete():  have all 12 calendar stones AND YeeshaPage20 is on, will give you FIRE!")
                     fireworks = 1
                     respCalStoneFire.run(self.key,state="on",fastforward=1)
                     if not self.sceneobject.isLocallyOwned():
@@ -137,7 +137,7 @@ class psnlCalendarStones(ptResponder):
                         self.DoFireworks(3,1)
                         self.DoFireworks(5,1)
         else:
-            print("psnlCalendarStones.OnServerInitComplete():  don't have all 12 calendar stones, no FIRE for you!")
+            PtDebugPrint("psnlCalendarStones.OnServerInitComplete():  don't have all 12 calendar stones, no FIRE for you!")
             respCalStoneFire.run(self.key,state="off",fastforward=1)
 
 
@@ -152,29 +152,29 @@ class psnlCalendarStones(ptResponder):
             return
         if id == 1:
             respFireworksLaunch1.run(self.key)
-            #print "launch rocket 1"
+            #PtDebugPrint("launch rocket 1")
             self.DoFireworks(1,2)
         elif id == 2:
             respFireworksExplode1.run(self.key)
-            #print "explode rocket 1"
+            #PtDebugPrint("explode rocket 1")
             if not fireworksTestMode:
                 self.DoFireworks(1,1)
         elif id == 3:
             respFireworksLaunch2.run(self.key)
-            #print "launch rocket 2"
+            #PtDebugPrint("launch rocket 2")
             self.DoFireworks(3,2)
         elif id == 4:
             respFireworksExplode2.run(self.key)
-            #print "explode rocket 2"
+            #PtDebugPrint("explode rocket 2")
             if not fireworksTestMode:
                 self.DoFireworks(3,1)
         elif id == 5:
             respFireworksLaunch3.run(self.key)
-            #print "launch rocket 3"
+            #PtDebugPrint("launch rocket 3")
             self.DoFireworks(5,2)
         elif id == 6:
             respFireworksExplode3.run(self.key)
-            #print "explode rocket 3"
+            #PtDebugPrint("explode rocket 3")
             if not fireworksTestMode:
                 self.DoFireworks(5,1)
 
@@ -203,25 +203,25 @@ class psnlCalendarStones(ptResponder):
         timer = float(param)
         if target == "fireworks1":
             respFireworksLaunch1.run(self.key)
-            print("launch rocket 1")
+            PtDebugPrint("launch rocket 1")
             PtAtTimeCallback(self.key,timer,2)
         elif target == "fireworks2":
             respFireworksLaunch2.run(self.key)
-            print("launch rocket 2")
+            PtDebugPrint("launch rocket 2")
             PtAtTimeCallback(self.key,timer,4)
         elif target == "fireworks3":
             respFireworksLaunch3.run(self.key)
-            print("launch rocket 3")
+            PtDebugPrint("launch rocket 3")
             PtAtTimeCallback(self.key,timer,6)
         elif target == "fireworksall":
             respFireworksLaunch1.run(self.key)
-            print("launch rocket 1")
+            PtDebugPrint("launch rocket 1")
             PtAtTimeCallback(self.key,timer,2)
             respFireworksLaunch2.run(self.key)
-            print("launch rocket 2")
+            PtDebugPrint("launch rocket 2")
             PtAtTimeCallback(self.key,timer,4)
             respFireworksLaunch3.run(self.key)
-            print("launch rocket 3")
+            PtDebugPrint("launch rocket 3")
             PtAtTimeCallback(self.key,timer,6)
 
 

--- a/Python/psnlYeeshaPageChanges.py
+++ b/Python/psnlYeeshaPageChanges.py
@@ -185,7 +185,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                                         val = ageSDL["CleftVisited"][0]
                                         if not val:
                                             HideCleftPole = 1
-                                            print "psnlYeeshaPageChanges.OnServerInitComplete():\t Fissure is open, so setting HideCleftPole = ",HideCleftPole
+                                            print("psnlYeeshaPageChanges.OnServerInitComplete():\t Fissure is open, so setting HideCleftPole = ",HideCleftPole)
                                 else:
                                     PtDebugPrint("ERROR: psnlYeeshaPageChanges.OnServerInitComplete():\tProblem trying to access age SDLs for Bahro poles")
                                     pass
@@ -202,7 +202,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                     
                 #There is only one object in Yeesha Page 5 with a value of 0, so I'm temporarily nestling my print statement here...
                 if PageNumber.value == 5 and stringShowStates.value == "0":
-                    print "psnlYeeshaPageChanges: You've found the following Yeesha Pages:"
+                    print("psnlYeeshaPageChanges: You've found the following Yeesha Pages:")
                     for thispage in range(1,TotalPossibleYeeshaPages+1):
                         FoundValue = self.ageSDL.findVar("YeeshaPage" + str(thispage))
                         PtDebugPrint ("\t The previous value of the SDL variable %s is %s" % ("YeeshaPage" + str(thispage), FoundValue.getInt()))
@@ -272,13 +272,13 @@ class psnlYeeshaPageChanges(ptMultiModifier):
         #~ print "No one else is here. Affecting any YP changes you've queued."
         if state == 3:
             state = 2
-            print "psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 3 to 2." % ("YeeshaPage" + str(PageNumber.value))
+            print("psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 3 to 2." % ("YeeshaPage" + str(PageNumber.value)))
             SDLVar.setInt( (size * 10) + state)
             AgeVault.updateAgeSDL(self.ageSDL) 
             
         elif state == 4 or state > 4:
             state = 1
-            print "psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 4 to 1." % ("YeeshaPage" + str(PageNumber.value))
+            print("psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 4 to 1." % ("YeeshaPage" + str(PageNumber.value)))
             SDLVar.setInt( (size * 10) + state)
             AgeVault.updateAgeSDL(self.ageSDL)
         elif sizechanged:

--- a/Python/psnlYeeshaPageChanges.py
+++ b/Python/psnlYeeshaPageChanges.py
@@ -185,7 +185,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                                         val = ageSDL["CleftVisited"][0]
                                         if not val:
                                             HideCleftPole = 1
-                                            print("psnlYeeshaPageChanges.OnServerInitComplete():\t Fissure is open, so setting HideCleftPole = ",HideCleftPole)
+                                            PtDebugPrint("psnlYeeshaPageChanges.OnServerInitComplete():\t Fissure is open, so setting HideCleftPole = ",HideCleftPole)
                                 else:
                                     PtDebugPrint("ERROR: psnlYeeshaPageChanges.OnServerInitComplete():\tProblem trying to access age SDLs for Bahro poles")
                                     pass
@@ -202,7 +202,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                     
                 #There is only one object in Yeesha Page 5 with a value of 0, so I'm temporarily nestling my print statement here...
                 if PageNumber.value == 5 and stringShowStates.value == "0":
-                    print("psnlYeeshaPageChanges: You've found the following Yeesha Pages:")
+                    PtDebugPrint("psnlYeeshaPageChanges: You've found the following Yeesha Pages:")
                     for thispage in range(1,TotalPossibleYeeshaPages+1):
                         FoundValue = self.ageSDL.findVar("YeeshaPage" + str(thispage))
                         PtDebugPrint ("\t The previous value of the SDL variable %s is %s" % ("YeeshaPage" + str(thispage), FoundValue.getInt()))
@@ -269,16 +269,16 @@ class psnlYeeshaPageChanges(ptMultiModifier):
 
 
     def UpdateState(self, state, size, SDLVar, AgeVault, sizechanged):
-        #~ print "No one else is here. Affecting any YP changes you've queued."
+        #~ PtDebugPrint("No one else is here. Affecting any YP changes you've queued.")
         if state == 3:
             state = 2
-            print("psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 3 to 2." % ("YeeshaPage" + str(PageNumber.value)))
+            PtDebugPrint("psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 3 to 2." % ("YeeshaPage" + str(PageNumber.value)))
             SDLVar.setInt( (size * 10) + state)
             AgeVault.updateAgeSDL(self.ageSDL) 
             
         elif state == 4 or state > 4:
             state = 1
-            print("psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 4 to 1." % ("YeeshaPage" + str(PageNumber.value)))
+            PtDebugPrint("psnlYeeshaPageChanges: Updated value of YeeshaPage %s from 4 to 1." % ("YeeshaPage" + str(PageNumber.value)))
             SDLVar.setInt( (size * 10) + state)
             AgeVault.updateAgeSDL(self.ageSDL)
         elif sizechanged:

--- a/Python/stupStartUp.py
+++ b/Python/stupStartUp.py
@@ -62,7 +62,7 @@ class stupStartUp(ptResponder):
         ptResponder.__init__(self)
         self.id = 5339
         self.version = 1
-        print "stupStartUp: init  version = %d" % self.version
+        print("stupStartUp: init  version = %d" % self.version)
 
     ###########################
     def OnFirstUpdate(self):

--- a/Python/stupStartUp.py
+++ b/Python/stupStartUp.py
@@ -62,7 +62,7 @@ class stupStartUp(ptResponder):
         ptResponder.__init__(self)
         self.id = 5339
         self.version = 1
-        print("stupStartUp: init  version = %d" % self.version)
+        PtDebugPrint("stupStartUp: init  version = %d" % self.version)
 
     ###########################
     def OnFirstUpdate(self):

--- a/Python/tldnAquarium.py
+++ b/Python/tldnAquarium.py
@@ -90,9 +90,9 @@ class tldnAquarium(ptResponder):
     def __del__(self):
         global gFirstPersonOverriden
 
-        print "tldnAquarium. __del__"
+        print("tldnAquarium. __del__")
         if gFirstPersonOverriden:
-            print "tldnAquarium: enable override again, before they leave"
+            print("tldnAquarium: enable override again, before they leave")
             ptCamera().enableFirstPersonOverride()
             gFirstPersonOverriden = 0
             PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
@@ -101,9 +101,9 @@ class tldnAquarium(ptResponder):
     def BeginAgeUnLoad(self,avatar):
         global gFirstPersonOverriden
 
-        print "tldnAquarium. age unload - last chance"
+        print("tldnAquarium. age unload - last chance")
         if gFirstPersonOverriden:
-            print "tldnAquarium: enable override again, before they leave"
+            print("tldnAquarium: enable override again, before they leave")
             ptCamera().enableFirstPersonOverride()
             gFirstPersonOverriden = 0
             PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
@@ -113,9 +113,9 @@ class tldnAquarium(ptResponder):
         global gFirstPersonOverriden
 
         if type == PtBehaviorTypes.kBehaviorTypeLinkOut:
-            print "tldnAquarium: OnBehaviorNotify",type,avatar,state
+            print("tldnAquarium: OnBehaviorNotify",type,avatar,state)
             if gFirstPersonOverriden:
-                print "tldnAquarium: enable override again, before they leave"
+                print("tldnAquarium: enable override again, before they leave")
                 ptCamera().enableFirstPersonOverride()
                 gFirstPersonOverriden = 0
                 PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
@@ -146,8 +146,8 @@ class tldnAquarium(ptResponder):
             except:
                 tankOpen = False
                 tankLightOn = False
-                print "tldnAquarium.OnServerInitComplete(): ERROR: age sdl read failed, defaulting:"
-            print "tldnAquarium.OnServerInitComplete(): %s = %d, %s = %d" % (kStringAgeSDLAquariumOpen,tankOpen,kStringAgeSDLAquariumLightOn,tankLightOn)
+                print("tldnAquarium.OnServerInitComplete(): ERROR: age sdl read failed, defaulting:")
+            print("tldnAquarium.OnServerInitComplete(): %s = %d, %s = %d" % (kStringAgeSDLAquariumOpen,tankOpen,kStringAgeSDLAquariumLightOn,tankLightOn))
 
             # init whatnots
             if tankLightOn:
@@ -171,7 +171,7 @@ class tldnAquarium(ptResponder):
         
         if gAgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            print "tldnAquarium.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%d, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID)
+            print("tldnAquarium.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%d, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
             
             if VARname == kStringAgeSDLAquariumLightOn:
                 if ageSDL[kStringAgeSDLAquariumLightOn][0]:
@@ -196,12 +196,12 @@ class tldnAquarium(ptResponder):
         global gFirstPersonOverriden
         global gAllowClick
 
-        print "-------------------------------------------------------------------------"
-        print "tldnAquarium: OnNotify - id=%d state=%d events=" % (id,state),events
+        print("-------------------------------------------------------------------------")
+        print("tldnAquarium: OnNotify - id=%d state=%d events=" % (id,state),events)
 
         if id == actBookClick.id:
             # only know about this activator to handle enabling/disabling it
-            print "tldnAquarium: actBookClick state=%d events=" % (state),events
+            print("tldnAquarium: actBookClick state=%d events=" % (state),events)
 
         elif id == rgnAquarium.id:
             for event in events:
@@ -209,29 +209,29 @@ class tldnAquarium(ptResponder):
                     try:
                         if event[2] == PtGetLocalAvatar():
                             if event[1] == 1:
-                                print "tldnAquarium: enter region"
+                                print("tldnAquarium: enter region")
                                 ptCamera().undoFirstPerson()
                                 ptCamera().disableFirstPersonOverride()
                                 gFirstPersonOverriden = 1
                                 PtGetLocalAvatar().avatar.registerForBehaviorNotify(self.key)
                             else:
-                                print "tldnAquarium: exit region"
+                                print("tldnAquarium: exit region")
                                 ptCamera().enableFirstPersonOverride()
                                 PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
                                 gFirstPersonOverriden = 0
                         else:
-                            print "tldnAquarium: region: not local avatar"
+                            print("tldnAquarium: region: not local avatar")
                     except NameError:
-                        print "tldnAquarium: no more local avatar to see if in region"
+                        print("tldnAquarium: no more local avatar to see if in region")
 
         elif id == actButton.id:
             for event in events:
                 if event[0] == 2 and event[1] == 1:
                     #true as button pressed
                     if gMouseDown == 1:
-                        print "tldnAquarium: The Tim factor! - two down presses... ignoring"
+                        print("tldnAquarium: The Tim factor! - two down presses... ignoring")
                     elif gAllowClick:
-                        print "tldnAquarium: Button pressed"
+                        print("tldnAquarium: Button pressed")
                         gAllowClick = 0
                         gMouseDown = 1
                         gWasClicked = 0
@@ -241,7 +241,7 @@ class tldnAquarium(ptResponder):
                             self.IButtonPress()
                 elif event[0] == 2 and event[1] == 0:
                     #true as button released
-                    print "tldnAquarium: Button Released"
+                    print("tldnAquarium: Button Released")
                     gMouseDown = 0
                     gLocalAvatar = PtFindAvatar(events)
                     if gWasClicked and gLocalAvatar == PtGetLocalAvatar():
@@ -251,27 +251,27 @@ class tldnAquarium(ptResponder):
             for event in events:
                 if event[0] == 10 and event[1] == 1 and event[2] == kAdvanceNextStage:
                     #true as multistage progresses from stage 1 (1 second "hold behavior" looping 3 times) to stage 2 (the same 1 second "hold behavior", but looping indefinitely)
-                    print "tldnAquarium: Button held for 3 seconds"
+                    print("tldnAquarium: Button held for 3 seconds")
                     gHeldForThree = 1
                 elif event[0] == 10 and event[1] == 0 and event[2] == kAdvanceNextStage:
                     #checks to circumvent "click bug". True as avatar finishes "press" behavior. If mouse no longer down, then release
                     SFXbuttonpress.run(self.key)
                     gWasClicked = 1
                     if not gMouseDown:
-                        print "tldnAquarium: Quick Click!"
+                        print("tldnAquarium: Quick Click!")
                         self.IButtonRelease()
                     else:
-                        print "tldnAquarium: still holding... next stage"
+                        print("tldnAquarium: still holding... next stage")
                         Behavior.gotoStage(gLocalAvatar,1)
 
         else:
-            print "tldnAquarium: something else triggered a callback (id=%d)" % (id)
+            print("tldnAquarium: something else triggered a callback (id=%d)" % (id))
 
     ###########################
     def IButtonPress(self):
         global gLocalAvatar
 
-        print "tldnAquarium: Play PRESS Oneshot"
+        print("tldnAquarium: Play PRESS Oneshot")
         Behavior.run(gLocalAvatar)
 
     ###########################
@@ -283,7 +283,7 @@ class tldnAquarium(ptResponder):
 
         if gAgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            print "tldnAquarium: Play RELEASE Oneshot"
+            print("tldnAquarium: Play RELEASE Oneshot")
             Behavior.gotoStage(gLocalAvatar,3)
             SFXbuttonrelease.run(self.key)
             gAllowClick = 1
@@ -292,20 +292,20 @@ class tldnAquarium(ptResponder):
 
             #if button was held for more than 3 seconds, toggle sheath
             if gHeldForThree == 1:
-                print "tldnAquarium: Button was held for 3 seconds"
+                print("tldnAquarium: Button was held for 3 seconds")
                 gHeldForThree == 0  #reset held flag
                 if ageSDL[kStringAgeSDLAquariumOpen][0]:
-                    print "tldnAquarium: close aquarium"
+                    print("tldnAquarium: close aquarium")
                     ageSDL[kStringAgeSDLAquariumOpen] = (0,)                
                 else:
-                    print "tldnAquarium: open aquarium"
+                    print("tldnAquarium: open aquarium")
                     ageSDL[kStringAgeSDLAquariumOpen] = (1,)   
                     
             #if button not held for 3 seconds, toggle the light
             else:
                 if ageSDL[kStringAgeSDLAquariumLightOn][0]:
-                    print "tldnAquarium: turn tank light off"
+                    print("tldnAquarium: turn tank light off")
                     ageSDL[kStringAgeSDLAquariumLightOn] = (0,)                
                 else:
-                    print "tldnAquarium: turn tank light on"
+                    print("tldnAquarium: turn tank light on")
                     ageSDL[kStringAgeSDLAquariumLightOn] = (1,)

--- a/Python/tldnAquarium.py
+++ b/Python/tldnAquarium.py
@@ -90,9 +90,9 @@ class tldnAquarium(ptResponder):
     def __del__(self):
         global gFirstPersonOverriden
 
-        print("tldnAquarium. __del__")
+        PtDebugPrint("tldnAquarium. __del__")
         if gFirstPersonOverriden:
-            print("tldnAquarium: enable override again, before they leave")
+            PtDebugPrint("tldnAquarium: enable override again, before they leave")
             ptCamera().enableFirstPersonOverride()
             gFirstPersonOverriden = 0
             PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
@@ -101,9 +101,9 @@ class tldnAquarium(ptResponder):
     def BeginAgeUnLoad(self,avatar):
         global gFirstPersonOverriden
 
-        print("tldnAquarium. age unload - last chance")
+        PtDebugPrint("tldnAquarium. age unload - last chance")
         if gFirstPersonOverriden:
-            print("tldnAquarium: enable override again, before they leave")
+            PtDebugPrint("tldnAquarium: enable override again, before they leave")
             ptCamera().enableFirstPersonOverride()
             gFirstPersonOverriden = 0
             PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
@@ -113,9 +113,9 @@ class tldnAquarium(ptResponder):
         global gFirstPersonOverriden
 
         if type == PtBehaviorTypes.kBehaviorTypeLinkOut:
-            print("tldnAquarium: OnBehaviorNotify",type,avatar,state)
+            PtDebugPrint("tldnAquarium: OnBehaviorNotify",type,avatar,state)
             if gFirstPersonOverriden:
-                print("tldnAquarium: enable override again, before they leave")
+                PtDebugPrint("tldnAquarium: enable override again, before they leave")
                 ptCamera().enableFirstPersonOverride()
                 gFirstPersonOverriden = 0
                 PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
@@ -146,8 +146,8 @@ class tldnAquarium(ptResponder):
             except:
                 tankOpen = False
                 tankLightOn = False
-                print("tldnAquarium.OnServerInitComplete(): ERROR: age sdl read failed, defaulting:")
-            print("tldnAquarium.OnServerInitComplete(): %s = %d, %s = %d" % (kStringAgeSDLAquariumOpen,tankOpen,kStringAgeSDLAquariumLightOn,tankLightOn))
+                PtDebugPrint("tldnAquarium.OnServerInitComplete(): ERROR: age sdl read failed, defaulting:")
+            PtDebugPrint("tldnAquarium.OnServerInitComplete(): %s = %d, %s = %d" % (kStringAgeSDLAquariumOpen,tankOpen,kStringAgeSDLAquariumLightOn,tankLightOn))
 
             # init whatnots
             if tankLightOn:
@@ -171,7 +171,7 @@ class tldnAquarium(ptResponder):
         
         if gAgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            print("tldnAquarium.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%d, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
+            PtDebugPrint("tldnAquarium.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%d, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
             
             if VARname == kStringAgeSDLAquariumLightOn:
                 if ageSDL[kStringAgeSDLAquariumLightOn][0]:
@@ -196,12 +196,12 @@ class tldnAquarium(ptResponder):
         global gFirstPersonOverriden
         global gAllowClick
 
-        print("-------------------------------------------------------------------------")
-        print("tldnAquarium: OnNotify - id=%d state=%d events=" % (id,state),events)
+        PtDebugPrint("-------------------------------------------------------------------------")
+        PtDebugPrint("tldnAquarium: OnNotify - id=%d state=%d events=" % (id,state),events)
 
         if id == actBookClick.id:
             # only know about this activator to handle enabling/disabling it
-            print("tldnAquarium: actBookClick state=%d events=" % (state),events)
+            PtDebugPrint("tldnAquarium: actBookClick state=%d events=" % (state),events)
 
         elif id == rgnAquarium.id:
             for event in events:
@@ -209,29 +209,29 @@ class tldnAquarium(ptResponder):
                     try:
                         if event[2] == PtGetLocalAvatar():
                             if event[1] == 1:
-                                print("tldnAquarium: enter region")
+                                PtDebugPrint("tldnAquarium: enter region")
                                 ptCamera().undoFirstPerson()
                                 ptCamera().disableFirstPersonOverride()
                                 gFirstPersonOverriden = 1
                                 PtGetLocalAvatar().avatar.registerForBehaviorNotify(self.key)
                             else:
-                                print("tldnAquarium: exit region")
+                                PtDebugPrint("tldnAquarium: exit region")
                                 ptCamera().enableFirstPersonOverride()
                                 PtGetLocalAvatar().avatar.unRegisterForBehaviorNotify(self.key)
                                 gFirstPersonOverriden = 0
                         else:
-                            print("tldnAquarium: region: not local avatar")
+                            PtDebugPrint("tldnAquarium: region: not local avatar")
                     except NameError:
-                        print("tldnAquarium: no more local avatar to see if in region")
+                        PtDebugPrint("tldnAquarium: no more local avatar to see if in region")
 
         elif id == actButton.id:
             for event in events:
                 if event[0] == 2 and event[1] == 1:
                     #true as button pressed
                     if gMouseDown == 1:
-                        print("tldnAquarium: The Tim factor! - two down presses... ignoring")
+                        PtDebugPrint("tldnAquarium: The Tim factor! - two down presses... ignoring")
                     elif gAllowClick:
-                        print("tldnAquarium: Button pressed")
+                        PtDebugPrint("tldnAquarium: Button pressed")
                         gAllowClick = 0
                         gMouseDown = 1
                         gWasClicked = 0
@@ -241,7 +241,7 @@ class tldnAquarium(ptResponder):
                             self.IButtonPress()
                 elif event[0] == 2 and event[1] == 0:
                     #true as button released
-                    print("tldnAquarium: Button Released")
+                    PtDebugPrint("tldnAquarium: Button Released")
                     gMouseDown = 0
                     gLocalAvatar = PtFindAvatar(events)
                     if gWasClicked and gLocalAvatar == PtGetLocalAvatar():
@@ -251,27 +251,27 @@ class tldnAquarium(ptResponder):
             for event in events:
                 if event[0] == 10 and event[1] == 1 and event[2] == kAdvanceNextStage:
                     #true as multistage progresses from stage 1 (1 second "hold behavior" looping 3 times) to stage 2 (the same 1 second "hold behavior", but looping indefinitely)
-                    print("tldnAquarium: Button held for 3 seconds")
+                    PtDebugPrint("tldnAquarium: Button held for 3 seconds")
                     gHeldForThree = 1
                 elif event[0] == 10 and event[1] == 0 and event[2] == kAdvanceNextStage:
                     #checks to circumvent "click bug". True as avatar finishes "press" behavior. If mouse no longer down, then release
                     SFXbuttonpress.run(self.key)
                     gWasClicked = 1
                     if not gMouseDown:
-                        print("tldnAquarium: Quick Click!")
+                        PtDebugPrint("tldnAquarium: Quick Click!")
                         self.IButtonRelease()
                     else:
-                        print("tldnAquarium: still holding... next stage")
+                        PtDebugPrint("tldnAquarium: still holding... next stage")
                         Behavior.gotoStage(gLocalAvatar,1)
 
         else:
-            print("tldnAquarium: something else triggered a callback (id=%d)" % (id))
+            PtDebugPrint("tldnAquarium: something else triggered a callback (id=%d)" % (id))
 
     ###########################
     def IButtonPress(self):
         global gLocalAvatar
 
-        print("tldnAquarium: Play PRESS Oneshot")
+        PtDebugPrint("tldnAquarium: Play PRESS Oneshot")
         Behavior.run(gLocalAvatar)
 
     ###########################
@@ -283,7 +283,7 @@ class tldnAquarium(ptResponder):
 
         if gAgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            print("tldnAquarium: Play RELEASE Oneshot")
+            PtDebugPrint("tldnAquarium: Play RELEASE Oneshot")
             Behavior.gotoStage(gLocalAvatar,3)
             SFXbuttonrelease.run(self.key)
             gAllowClick = 1
@@ -292,20 +292,20 @@ class tldnAquarium(ptResponder):
 
             #if button was held for more than 3 seconds, toggle sheath
             if gHeldForThree == 1:
-                print("tldnAquarium: Button was held for 3 seconds")
+                PtDebugPrint("tldnAquarium: Button was held for 3 seconds")
                 gHeldForThree == 0  #reset held flag
                 if ageSDL[kStringAgeSDLAquariumOpen][0]:
-                    print("tldnAquarium: close aquarium")
+                    PtDebugPrint("tldnAquarium: close aquarium")
                     ageSDL[kStringAgeSDLAquariumOpen] = (0,)                
                 else:
-                    print("tldnAquarium: open aquarium")
+                    PtDebugPrint("tldnAquarium: open aquarium")
                     ageSDL[kStringAgeSDLAquariumOpen] = (1,)   
                     
             #if button not held for 3 seconds, toggle the light
             else:
                 if ageSDL[kStringAgeSDLAquariumLightOn][0]:
-                    print("tldnAquarium: turn tank light off")
+                    PtDebugPrint("tldnAquarium: turn tank light off")
                     ageSDL[kStringAgeSDLAquariumLightOn] = (0,)                
                 else:
-                    print("tldnAquarium: turn tank light on")
+                    PtDebugPrint("tldnAquarium: turn tank light on")
                     ageSDL[kStringAgeSDLAquariumLightOn] = (1,)

--- a/Python/tldnBucketBrain.py
+++ b/Python/tldnBucketBrain.py
@@ -206,7 +206,7 @@ class tldnBucketBrain(ptResponder):
             # loading cause I just joined age and there's no one else here so...clear out any phantom riders
             PtDebugPrint("tldnBucketBrain.OnServerInitComplete():\tRe-initializing age as I'm the only one here!",level=kDebugDumpLevel)
             ageSDL[kStringAgeSDLRiders] = (-1,-1,-1,-1)
-            print "Tye: Resetting avatar at entry!"
+            print("Tye: Resetting avatar at entry!")
             avaIDAtEntry = -1
 
             #If we're creating a brand new age we need to intialize this variable.  Since it's not done by default,
@@ -268,7 +268,7 @@ class tldnBucketBrain(ptResponder):
             #Now we can setup the activators as necessary....
             if bucketAtEntry  < 0:
                 #The bucket is not at the entry point!
-                print "Tye: Resetting avatar at entry!"
+                print("Tye: Resetting avatar at entry!")
                 avaIDAtEntry = -1
 
                 #Normally we'd disable the enter activators, but for safety's sake, we disabled them earlier
@@ -277,7 +277,7 @@ class tldnBucketBrain(ptResponder):
             elif riders[bucketAtEntry] < 0:  
                 #The bucket is empty and ready to accept a rider.
                 avaIDAtEntry = -1
-                print "Tye: Resetting avatar at entry!"
+                print("Tye: Resetting avatar at entry!")
                 
                 #Enable the enter activators
                 PtDebugPrint("tldnBucketBrain.OnServerInit():\tEnabling the bucket enter activators!",level=kDebugDumpLevel)
@@ -386,7 +386,7 @@ class tldnBucketBrain(ptResponder):
         for rider in riders:
             if rider == avaID:
                 avaIDAtEntry = -1
-                print "Tye: Resetting avatar at entry!"
+                print("Tye: Resetting avatar at entry!")
                 PtDebugPrint("tldnBucketBrain.AvatarPage():\tbucket rider left age, pruning bucket rider list",level=kDebugDumpLevel)
                 rider = -1
 

--- a/Python/tldnBucketBrain.py
+++ b/Python/tldnBucketBrain.py
@@ -206,7 +206,7 @@ class tldnBucketBrain(ptResponder):
             # loading cause I just joined age and there's no one else here so...clear out any phantom riders
             PtDebugPrint("tldnBucketBrain.OnServerInitComplete():\tRe-initializing age as I'm the only one here!",level=kDebugDumpLevel)
             ageSDL[kStringAgeSDLRiders] = (-1,-1,-1,-1)
-            print("Tye: Resetting avatar at entry!")
+            PtDebugPrint("Tye: Resetting avatar at entry!")
             avaIDAtEntry = -1
 
             #If we're creating a brand new age we need to intialize this variable.  Since it's not done by default,
@@ -268,7 +268,7 @@ class tldnBucketBrain(ptResponder):
             #Now we can setup the activators as necessary....
             if bucketAtEntry  < 0:
                 #The bucket is not at the entry point!
-                print("Tye: Resetting avatar at entry!")
+                PtDebugPrint("Tye: Resetting avatar at entry!")
                 avaIDAtEntry = -1
 
                 #Normally we'd disable the enter activators, but for safety's sake, we disabled them earlier
@@ -277,7 +277,7 @@ class tldnBucketBrain(ptResponder):
             elif riders[bucketAtEntry] < 0:  
                 #The bucket is empty and ready to accept a rider.
                 avaIDAtEntry = -1
-                print("Tye: Resetting avatar at entry!")
+                PtDebugPrint("Tye: Resetting avatar at entry!")
                 
                 #Enable the enter activators
                 PtDebugPrint("tldnBucketBrain.OnServerInit():\tEnabling the bucket enter activators!",level=kDebugDumpLevel)
@@ -386,7 +386,7 @@ class tldnBucketBrain(ptResponder):
         for rider in riders:
             if rider == avaID:
                 avaIDAtEntry = -1
-                print("Tye: Resetting avatar at entry!")
+                PtDebugPrint("Tye: Resetting avatar at entry!")
                 PtDebugPrint("tldnBucketBrain.AvatarPage():\tbucket rider left age, pruning bucket rider list",level=kDebugDumpLevel)
                 rider = -1
 

--- a/Python/tldnEmgrPhase0.py
+++ b/Python/tldnEmgrPhase0.py
@@ -82,7 +82,7 @@ class tldnEmgrPhase0(ptResponder):
 
         version = 3
         self.version = version
-        print("__init__tldnEmgrPhase0 v.", version)
+        PtDebugPrint("__init__tldnEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -92,12 +92,12 @@ class tldnEmgrPhase0(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             for variable in BooleanVARs:
-                #~ print "Tying together BOOL variable", variable
+                #~ PtDebugPrint("Tying together BOOL variable", variable)
                 ageSDL.setNotify(self.key,variable,0.0)
                 self.IManageBOOLs(variable, "")
                 
             for variable in StateVARs:
-                #~ print "Tying together INT", variable
+                #~ PtDebugPrint("Tying together INT", variable)
                 ageSDL.setNotify(self.key,variable,0.0)   
                 StateVARs[variable](variable, ageSDL[variable][0])
        
@@ -110,7 +110,7 @@ class tldnEmgrPhase0(ptResponder):
             PtDebugPrint("tldnEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
             
             if VARname in BooleanVARs:
-                print("tldnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
+                PtDebugPrint("tldnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
                 self.IManageBOOLs(VARname,SDLname)
     
             elif VARname in StateVARs.viewkeys():
@@ -131,7 +131,7 @@ class tldnEmgrPhase0(ptResponder):
                 PtDebugPrint("tldnEmgrPhase0.OnSDLNotify:\tPaging in room %s" % (VARname))
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print("variable = ", VARname)
+                PtDebugPrint("variable = ", VARname)
                 PtDebugPrint("tldnEmgrPhase0.OnSDLNotify:\tPaging out room %s" % (VARname))
                 PtPageOutNode(VARname)
             else:

--- a/Python/tldnEmgrPhase0.py
+++ b/Python/tldnEmgrPhase0.py
@@ -82,7 +82,7 @@ class tldnEmgrPhase0(ptResponder):
 
         version = 3
         self.version = version
-        print "__init__tldnEmgrPhase0 v.", version
+        print("__init__tldnEmgrPhase0 v.", version)
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -110,7 +110,7 @@ class tldnEmgrPhase0(ptResponder):
             PtDebugPrint("tldnEmgrPhase0.SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
             
             if VARname in BooleanVARs:
-                print "tldnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname)
+                print("tldnEmgrPhase0.OnSDLNotify : %s is a BOOLEAN Variable" % (VARname))
                 self.IManageBOOLs(VARname,SDLname)
     
             elif VARname in StateVARs.viewkeys():
@@ -131,7 +131,7 @@ class tldnEmgrPhase0(ptResponder):
                 PtDebugPrint("tldnEmgrPhase0.OnSDLNotify:\tPaging in room %s" % (VARname))
                 PtPageInNode(VARname)
             elif ageSDL[VARname][0] == 0:  #are we paging things out?
-                print "variable = ", VARname
+                print("variable = ", VARname)
                 PtDebugPrint("tldnEmgrPhase0.OnSDLNotify:\tPaging out room %s" % (VARname))
                 PtPageOutNode(VARname)
             else:

--- a/Python/tldnHatchLadderBottom.py
+++ b/Python/tldnHatchLadderBottom.py
@@ -134,15 +134,15 @@ class tldnHatchLadderBottom(ptModifier):
                 if PtFindAvatar(events) == LocalAvatar:
                     if event[2] == kAdvanceNextStage:
                         stageNum = event[1]
-                        print "Got stage advance callback from stage %d" % stageNum
+                        print("Got stage advance callback from stage %d" % stageNum)
                         if stageNum == 1:
-                            print "In stage 2, negotiating hatch."
+                            print("In stage 2, negotiating hatch.")
                             self.INegotiateHatch();
                         elif stageNum == 2:
                             # after the "it's locked" anim, return to the climb...
                             Climber.gotoStage(LocalAvatar, 1,0,0)
                         elif stageNum == 2 or stageNum == 3 or stageNum == 5:
-                            print "Got through hatch: finishing & removing brain."
+                            print("Got through hatch: finishing & removing brain.")
                             Climber.gotoStage(LocalAvatar, -1)
     
     def INegotiateHatch(self):
@@ -150,7 +150,7 @@ class tldnHatchLadderBottom(ptModifier):
         global hatchOpen
         global hatchLocked
         
-        print "Negotiating hatch"
+        print("Negotiating hatch")
         if hatchOpen:
             self.IHatchOpen()
         else:
@@ -162,14 +162,14 @@ class tldnHatchLadderBottom(ptModifier):
     def IHatchLocked(self):
         "Hatch is locked; show the frustrated animation and return to previous stage"
         global LocalAvatar
-        print "Hatch is locked; Sending gotoStage(2)"
+        print("Hatch is locked; Sending gotoStage(2)")
         respHatchOps.run(self.key,state='lockedbelow')
         Climber.gotoStage(LocalAvatar,2,0,1)
 
     def IHatchUnlocked(self):
         "Hatch is unlocked; open it and pass through."
         global LocalAvatar
-        print "Hatch is unlocked; Sending gotoStage(3)"
+        print("Hatch is unlocked; Sending gotoStage(3)")
         respHatchOps.run(self.key,state='openbelow')
         Climber.gotoStage(LocalAvatar,3,0,0)
         hatchOpen = 1
@@ -180,5 +180,5 @@ class tldnHatchLadderBottom(ptModifier):
     def IHatchOpen(self):
         "Hatch is open; just climb through."
         global LocalAvatar
-        print "Hatch is open; Sending gotoStage(4)"
+        print("Hatch is open; Sending gotoStage(4)")
         Climber.gotoStage(LocalAvatar,4,0,0)

--- a/Python/tldnHatchLadderBottom.py
+++ b/Python/tldnHatchLadderBottom.py
@@ -119,7 +119,7 @@ class tldnHatchLadderBottom(ptModifier):
     def OnNotify(self,state,id,events):
         global LocalAvatar
         
-        # print "tldnHatchLadderBottom:OnNotify  state=%f id=%d events=" % (state,id),events
+        # PtDebugPrint("tldnHatchLadderBottom:OnNotify  state=%f id=%d events=" % (state,id),events)
         if state:
             if id == ActStart.id and PtWasLocallyNotified(self.key):
                 LocalAvatar = PtFindAvatar(events)
@@ -134,15 +134,15 @@ class tldnHatchLadderBottom(ptModifier):
                 if PtFindAvatar(events) == LocalAvatar:
                     if event[2] == kAdvanceNextStage:
                         stageNum = event[1]
-                        print("Got stage advance callback from stage %d" % stageNum)
+                        PtDebugPrint("Got stage advance callback from stage %d" % stageNum)
                         if stageNum == 1:
-                            print("In stage 2, negotiating hatch.")
+                            PtDebugPrint("In stage 2, negotiating hatch.")
                             self.INegotiateHatch();
                         elif stageNum == 2:
                             # after the "it's locked" anim, return to the climb...
                             Climber.gotoStage(LocalAvatar, 1,0,0)
                         elif stageNum == 2 or stageNum == 3 or stageNum == 5:
-                            print("Got through hatch: finishing & removing brain.")
+                            PtDebugPrint("Got through hatch: finishing & removing brain.")
                             Climber.gotoStage(LocalAvatar, -1)
     
     def INegotiateHatch(self):
@@ -150,7 +150,7 @@ class tldnHatchLadderBottom(ptModifier):
         global hatchOpen
         global hatchLocked
         
-        print("Negotiating hatch")
+        PtDebugPrint("Negotiating hatch")
         if hatchOpen:
             self.IHatchOpen()
         else:
@@ -162,14 +162,14 @@ class tldnHatchLadderBottom(ptModifier):
     def IHatchLocked(self):
         "Hatch is locked; show the frustrated animation and return to previous stage"
         global LocalAvatar
-        print("Hatch is locked; Sending gotoStage(2)")
+        PtDebugPrint("Hatch is locked; Sending gotoStage(2)")
         respHatchOps.run(self.key,state='lockedbelow')
         Climber.gotoStage(LocalAvatar,2,0,1)
 
     def IHatchUnlocked(self):
         "Hatch is unlocked; open it and pass through."
         global LocalAvatar
-        print("Hatch is unlocked; Sending gotoStage(3)")
+        PtDebugPrint("Hatch is unlocked; Sending gotoStage(3)")
         respHatchOps.run(self.key,state='openbelow')
         Climber.gotoStage(LocalAvatar,3,0,0)
         hatchOpen = 1
@@ -180,5 +180,5 @@ class tldnHatchLadderBottom(ptModifier):
     def IHatchOpen(self):
         "Hatch is open; just climb through."
         global LocalAvatar
-        print("Hatch is open; Sending gotoStage(4)")
+        PtDebugPrint("Hatch is open; Sending gotoStage(4)")
         Climber.gotoStage(LocalAvatar,4,0,0)

--- a/Python/tldnHatchLadderTop.py
+++ b/Python/tldnHatchLadderTop.py
@@ -140,15 +140,15 @@ class tldnHatchLadderTop(ptModifier):
         global HatchState
         global cabinDrained
 
-        print " "
-        print "-------------------------------------------------------------------------------------------"
-        print " "
-        print "tldnHatchLadderTop:OnNotify  state=%d id=%d events=" % (state,id),events
+        print(" ")
+        print("-------------------------------------------------------------------------------------------")
+        print(" ")
+        print("tldnHatchLadderTop:OnNotify  state=%d id=%d events=" % (state,id),events)
 
         if id == ActStart.id and state:
             ClimbingAvatar = PtFindAvatar(events)
             if ClimbingAvatar == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                print "Starting climb behavior"
+                print("Starting climb behavior")
                 Climber.run(ClimbingAvatar)
             return
 
@@ -170,35 +170,35 @@ class tldnHatchLadderTop(ptModifier):
                         return
                     if PtFindAvatar(events) == ClimbingAvatar:
                         stageNum = event[1]
-                        print "tldnHatchLadderTop: message from multistage %i" % stageNum
+                        print("tldnHatchLadderTop: message from multistage %i" % stageNum)
                         if event[2] == kRegressPrevStage and (stageNum == 2 or stageNum == 6):
-                            print "tldnHatchLadderTop: Got stage Regress callback from stage %d" % stageNum
+                            print("tldnHatchLadderTop: Got stage Regress callback from stage %d" % stageNum)
                             self.INegotiateHatch()
                         elif event[2] == kAdvanceNextStage:
                             if stageNum == 1:
-                                print "tldnHatchLadderTop: checking drained"
+                                print("tldnHatchLadderTop: checking drained")
                                 if not cabinDrained:
                                     Climber.gotoStage(ClimbingAvatar, 6, 0, 0);                            
-                                    print "tldnHatchLadderTop: water not drained"
+                                    print("tldnHatchLadderTop: water not drained")
                             if stageNum == 4:
                                 if not cabinDrained:
                                     Climber.gotoStage(ClimbingAvatar, 6, dirFlag=1, isForward=1)
                                 else:
                                     Climber.gotoStage(ClimbingAvatar, 2, dirFlag=1, isForward=1)
-                                print "tldnHatchLadderTop: now stage 2/6 again"
+                                print("tldnHatchLadderTop: now stage 2/6 again")
                             elif stageNum == 5:
-                                print "tldnHatchLadderTop: Got through hatch: finishing & removing brain."
+                                print("tldnHatchLadderTop: Got through hatch: finishing & removing brain.")
                                 Climber.gotoStage(ClimbingAvatar, -1)
                                 #ActStart.enable()
                             elif stageNum == 3:
-                                print "tldnHatchLadderTop: done with bottom"
+                                print("tldnHatchLadderTop: done with bottom")
                                 Climber.gotoStage(ClimbingAvatar, -1)
 
     def INegotiateHatch(self):
         global hatchOpen
         global hatchLocked
         
-        print "tldnHatchLadderTop: Negotiating hatch"
+        print("tldnHatchLadderTop: Negotiating hatch")
         if hatchOpen:
             self.IHatchOpen()
         else:
@@ -210,7 +210,7 @@ class tldnHatchLadderTop(ptModifier):
     def IHatchLocked(self):
         global ClimbingAvatar
 
-        print "tldnHatchLadderTop: Hatch is locked; Sending gotoStage(4)"
+        print("tldnHatchLadderTop: Hatch is locked; Sending gotoStage(4)")
         Climber.gotoStage(ClimbingAvatar, 4, dirFlag=1, isForward=1, setTimeFlag=1, newTime=0.0)
         respHatchOps.run(self.key,state='lockedbelow')
 
@@ -218,7 +218,7 @@ class tldnHatchLadderTop(ptModifier):
         global ClimbingAvatar
         global hatchOpen
         
-        print "tldnHatchLadderTop: Hatch is unlocked; Sending gotoStage(5)"
+        print("tldnHatchLadderTop: Hatch is unlocked; Sending gotoStage(5)")
         Climber.gotoStage(ClimbingAvatar, 5, dirFlag=1, isForward=1, setTimeFlag=1, newTime=0.0)
         respHatchOps.run(self.key,state='openbelow')        
         hatchOpen = 1
@@ -229,5 +229,5 @@ class tldnHatchLadderTop(ptModifier):
     def IHatchOpen(self):
         global ClimbingAvatar
 
-        print "tldnHatchLadderTop: Hatch is open; Sending gotoStage(1)"
+        print("tldnHatchLadderTop: Hatch is open; Sending gotoStage(1)")
         Climber.gotoStage(ClimbingAvatar, 1, setTimeFlag=1, newTime=1.2)

--- a/Python/tldnHatchLadderTop.py
+++ b/Python/tldnHatchLadderTop.py
@@ -140,15 +140,15 @@ class tldnHatchLadderTop(ptModifier):
         global HatchState
         global cabinDrained
 
-        print(" ")
-        print("-------------------------------------------------------------------------------------------")
-        print(" ")
-        print("tldnHatchLadderTop:OnNotify  state=%d id=%d events=" % (state,id),events)
+        PtDebugPrint(" ")
+        PtDebugPrint("-------------------------------------------------------------------------------------------")
+        PtDebugPrint(" ")
+        PtDebugPrint("tldnHatchLadderTop:OnNotify  state=%d id=%d events=" % (state,id),events)
 
         if id == ActStart.id and state:
             ClimbingAvatar = PtFindAvatar(events)
             if ClimbingAvatar == PtGetLocalAvatar() and PtWasLocallyNotified(self.key):
-                print("Starting climb behavior")
+                PtDebugPrint("Starting climb behavior")
                 Climber.run(ClimbingAvatar)
             return
 
@@ -170,35 +170,35 @@ class tldnHatchLadderTop(ptModifier):
                         return
                     if PtFindAvatar(events) == ClimbingAvatar:
                         stageNum = event[1]
-                        print("tldnHatchLadderTop: message from multistage %i" % stageNum)
+                        PtDebugPrint("tldnHatchLadderTop: message from multistage %i" % stageNum)
                         if event[2] == kRegressPrevStage and (stageNum == 2 or stageNum == 6):
-                            print("tldnHatchLadderTop: Got stage Regress callback from stage %d" % stageNum)
+                            PtDebugPrint("tldnHatchLadderTop: Got stage Regress callback from stage %d" % stageNum)
                             self.INegotiateHatch()
                         elif event[2] == kAdvanceNextStage:
                             if stageNum == 1:
-                                print("tldnHatchLadderTop: checking drained")
+                                PtDebugPrint("tldnHatchLadderTop: checking drained")
                                 if not cabinDrained:
                                     Climber.gotoStage(ClimbingAvatar, 6, 0, 0);                            
-                                    print("tldnHatchLadderTop: water not drained")
+                                    PtDebugPrint("tldnHatchLadderTop: water not drained")
                             if stageNum == 4:
                                 if not cabinDrained:
                                     Climber.gotoStage(ClimbingAvatar, 6, dirFlag=1, isForward=1)
                                 else:
                                     Climber.gotoStage(ClimbingAvatar, 2, dirFlag=1, isForward=1)
-                                print("tldnHatchLadderTop: now stage 2/6 again")
+                                PtDebugPrint("tldnHatchLadderTop: now stage 2/6 again")
                             elif stageNum == 5:
-                                print("tldnHatchLadderTop: Got through hatch: finishing & removing brain.")
+                                PtDebugPrint("tldnHatchLadderTop: Got through hatch: finishing & removing brain.")
                                 Climber.gotoStage(ClimbingAvatar, -1)
                                 #ActStart.enable()
                             elif stageNum == 3:
-                                print("tldnHatchLadderTop: done with bottom")
+                                PtDebugPrint("tldnHatchLadderTop: done with bottom")
                                 Climber.gotoStage(ClimbingAvatar, -1)
 
     def INegotiateHatch(self):
         global hatchOpen
         global hatchLocked
         
-        print("tldnHatchLadderTop: Negotiating hatch")
+        PtDebugPrint("tldnHatchLadderTop: Negotiating hatch")
         if hatchOpen:
             self.IHatchOpen()
         else:
@@ -210,7 +210,7 @@ class tldnHatchLadderTop(ptModifier):
     def IHatchLocked(self):
         global ClimbingAvatar
 
-        print("tldnHatchLadderTop: Hatch is locked; Sending gotoStage(4)")
+        PtDebugPrint("tldnHatchLadderTop: Hatch is locked; Sending gotoStage(4)")
         Climber.gotoStage(ClimbingAvatar, 4, dirFlag=1, isForward=1, setTimeFlag=1, newTime=0.0)
         respHatchOps.run(self.key,state='lockedbelow')
 
@@ -218,7 +218,7 @@ class tldnHatchLadderTop(ptModifier):
         global ClimbingAvatar
         global hatchOpen
         
-        print("tldnHatchLadderTop: Hatch is unlocked; Sending gotoStage(5)")
+        PtDebugPrint("tldnHatchLadderTop: Hatch is unlocked; Sending gotoStage(5)")
         Climber.gotoStage(ClimbingAvatar, 5, dirFlag=1, isForward=1, setTimeFlag=1, newTime=0.0)
         respHatchOps.run(self.key,state='openbelow')        
         hatchOpen = 1
@@ -229,5 +229,5 @@ class tldnHatchLadderTop(ptModifier):
     def IHatchOpen(self):
         global ClimbingAvatar
 
-        print("tldnHatchLadderTop: Hatch is open; Sending gotoStage(1)")
+        PtDebugPrint("tldnHatchLadderTop: Hatch is open; Sending gotoStage(1)")
         Climber.gotoStage(ClimbingAvatar, 1, setTimeFlag=1, newTime=1.2)

--- a/Python/tldnLagoonBridge.py
+++ b/Python/tldnLagoonBridge.py
@@ -73,13 +73,13 @@ class tldnLagoonBridge(ptResponder):
 
         version = 2
         self.version = version
-        print "__init__tldnLagoonBridge v.", version,".1"
+        print("__init__tldnLagoonBridge v.", version,".1")
         
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print "tldnLagoonBridge:\tERROR---Cannot find the Teledahn Age SDL"
+            print("tldnLagoonBridge:\tERROR---Cannot find the Teledahn Age SDL")
             #ageSDL["tldnLagoonBridgeStuck"] = (1, )
             #ageSDL["tldnLagoonBridgeRaised"] = (1, )
 
@@ -95,16 +95,16 @@ class tldnLagoonBridge(ptResponder):
         tldnLagoonBridgeStuck = ageSDL["tldnLagoonBridgeStuck"][0]
         tldnLagoonBridgeRaised = ageSDL["tldnLagoonBridgeRaised"][0]
         
-        print "tldnLagoonBridge: When I got here:"
+        print("tldnLagoonBridge: When I got here:")
 
         if tldnLagoonBridgeStuck == 1:
-            print "\tThe Lagoon Bridge is stuck."
+            print("\tThe Lagoon Bridge is stuck.")
         elif tldnLagoonBridgeStuck == 0:
             if tldnLagoonBridgeRaised == 1:
-                print "\tThe Lagoon Bridge is raised."
+                print("\tThe Lagoon Bridge is raised.")
                 respLoweredtoRaised.run(self.key, fastforward=1)            
             elif tldnLagoonBridgeRaised == 0:
-                print "\tThe Lagoon Bridge is lowered."
+                print("\tThe Lagoon Bridge is lowered.")
                 respRaisedtoLowered.run(self.key, fastforward=1)            
 
     def OnNotify(self,state,id,events):
@@ -116,20 +116,20 @@ class tldnLagoonBridge(ptResponder):
         #~ if not PtWasLocallyNotified(self.key):
             #~ return
 
-        print "tldnLagoonBridge.OnNotify:  state=%f id=%d events=" % (state,id),events
+        print("tldnLagoonBridge.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
             
         if id == actLever.id:
-            print "The lever was clicked."
+            print("The lever was clicked.")
             respLever.run(self.key, events=events)
             
         elif id == respLever.id and self.sceneobject.isLocallyOwned():
-            print "The lever was pulled by an avatar."
+            print("The lever was pulled by an avatar.")
             
             tldnLagoonBridgeStuck = ageSDL["tldnLagoonBridgeStuck"][0]
             
             if tldnLagoonBridgeStuck:
-                print "The Lagoon Bridge is stuck, so pulling this lever did absolutely nothing."
+                print("The Lagoon Bridge is stuck, so pulling this lever did absolutely nothing.")
                 return
                 
             else:
@@ -140,7 +140,7 @@ class tldnLagoonBridge(ptResponder):
                 ageSDL["tldnLagoonBridgeRaised"] = (newstate,)
 
         elif id == actJumpZone.id and PtWasLocallyNotified(self.key):
-            print "I bumped the bridge."
+            print("I bumped the bridge.")
             ageSDL["tldnLagoonBridgeStuck"] = (0,)
             
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -151,11 +151,11 @@ class tldnLagoonBridge(ptResponder):
             tldnLagoonBridgeStuck = ageSDL["tldnLagoonBridgeStuck"][0]
             
             if tldnLagoonBridgeStuck == 0:
-                print "tldnLagoonBridge.OnSDLNotify: The Lagoon bridge was just bumped."
+                print("tldnLagoonBridge.OnSDLNotify: The Lagoon bridge was just bumped.")
                 respStucktoRaised.run(self.key)
                 return
             else:
-                print "tldnLagoonBridge.OnSDLNotify: Hmmm... LagoonBridgeStuck = ", tldnLagoonBridgeStuck
+                print("tldnLagoonBridge.OnSDLNotify: Hmmm... LagoonBridgeStuck = ", tldnLagoonBridgeStuck)
                 
              
         elif VARname == "tldnLagoonBridgeRaised":
@@ -167,7 +167,7 @@ class tldnLagoonBridge(ptResponder):
                 tldnLagoonBridgeRaised = ageSDL["tldnLagoonBridgeRaised"][0]            
                 if tldnLagoonBridgeRaised == 1:
                     respLoweredtoRaised.run(self.key)
-                    print "tldnLagoonBridge.OnSDLNotify: Raising Lagoon bridge."
+                    print("tldnLagoonBridge.OnSDLNotify: Raising Lagoon bridge.")
                 elif tldnLagoonBridgeRaised == 0:
                     respRaisedtoLowered.run(self.key)
-                    print "tldnLagoonBridge.OnSDLNotify: Lowering Lagoon bridge."
+                    print("tldnLagoonBridge.OnSDLNotify: Lowering Lagoon bridge.")

--- a/Python/tldnLagoonBridge.py
+++ b/Python/tldnLagoonBridge.py
@@ -73,13 +73,13 @@ class tldnLagoonBridge(ptResponder):
 
         version = 2
         self.version = version
-        print("__init__tldnLagoonBridge v.", version,".1")
+        PtDebugPrint("__init__tldnLagoonBridge v.", version,".1")
         
 
     def OnServerInitComplete(self):
         ageSDL = PtGetAgeSDL()
         if ageSDL == None:
-            print("tldnLagoonBridge:\tERROR---Cannot find the Teledahn Age SDL")
+            PtDebugPrint("tldnLagoonBridge:\tERROR---Cannot find the Teledahn Age SDL")
             #ageSDL["tldnLagoonBridgeStuck"] = (1, )
             #ageSDL["tldnLagoonBridgeRaised"] = (1, )
 
@@ -95,16 +95,16 @@ class tldnLagoonBridge(ptResponder):
         tldnLagoonBridgeStuck = ageSDL["tldnLagoonBridgeStuck"][0]
         tldnLagoonBridgeRaised = ageSDL["tldnLagoonBridgeRaised"][0]
         
-        print("tldnLagoonBridge: When I got here:")
+        PtDebugPrint("tldnLagoonBridge: When I got here:")
 
         if tldnLagoonBridgeStuck == 1:
-            print("\tThe Lagoon Bridge is stuck.")
+            PtDebugPrint("\tThe Lagoon Bridge is stuck.")
         elif tldnLagoonBridgeStuck == 0:
             if tldnLagoonBridgeRaised == 1:
-                print("\tThe Lagoon Bridge is raised.")
+                PtDebugPrint("\tThe Lagoon Bridge is raised.")
                 respLoweredtoRaised.run(self.key, fastforward=1)            
             elif tldnLagoonBridgeRaised == 0:
-                print("\tThe Lagoon Bridge is lowered.")
+                PtDebugPrint("\tThe Lagoon Bridge is lowered.")
                 respRaisedtoLowered.run(self.key, fastforward=1)            
 
     def OnNotify(self,state,id,events):
@@ -116,20 +116,20 @@ class tldnLagoonBridge(ptResponder):
         #~ if not PtWasLocallyNotified(self.key):
             #~ return
 
-        print("tldnLagoonBridge.OnNotify:  state=%f id=%d events=" % (state,id),events)
+        PtDebugPrint("tldnLagoonBridge.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
             
         if id == actLever.id:
-            print("The lever was clicked.")
+            PtDebugPrint("The lever was clicked.")
             respLever.run(self.key, events=events)
             
         elif id == respLever.id and self.sceneobject.isLocallyOwned():
-            print("The lever was pulled by an avatar.")
+            PtDebugPrint("The lever was pulled by an avatar.")
             
             tldnLagoonBridgeStuck = ageSDL["tldnLagoonBridgeStuck"][0]
             
             if tldnLagoonBridgeStuck:
-                print("The Lagoon Bridge is stuck, so pulling this lever did absolutely nothing.")
+                PtDebugPrint("The Lagoon Bridge is stuck, so pulling this lever did absolutely nothing.")
                 return
                 
             else:
@@ -140,22 +140,22 @@ class tldnLagoonBridge(ptResponder):
                 ageSDL["tldnLagoonBridgeRaised"] = (newstate,)
 
         elif id == actJumpZone.id and PtWasLocallyNotified(self.key):
-            print("I bumped the bridge.")
+            PtDebugPrint("I bumped the bridge.")
             ageSDL["tldnLagoonBridgeStuck"] = (0,)
             
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
-        #~ print "tldnLagoonBridge.OnSDLNotify():\t VARname:%s, SDLname:%s, tag:%s, value:%d, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID)
+        #~ PtDebugPrint("tldnLagoonBridge.OnSDLNotify():\t VARname:%s, SDLname:%s, tag:%s, value:%d, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
         
         if VARname == "tldnLagoonBridgeStuck":
             tldnLagoonBridgeStuck = ageSDL["tldnLagoonBridgeStuck"][0]
             
             if tldnLagoonBridgeStuck == 0:
-                print("tldnLagoonBridge.OnSDLNotify: The Lagoon bridge was just bumped.")
+                PtDebugPrint("tldnLagoonBridge.OnSDLNotify: The Lagoon bridge was just bumped.")
                 respStucktoRaised.run(self.key)
                 return
             else:
-                print("tldnLagoonBridge.OnSDLNotify: Hmmm... LagoonBridgeStuck = ", tldnLagoonBridgeStuck)
+                PtDebugPrint("tldnLagoonBridge.OnSDLNotify: Hmmm... LagoonBridgeStuck = ", tldnLagoonBridgeStuck)
                 
              
         elif VARname == "tldnLagoonBridgeRaised":
@@ -167,7 +167,7 @@ class tldnLagoonBridge(ptResponder):
                 tldnLagoonBridgeRaised = ageSDL["tldnLagoonBridgeRaised"][0]            
                 if tldnLagoonBridgeRaised == 1:
                     respLoweredtoRaised.run(self.key)
-                    print("tldnLagoonBridge.OnSDLNotify: Raising Lagoon bridge.")
+                    PtDebugPrint("tldnLagoonBridge.OnSDLNotify: Raising Lagoon bridge.")
                 elif tldnLagoonBridgeRaised == 0:
                     respRaisedtoLowered.run(self.key)
-                    print("tldnLagoonBridge.OnSDLNotify: Lowering Lagoon bridge.")
+                    PtDebugPrint("tldnLagoonBridge.OnSDLNotify: Lowering Lagoon bridge.")

--- a/Python/tldnPwrTwrPeriscope.py
+++ b/Python/tldnPwrTwrPeriscope.py
@@ -113,7 +113,7 @@ class tldnPwrTwrPeriscope(ptResponder):
         self.id = 5003
         version = 4
         self.version = version
-        print "tldnPwrTwrPerscope v.",version,".3"
+        print("tldnPwrTwrPerscope v.",version,".3")
 
     def OnFirstUpdate(self):
         global AgeStartedIn

--- a/Python/tldnPwrTwrPeriscope.py
+++ b/Python/tldnPwrTwrPeriscope.py
@@ -113,7 +113,7 @@ class tldnPwrTwrPeriscope(ptResponder):
         self.id = 5003
         version = 4
         self.version = version
-        print("tldnPwrTwrPerscope v.",version,".3")
+        PtDebugPrint("tldnPwrTwrPerscope v.",version,".3")
 
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -378,8 +378,8 @@ class tldnPwrTwrPeriscope(ptResponder):
         # Toggle Main Power via Sun #
         #############################
         if id==actSun.id and boolTwrRaised:
-            #print "PERISCOPE: detected sun. state=%d, events to follow" % state
-            #print events
+            #PtDebugPrint("PERISCOPE: detected sun. state=%d, events to follow" % state)
+            #PtDebugPrint(events)
             if AgeStartedIn == PtGetAgeName():
                 ageSDL = PtGetAgeSDL()
                 for event in events:
@@ -446,12 +446,12 @@ class tldnPwrTwrPeriscope(ptResponder):
         if isinstance(control,ptGUIControlButton):
             btnID = control.getTagID()
         else:
-            #print "SCOPE GUI: non-button notification"
+            #PtDebugPrint("SCOPE GUI: non-button notification")
             return
 
-        #print "tldnPwrTwrPeriscope.OnGUINotify():\tbefore click...left=%f,up=%f,top=%d,btm=%d" % (scopeSpdLeft,scopeSpdUp,boolScopeAtTop,boolScopeAtBtm)
+        #PtDebugPrint("tldnPwrTwrPeriscope.OnGUINotify():\tbefore click...left=%f,up=%f,top=%d,btm=%d" % (scopeSpdLeft,scopeSpdUp,boolScopeAtTop,boolScopeAtBtm))
 
-        #print "SCOPE GUI: got a button id = %d" % btnID
+        #PtDebugPrint("SCOPE GUI: got a button id = %d" % btnID)
         if btnID == kGUILeftBtn:
             if scopeSpdLeft == scopeSpdLeftMax:
                 return
@@ -521,7 +521,7 @@ class tldnPwrTwrPeriscope(ptResponder):
 
     def OnControlKeyEvent(self,controlKey,activeFlag):
         "Control key events... anything we're interested in?"
-        #print "Got controlKey event %d and its activeFlage is %d" % (controlKey,activeFlag)
+        #PtDebugPrint("Got controlKey event %d and its activeFlage is %d" % (controlKey,activeFlag))
         if controlKey == PlasmaControlKeys.kKeyExitMode:
             self.IQuitTelescope()
         elif controlKey == PlasmaControlKeys.kKeyMoveBackward or controlKey == PlasmaControlKeys.kKeyRotateLeft or controlKey == PlasmaControlKeys.kKeyRotateRight:

--- a/Python/tldnShooterTrap.py
+++ b/Python/tldnShooterTrap.py
@@ -67,7 +67,7 @@ class tldnShooterTrap(ptResponder):
         
         version = 2
         self.version = version
-        print "__init__tldnShooterTrap v.", version
+        print("__init__tldnShooterTrap v.", version)
         
     def OnNotify(self,state,id,events):
         if state:

--- a/Python/tldnShooterTrap.py
+++ b/Python/tldnShooterTrap.py
@@ -67,7 +67,7 @@ class tldnShooterTrap(ptResponder):
         
         version = 2
         self.version = version
-        print("__init__tldnShooterTrap v.", version)
+        PtDebugPrint("__init__tldnShooterTrap v.", version)
         
     def OnNotify(self,state,id,events):
         if state:
@@ -76,4 +76,4 @@ class tldnShooterTrap(ptResponder):
                 #intSporeCount.value = intSporeCount.value - 1
             else:
                 respEmpty.run(self.key,events=events)
-            #print "tldnShooterTrap.OnNotify intSporeCount=%d" % intSporeCount.value
+            #PtDebugPrint("tldnShooterTrap.OnNotify intSporeCount=%d" % intSporeCount.value)

--- a/Python/tldnShroomieBrain.py
+++ b/Python/tldnShroomieBrain.py
@@ -112,14 +112,14 @@ class tldnShroomieBrain(ptResponder):
         self.id = 5237
         version = 3
         self.version = version
-        print "__init__tldnShroomieBrain v.", version,".2"
+        print("__init__tldnShroomieBrain v.", version,".2")
         random.seed()
 
     def OnServerInitComplete(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "tldnShroomieBrain:\tERROR---Cannot find the Teledahn Age SDL"
+            print("tldnShroomieBrain:\tERROR---Cannot find the Teledahn Age SDL")
             ageSDL["ShroomieTotalTimesSeen"] = (0, ) 
             ageSDL["ShroomieTimeLastSeen"] = (0, ) 
 
@@ -132,12 +132,12 @@ class tldnShroomieBrain(ptResponder):
         ShroomieTotalTimesSeen = ageSDL["ShroomieTotalTimesSeen"][0]
         ShroomieTimeLastSeen = ageSDL["ShroomieTimeLastSeen"][0]
         
-        print "tldnShroomieBrain: When I got here:"
-        print "\tShroomie has been seen", ShroomieTotalTimesSeen," times."
+        print("tldnShroomieBrain: When I got here:")
+        print("\tShroomie has been seen", ShroomieTotalTimesSeen," times.")
         
         if ShroomieTotalTimesSeen:            
             CurrentTime = PtGetDniTime()            
-            print "\tShroomie was last seen ", (CurrentTime - ShroomieTimeLastSeen)," seconds ago."
+            print("\tShroomie was last seen ", (CurrentTime - ShroomieTimeLastSeen)," seconds ago.")
             
     def OnNotify(self,state,id,events):
         ageSDL = PtGetAgeSDL()
@@ -177,14 +177,14 @@ class tldnShroomieBrain(ptResponder):
         
         ShroomieTimeLastSeen = ageSDL["ShroomieTimeLastSeen"][0]
 
-        print "tldnShroomieBrain: Shroomie was last seen", CurrentTime - ShroomieTimeLastSeen," seconds ago."
+        print("tldnShroomieBrain: Shroomie was last seen", CurrentTime - ShroomieTimeLastSeen," seconds ago.")
 
         if (CurrentTime - ShroomieTimeLastSeen) > 240:
-            print "\tShroomie CAN be seen."
+            print("\tShroomie CAN be seen.")
             return True
             
         else:
-            print "\tShroomie CAN'T be seen."
+            print("\tShroomie CAN'T be seen.")
             return False
             
 
@@ -194,10 +194,10 @@ class tldnShroomieBrain(ptResponder):
         #~ print "randnum = ",randnum,"probability = ", probability*100
         
         if randnum < (probability*100):
-            print "\t Shroomie WILL be seen."
+            print("\t Shroomie WILL be seen.")
             return True
         else:
-            print "\tShroomie WON'T be seen."
+            print("\tShroomie WON'T be seen.")
             
     def ShroomieSurfaces(self,spawn):
         ageSDL = PtGetAgeSDL()
@@ -210,11 +210,11 @@ class tldnShroomieBrain(ptResponder):
             whichbehavior = random.randint(1,4)
             
             if tldnMainPowerOn:
-                print "tldnShroomieBrain: The Power Tower noise has scared Shroomie. He'll come, but not very close."
+                print("tldnShroomieBrain: The Power Tower noise has scared Shroomie. He'll come, but not very close.")
                 NearOrFar = "Far"
                 
             else:                 #Determine how far out Shroomie will be seen. Added 12/12/2004
-                print "tldnShroomieBrain: The Power Tower is down, so Shroomie isn't scared by the noise."
+                print("tldnShroomieBrain: The Power Tower is down, so Shroomie isn't scared by the noise.")
 
                 howclose = random.randint(1,100)
                 if howclose == 1:
@@ -229,7 +229,7 @@ class tldnShroomieBrain(ptResponder):
             whichbehavior = random.randint(2,4)
             NearOrFar = "Far"
             
-        print "tldnShroomieBrain: whichbehavior = ",whichbehavior," NearOrFar = ",NearOrFar
+        print("tldnShroomieBrain: whichbehavior = ",whichbehavior," NearOrFar = ",NearOrFar)
 
 
         whichspawnpoint = random.randint(1,5)
@@ -241,13 +241,13 @@ class tldnShroomieBrain(ptResponder):
             code = "target = SpawnMid0" + str(whichspawnpoint) + ".sceneobject.getKey()"            
         elif NearOrFar == "Far":
             code = "target = SpawnFar0" + str(whichspawnpoint) + ".sceneobject.getKey()"
-        print "target code:", code
-        exec code
+        print("target code:", code)
+        exec(code)
         ShroomieMaster.sceneobject.physics.warpObj(target)
         
         code = "respTrick0" + str(whichbehavior) + ".run(self.key)"
         #~ print "code = ", code
-        exec code
+        exec(code)
 
 
         CurrentTime = PtGetDniTime()
@@ -256,4 +256,4 @@ class tldnShroomieBrain(ptResponder):
         ShroomieTotalTimesSeen = ageSDL["ShroomieTotalTimesSeen"][0]
         ShroomieTotalTimesSeen = ShroomieTotalTimesSeen + 1
         ageSDL["ShroomieTotalTimesSeen"] = (ShroomieTotalTimesSeen,)
-        print "tldnShroomieBrain: Shroomie has been seen", ShroomieTotalTimesSeen,"times."
+        print("tldnShroomieBrain: Shroomie has been seen", ShroomieTotalTimesSeen,"times.")

--- a/Python/tldnShroomieBrain.py
+++ b/Python/tldnShroomieBrain.py
@@ -112,14 +112,14 @@ class tldnShroomieBrain(ptResponder):
         self.id = 5237
         version = 3
         self.version = version
-        print("__init__tldnShroomieBrain v.", version,".2")
+        PtDebugPrint("__init__tldnShroomieBrain v.", version,".2")
         random.seed()
 
     def OnServerInitComplete(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("tldnShroomieBrain:\tERROR---Cannot find the Teledahn Age SDL")
+            PtDebugPrint("tldnShroomieBrain:\tERROR---Cannot find the Teledahn Age SDL")
             ageSDL["ShroomieTotalTimesSeen"] = (0, ) 
             ageSDL["ShroomieTimeLastSeen"] = (0, ) 
 
@@ -132,17 +132,17 @@ class tldnShroomieBrain(ptResponder):
         ShroomieTotalTimesSeen = ageSDL["ShroomieTotalTimesSeen"][0]
         ShroomieTimeLastSeen = ageSDL["ShroomieTimeLastSeen"][0]
         
-        print("tldnShroomieBrain: When I got here:")
-        print("\tShroomie has been seen", ShroomieTotalTimesSeen," times.")
+        PtDebugPrint("tldnShroomieBrain: When I got here:")
+        PtDebugPrint("\tShroomie has been seen", ShroomieTotalTimesSeen," times.")
         
         if ShroomieTotalTimesSeen:            
             CurrentTime = PtGetDniTime()            
-            print("\tShroomie was last seen ", (CurrentTime - ShroomieTimeLastSeen)," seconds ago.")
+            PtDebugPrint("\tShroomie was last seen ", (CurrentTime - ShroomieTimeLastSeen)," seconds ago.")
             
     def OnNotify(self,state,id,events):
         ageSDL = PtGetAgeSDL()
         
-        #~ print "tldnShroomieBrain.OnNotify:  state=%f id=%d events=" % (state,id),events
+        #~ PtDebugPrint("tldnShroomieBrain.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if not state:
             return
@@ -177,27 +177,27 @@ class tldnShroomieBrain(ptResponder):
         
         ShroomieTimeLastSeen = ageSDL["ShroomieTimeLastSeen"][0]
 
-        print("tldnShroomieBrain: Shroomie was last seen", CurrentTime - ShroomieTimeLastSeen," seconds ago.")
+        PtDebugPrint("tldnShroomieBrain: Shroomie was last seen", CurrentTime - ShroomieTimeLastSeen," seconds ago.")
 
         if (CurrentTime - ShroomieTimeLastSeen) > 240:
-            print("\tShroomie CAN be seen.")
+            PtDebugPrint("\tShroomie CAN be seen.")
             return True
             
         else:
-            print("\tShroomie CAN'T be seen.")
+            PtDebugPrint("\tShroomie CAN'T be seen.")
             return False
             
 
     def WillShroomieBeSeen(self,probability):
         randnum = random.randint(0,100)
         
-        #~ print "randnum = ",randnum,"probability = ", probability*100
+        #~ PtDebugPrint("randnum = ",randnum,"probability = ", probability*100)
         
         if randnum < (probability*100):
-            print("\t Shroomie WILL be seen.")
+            PtDebugPrint("\t Shroomie WILL be seen.")
             return True
         else:
-            print("\tShroomie WON'T be seen.")
+            PtDebugPrint("\tShroomie WON'T be seen.")
             
     def ShroomieSurfaces(self,spawn):
         ageSDL = PtGetAgeSDL()
@@ -210,11 +210,11 @@ class tldnShroomieBrain(ptResponder):
             whichbehavior = random.randint(1,4)
             
             if tldnMainPowerOn:
-                print("tldnShroomieBrain: The Power Tower noise has scared Shroomie. He'll come, but not very close.")
+                PtDebugPrint("tldnShroomieBrain: The Power Tower noise has scared Shroomie. He'll come, but not very close.")
                 NearOrFar = "Far"
                 
             else:                 #Determine how far out Shroomie will be seen. Added 12/12/2004
-                print("tldnShroomieBrain: The Power Tower is down, so Shroomie isn't scared by the noise.")
+                PtDebugPrint("tldnShroomieBrain: The Power Tower is down, so Shroomie isn't scared by the noise.")
 
                 howclose = random.randint(1,100)
                 if howclose == 1:
@@ -229,7 +229,7 @@ class tldnShroomieBrain(ptResponder):
             whichbehavior = random.randint(2,4)
             NearOrFar = "Far"
             
-        print("tldnShroomieBrain: whichbehavior = ",whichbehavior," NearOrFar = ",NearOrFar)
+        PtDebugPrint("tldnShroomieBrain: whichbehavior = ",whichbehavior," NearOrFar = ",NearOrFar)
 
 
         whichspawnpoint = random.randint(1,5)
@@ -241,12 +241,12 @@ class tldnShroomieBrain(ptResponder):
             code = "target = SpawnMid0" + str(whichspawnpoint) + ".sceneobject.getKey()"            
         elif NearOrFar == "Far":
             code = "target = SpawnFar0" + str(whichspawnpoint) + ".sceneobject.getKey()"
-        print("target code:", code)
+        PtDebugPrint("target code:", code)
         exec(code)
         ShroomieMaster.sceneobject.physics.warpObj(target)
         
         code = "respTrick0" + str(whichbehavior) + ".run(self.key)"
-        #~ print "code = ", code
+        #~ PtDebugPrint("code = ", code)
         exec(code)
 
 
@@ -256,4 +256,4 @@ class tldnShroomieBrain(ptResponder):
         ShroomieTotalTimesSeen = ageSDL["ShroomieTotalTimesSeen"][0]
         ShroomieTotalTimesSeen = ShroomieTotalTimesSeen + 1
         ageSDL["ShroomieTotalTimesSeen"] = (ShroomieTotalTimesSeen,)
-        print("tldnShroomieBrain: Shroomie has been seen", ShroomieTotalTimesSeen,"times.")
+        PtDebugPrint("tldnShroomieBrain: Shroomie has been seen", ShroomieTotalTimesSeen,"times.")

--- a/Python/tldnShroomieGate.py
+++ b/Python/tldnShroomieGate.py
@@ -65,11 +65,11 @@ class tldnShroomieGate(ptResponder):
         
         version = 1
         self.version = version
-        print "__init__tldnShroomieGate v.", version
+        print("__init__tldnShroomieGate v.", version)
         
     def OnNotify(self,state,id,events):
         if id == clkLever.id and state:
-            print "tldnShroomieGate:\t---Someone Pulled the Lever"
+            print("tldnShroomieGate:\t---Someone Pulled the Lever")
             respLeverPull.run(self.key,avatar=PtFindAvatar(events))
 
         elif id == respLeverPull.id:
@@ -78,10 +78,10 @@ class tldnShroomieGate(ptResponder):
             if ageSDL["tldnShroomieGatePowerOn"][0] and self.sceneobject.isLocallyOwned():                
                 if ageSDL["tldnShroomieGateUp"][0]:
                     respGateDown.run(self.key)
-                    print "tldnShroomieGate:\t---Shroomie Gate Going Down"
+                    print("tldnShroomieGate:\t---Shroomie Gate Going Down")
                 else:
                     respGateUp.run(self.key)
-                    print "tldnShroomieGate:\t---Shroomie Gate Going Up"
+                    print("tldnShroomieGate:\t---Shroomie Gate Going Up")
             ageSDL["tldnShroomieGateUp"] = (not ageSDL["tldnShroomieGateUp"][0],)
                             
         
@@ -89,15 +89,15 @@ class tldnShroomieGate(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "tldnShroomieGate:\tERROR---Cannot find the Teledahn Age SDL"
+            print("tldnShroomieGate:\tERROR---Cannot find the Teledahn Age SDL")
 
         ageSDL.sendToClients("tldnShroomieGateUp")
         ageSDL.setFlags("tldnShroomieGateUp", 1, 1)
         ageSDL.setNotify(self.key, "tldnShroomieGateUp", 0.0)
         
         if ageSDL["tldnShroomieGateUp"][0]:
-            print "tldnShroomieGate:\tInit---Shroomie Gate Up"
+            print("tldnShroomieGate:\tInit---Shroomie Gate Up")
             respGateUp.run(self.key,fastforward=1)
         else:
-            print "tldnShroomieGate:\tInit---Shroomie Gate Down"
+            print("tldnShroomieGate:\tInit---Shroomie Gate Down")
             respGateDown.run(self.key,fastforward=1)

--- a/Python/tldnShroomieGate.py
+++ b/Python/tldnShroomieGate.py
@@ -65,11 +65,11 @@ class tldnShroomieGate(ptResponder):
         
         version = 1
         self.version = version
-        print("__init__tldnShroomieGate v.", version)
+        PtDebugPrint("__init__tldnShroomieGate v.", version)
         
     def OnNotify(self,state,id,events):
         if id == clkLever.id and state:
-            print("tldnShroomieGate:\t---Someone Pulled the Lever")
+            PtDebugPrint("tldnShroomieGate:\t---Someone Pulled the Lever")
             respLeverPull.run(self.key,avatar=PtFindAvatar(events))
 
         elif id == respLeverPull.id:
@@ -78,10 +78,10 @@ class tldnShroomieGate(ptResponder):
             if ageSDL["tldnShroomieGatePowerOn"][0] and self.sceneobject.isLocallyOwned():                
                 if ageSDL["tldnShroomieGateUp"][0]:
                     respGateDown.run(self.key)
-                    print("tldnShroomieGate:\t---Shroomie Gate Going Down")
+                    PtDebugPrint("tldnShroomieGate:\t---Shroomie Gate Going Down")
                 else:
                     respGateUp.run(self.key)
-                    print("tldnShroomieGate:\t---Shroomie Gate Going Up")
+                    PtDebugPrint("tldnShroomieGate:\t---Shroomie Gate Going Up")
             ageSDL["tldnShroomieGateUp"] = (not ageSDL["tldnShroomieGateUp"][0],)
                             
         
@@ -89,15 +89,15 @@ class tldnShroomieGate(ptResponder):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("tldnShroomieGate:\tERROR---Cannot find the Teledahn Age SDL")
+            PtDebugPrint("tldnShroomieGate:\tERROR---Cannot find the Teledahn Age SDL")
 
         ageSDL.sendToClients("tldnShroomieGateUp")
         ageSDL.setFlags("tldnShroomieGateUp", 1, 1)
         ageSDL.setNotify(self.key, "tldnShroomieGateUp", 0.0)
         
         if ageSDL["tldnShroomieGateUp"][0]:
-            print("tldnShroomieGate:\tInit---Shroomie Gate Up")
+            PtDebugPrint("tldnShroomieGate:\tInit---Shroomie Gate Up")
             respGateUp.run(self.key,fastforward=1)
         else:
-            print("tldnShroomieGate:\tInit---Shroomie Gate Down")
+            PtDebugPrint("tldnShroomieGate:\tInit---Shroomie Gate Down")
             respGateDown.run(self.key,fastforward=1)

--- a/Python/tldnSlavePrisonDoors.py
+++ b/Python/tldnSlavePrisonDoors.py
@@ -185,7 +185,7 @@ class tldnSlavePrisonDoors(ptResponder):
         # make sure its one of the activators we know about
         if id in activatorToResp:
             for event in events:
-                print("event = ", event)
+                PtDebugPrint("event = ", event)
             # evaluate plates to paddles and set doors accordingly
             self.IEvalPlateAndPaddles(activator=id)
             ageSDL = PtGetAgeSDL()
@@ -281,7 +281,7 @@ class tldnSlavePrisonDoors(ptResponder):
                 respOuterDoor.run(self.key,state="down",fastforward=fastforward)
         
             ageSDL["tldnSlaveCaveSecretDoorOpen"] = (1,)
-            print("tldnSlavePrisonDoors: The exp1 secret panel should now be open.")
+            PtDebugPrint("tldnSlavePrisonDoors: The exp1 secret panel should now be open.")
         
         else:
             # raise the outer doors and shut the inner doors
@@ -294,7 +294,7 @@ class tldnSlavePrisonDoors(ptResponder):
                 respOuterDoor.run(self.key,state="up",fastforward=fastforward)
 
             ageSDL["tldnSlaveCaveSecretDoorOpen"] = (0,)
-            print("tldnSlavePrisonDoors: The exp1 secret panel should now be closed.")
+            PtDebugPrint("tldnSlavePrisonDoors: The exp1 secret panel should now be closed.")
 
 
     def OnBackdoorMsg(self, target, param):

--- a/Python/tldnSlavePrisonDoors.py
+++ b/Python/tldnSlavePrisonDoors.py
@@ -185,7 +185,7 @@ class tldnSlavePrisonDoors(ptResponder):
         # make sure its one of the activators we know about
         if id in activatorToResp:
             for event in events:
-                print "event = ", event
+                print("event = ", event)
             # evaluate plates to paddles and set doors accordingly
             self.IEvalPlateAndPaddles(activator=id)
             ageSDL = PtGetAgeSDL()
@@ -281,7 +281,7 @@ class tldnSlavePrisonDoors(ptResponder):
                 respOuterDoor.run(self.key,state="down",fastforward=fastforward)
         
             ageSDL["tldnSlaveCaveSecretDoorOpen"] = (1,)
-            print "tldnSlavePrisonDoors: The exp1 secret panel should now be open."
+            print("tldnSlavePrisonDoors: The exp1 secret panel should now be open.")
         
         else:
             # raise the outer doors and shut the inner doors
@@ -294,7 +294,7 @@ class tldnSlavePrisonDoors(ptResponder):
                 respOuterDoor.run(self.key,state="up",fastforward=fastforward)
 
             ageSDL["tldnSlaveCaveSecretDoorOpen"] = (0,)
-            print "tldnSlavePrisonDoors: The exp1 secret panel should now be closed."
+            print("tldnSlavePrisonDoors: The exp1 secret panel should now be closed.")
 
 
     def OnBackdoorMsg(self, target, param):

--- a/Python/tldnSlavePrisonPanels.py
+++ b/Python/tldnSlavePrisonPanels.py
@@ -75,7 +75,7 @@ class tldnSlavePrisonPanels(ptResponder):
         self.id = 5238
         version = 2
         self.version = version
-        print "__init__tldnSlavePrisonPanels v. ", version,".1"
+        print("__init__tldnSlavePrisonPanels v. ", version,".1")
         
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -131,11 +131,11 @@ class tldnSlavePrisonPanels(ptResponder):
                 respLeverDown.run(self.key,events=events)
         
         elif id == respLeverUp.id and self.sceneobject.isLocallyOwned():
-            print "tldnSlavePrisonPanels: Lever now completely up. Updating SDL", stringVarName.value, " to 0"
+            print("tldnSlavePrisonPanels: Lever now completely up. Updating SDL", stringVarName.value, " to 0")
             ageSDL[stringVarName.value] = (0,)
             
         elif id == respLeverDown.id and self.sceneobject.isLocallyOwned():
-            print "tldnSlavePrisonPanels: Lever now completely down. Updating SDL", stringVarName.value," to 1"
+            print("tldnSlavePrisonPanels: Lever now completely down. Updating SDL", stringVarName.value," to 1")
             ageSDL[stringVarName.value] = (1,)
   
   

--- a/Python/tldnSlavePrisonPanels.py
+++ b/Python/tldnSlavePrisonPanels.py
@@ -75,7 +75,7 @@ class tldnSlavePrisonPanels(ptResponder):
         self.id = 5238
         version = 2
         self.version = version
-        print("__init__tldnSlavePrisonPanels v. ", version,".1")
+        PtDebugPrint("__init__tldnSlavePrisonPanels v. ", version,".1")
         
     def OnFirstUpdate(self):
         global AgeStartedIn
@@ -112,7 +112,7 @@ class tldnSlavePrisonPanels(ptResponder):
         
     def OnNotify(self,state,id,events):        
         global boolCurrentValue
-        #~ print "tldnSlavePrisonPanels:OnNotify  state=%f id=%d events=" % (state,id),events        
+        #~ PtDebugPrint("tldnSlavePrisonPanels:OnNotify  state=%f id=%d events=" % (state,id),events)
         
         if not state:
             return
@@ -123,7 +123,7 @@ class tldnSlavePrisonPanels(ptResponder):
         if id == actTrigger.id:
                
             boolCurrentValue = ageSDL[stringVarName.value][0]
-            #~ print "SDL variable ", stringVarName.value," = ",  boolCurrentValue
+            #~ PtDebugPrint("SDL variable ", stringVarName.value," = ",  boolCurrentValue)
                         
             if boolCurrentValue ==1 :
                 respLeverUp.run(self.key,events=events)
@@ -131,11 +131,11 @@ class tldnSlavePrisonPanels(ptResponder):
                 respLeverDown.run(self.key,events=events)
         
         elif id == respLeverUp.id and self.sceneobject.isLocallyOwned():
-            print("tldnSlavePrisonPanels: Lever now completely up. Updating SDL", stringVarName.value, " to 0")
+            PtDebugPrint("tldnSlavePrisonPanels: Lever now completely up. Updating SDL", stringVarName.value, " to 0")
             ageSDL[stringVarName.value] = (0,)
             
         elif id == respLeverDown.id and self.sceneobject.isLocallyOwned():
-            print("tldnSlavePrisonPanels: Lever now completely down. Updating SDL", stringVarName.value," to 1")
+            PtDebugPrint("tldnSlavePrisonPanels: Lever now completely down. Updating SDL", stringVarName.value," to 1")
             ageSDL[stringVarName.value] = (1,)
   
   

--- a/Python/tldnWRCCBrain.py
+++ b/Python/tldnWRCCBrain.py
@@ -138,7 +138,7 @@ class tldnWRCCBrain(ptResponder):
             self.SDL["OperatorID"] = (-1,)
             self.SDL["boolOperated"] = (0,)
             #respWRCCMaster.run(self.key,state='off')
-            print("tldnWRCCBrain.AvatarPage(): WRCC operator paged out, reenabled WRCC.")
+            PtDebugPrint("tldnWRCCBrain.AvatarPage(): WRCC operator paged out, reenabled WRCC.")
         else:
             return
 
@@ -151,7 +151,7 @@ class tldnWRCCBrain(ptResponder):
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:
             if solo:
-                print("tldnWRCCBrain.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated)
+                PtDebugPrint("tldnWRCCBrain.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated)
                 boolOperated = 0
                 self.SDL["boolOperated"] = (0,)
                 self.SDL["OperatorID"] = (-1,)
@@ -159,7 +159,7 @@ class tldnWRCCBrain(ptResponder):
                 #respWRCCMaster.run(self.key,state='off')
             else:
                 actSitClickable.disable()
-                print("tldnWRCCBrain.Load():\tboolOperated=%d, disabling WRCC clickable" % boolOperated)
+                PtDebugPrint("tldnWRCCBrain.Load():\tboolOperated=%d, disabling WRCC clickable" % boolOperated)
 
 
     def OnServerInitComplete(self):
@@ -367,32 +367,32 @@ class tldnWRCCBrain(ptResponder):
         for event in events: #this detects the untrigger of the sitting component
             if event[0]==6 and event[1]==1 and id== actSitComponent.id:
                 if state==0: #true as player stands up
-                    print("tldnWRCCBrain.OnNotify():\tWRCC unoccupied, re-enabling WRCC sit clickable.")
+                    PtDebugPrint("tldnWRCCBrain.OnNotify():\tWRCC unoccupied, re-enabling WRCC sit clickable.")
                     actSitClickable.enable()
                     self.SDL["boolOperated"] = (0,)
                     self.SDL["OperatorID"] = (-1,)
                     
                     if PtWasLocallyNotified(self.key):
                         PtEnableMouseMovement()
-                        print("tldnWRCCBrain.OnNotify():\tI'm the one who stood up, will hide panel's clickables")
+                        PtDebugPrint("tldnWRCCBrain.OnNotify():\tI'm the one who stood up, will hide panel's clickables")
                         respWRCCMaster.run(self.key,state='on')
 
         if not state: # notification is from some kind of untrigger
             return
 
         if id==actSitClickable.id:
-            print("tldnWRCCBrain.OnNotify():\tWRCC occupied, disabling WRCC sit clickable.")
+            PtDebugPrint("tldnWRCCBrain.OnNotify():\tWRCC occupied, disabling WRCC sit clickable.")
             actSitClickable.disable()
             self.SDL["boolOperated"] = (1,)
                     
             LocalAvatar = PtFindAvatar(events)
             avID = PtGetClientIDFromAvatarKey(LocalAvatar.getKey())
             self.SDL["OperatorID"] = (avID,)
-            print("tldnWRCCBrain.OnNotify:\twrote SDL - scope operator id = ", avID) 
+            PtDebugPrint("tldnWRCCBrain.OnNotify:\twrote SDL - scope operator id = ", avID) 
             
             if PtWasLocallyNotified(self.key):
                 PtDisableMouseMovement()
-                print("tldnWRCCBrain.OnNotify():\tI'm the one who sat down, will show panel's clickables")
+                PtDebugPrint("tldnWRCCBrain.OnNotify():\tI'm the one who sat down, will show panel's clickables")
                 respWRCCMaster.run(self.key,state='off')
         
         if id==actDrainLvr.id:
@@ -400,15 +400,15 @@ class tldnWRCCBrain(ptResponder):
                 ageSDL = PtGetAgeSDL()
                 if pwrOn and hatchLocked and not cabinDrained:
                     respDrainLvr.run(self.key,state='drain')
-                    print("tldnWRCCBrain.OnNotify:\tDraining under-cabin.")
+                    PtDebugPrint("tldnWRCCBrain.OnNotify:\tDraining under-cabin.")
                     ageSDL.setTagString(kStringAgeSDLCabinDrained,"ignore") # ignore so we don't set global cabinDrained yet...see respCabinDrain callback below
                     ageSDL[kStringAgeSDLCabinDrained] = (1,) # set this now so folks coming in will just see it drained
                 elif pwrOn and hatchLocked and cabinDrained:
                     respDrainLvr.run(self.key,state='pull')
-                    print("tldnWRCCBrain.OnNotify:\tUnder-cabin already empty.")
+                    PtDebugPrint("tldnWRCCBrain.OnNotify:\tUnder-cabin already empty.")
                 else:
                     respDrainLvr.run(self.key,state='off')
-                    print("tldnWRCCBrain.OnNotify:\tCan't operate drain -- pwrOn=%d hatchLocked=%d." % (pwrOn,hatchLocked))
+                    PtDebugPrint("tldnWRCCBrain.OnNotify:\tCan't operate drain -- pwrOn=%d hatchLocked=%d." % (pwrOn,hatchLocked))
             return
 
         if id==respDrainLvr.id:
@@ -439,10 +439,10 @@ class tldnWRCCBrain(ptResponder):
                         ageSDL[kStringAgeSDLHatchLocked] = (1,)
                 elif hatchLocked:
                     respLockSwitch.run(self.key,state='unlockfail')
-                    print("tldnWRCCBrain.OnNotify:\tCan't unlock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining))
+                    PtDebugPrint("tldnWRCCBrain.OnNotify:\tCan't unlock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining))
                 else:
                     respLockSwitch.run(self.key,state='lockfail')
-                    print("tldnWRCCBrain.OnNotify:\tCan't lock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining))
+                    PtDebugPrint("tldnWRCCBrain.OnNotify:\tCan't lock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining))
             return
 
         if id==actOpenHatchAbv.id:

--- a/Python/tldnWRCCBrain.py
+++ b/Python/tldnWRCCBrain.py
@@ -138,7 +138,7 @@ class tldnWRCCBrain(ptResponder):
             self.SDL["OperatorID"] = (-1,)
             self.SDL["boolOperated"] = (0,)
             #respWRCCMaster.run(self.key,state='off')
-            print "tldnWRCCBrain.AvatarPage(): WRCC operator paged out, reenabled WRCC."
+            print("tldnWRCCBrain.AvatarPage(): WRCC operator paged out, reenabled WRCC.")
         else:
             return
 
@@ -151,7 +151,7 @@ class tldnWRCCBrain(ptResponder):
         boolOperated = self.SDL["boolOperated"][0]
         if boolOperated:
             if solo:
-                print "tldnWRCCBrain.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated
+                print("tldnWRCCBrain.Load():\tboolOperated=%d but no one else here...correcting" % boolOperated)
                 boolOperated = 0
                 self.SDL["boolOperated"] = (0,)
                 self.SDL["OperatorID"] = (-1,)
@@ -159,7 +159,7 @@ class tldnWRCCBrain(ptResponder):
                 #respWRCCMaster.run(self.key,state='off')
             else:
                 actSitClickable.disable()
-                print "tldnWRCCBrain.Load():\tboolOperated=%d, disabling WRCC clickable" % boolOperated
+                print("tldnWRCCBrain.Load():\tboolOperated=%d, disabling WRCC clickable" % boolOperated)
 
 
     def OnServerInitComplete(self):
@@ -367,32 +367,32 @@ class tldnWRCCBrain(ptResponder):
         for event in events: #this detects the untrigger of the sitting component
             if event[0]==6 and event[1]==1 and id== actSitComponent.id:
                 if state==0: #true as player stands up
-                    print "tldnWRCCBrain.OnNotify():\tWRCC unoccupied, re-enabling WRCC sit clickable."
+                    print("tldnWRCCBrain.OnNotify():\tWRCC unoccupied, re-enabling WRCC sit clickable.")
                     actSitClickable.enable()
                     self.SDL["boolOperated"] = (0,)
                     self.SDL["OperatorID"] = (-1,)
                     
                     if PtWasLocallyNotified(self.key):
                         PtEnableMouseMovement()
-                        print "tldnWRCCBrain.OnNotify():\tI'm the one who stood up, will hide panel's clickables"
+                        print("tldnWRCCBrain.OnNotify():\tI'm the one who stood up, will hide panel's clickables")
                         respWRCCMaster.run(self.key,state='on')
 
         if not state: # notification is from some kind of untrigger
             return
 
         if id==actSitClickable.id:
-            print "tldnWRCCBrain.OnNotify():\tWRCC occupied, disabling WRCC sit clickable."
+            print("tldnWRCCBrain.OnNotify():\tWRCC occupied, disabling WRCC sit clickable.")
             actSitClickable.disable()
             self.SDL["boolOperated"] = (1,)
                     
             LocalAvatar = PtFindAvatar(events)
             avID = PtGetClientIDFromAvatarKey(LocalAvatar.getKey())
             self.SDL["OperatorID"] = (avID,)
-            print "tldnWRCCBrain.OnNotify:\twrote SDL - scope operator id = ", avID 
+            print("tldnWRCCBrain.OnNotify:\twrote SDL - scope operator id = ", avID) 
             
             if PtWasLocallyNotified(self.key):
                 PtDisableMouseMovement()
-                print "tldnWRCCBrain.OnNotify():\tI'm the one who sat down, will show panel's clickables"
+                print("tldnWRCCBrain.OnNotify():\tI'm the one who sat down, will show panel's clickables")
                 respWRCCMaster.run(self.key,state='off')
         
         if id==actDrainLvr.id:
@@ -400,15 +400,15 @@ class tldnWRCCBrain(ptResponder):
                 ageSDL = PtGetAgeSDL()
                 if pwrOn and hatchLocked and not cabinDrained:
                     respDrainLvr.run(self.key,state='drain')
-                    print "tldnWRCCBrain.OnNotify:\tDraining under-cabin."
+                    print("tldnWRCCBrain.OnNotify:\tDraining under-cabin.")
                     ageSDL.setTagString(kStringAgeSDLCabinDrained,"ignore") # ignore so we don't set global cabinDrained yet...see respCabinDrain callback below
                     ageSDL[kStringAgeSDLCabinDrained] = (1,) # set this now so folks coming in will just see it drained
                 elif pwrOn and hatchLocked and cabinDrained:
                     respDrainLvr.run(self.key,state='pull')
-                    print "tldnWRCCBrain.OnNotify:\tUnder-cabin already empty."
+                    print("tldnWRCCBrain.OnNotify:\tUnder-cabin already empty.")
                 else:
                     respDrainLvr.run(self.key,state='off')
-                    print "tldnWRCCBrain.OnNotify:\tCan't operate drain -- pwrOn=%d hatchLocked=%d." % (pwrOn,hatchLocked)
+                    print("tldnWRCCBrain.OnNotify:\tCan't operate drain -- pwrOn=%d hatchLocked=%d." % (pwrOn,hatchLocked))
             return
 
         if id==respDrainLvr.id:
@@ -439,10 +439,10 @@ class tldnWRCCBrain(ptResponder):
                         ageSDL[kStringAgeSDLHatchLocked] = (1,)
                 elif hatchLocked:
                     respLockSwitch.run(self.key,state='unlockfail')
-                    print "tldnWRCCBrain.OnNotify:\tCan't unlock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining)
+                    print("tldnWRCCBrain.OnNotify:\tCan't unlock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining))
                 else:
                     respLockSwitch.run(self.key,state='lockfail')
-                    print "tldnWRCCBrain.OnNotify:\tCan't lock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining)
+                    print("tldnWRCCBrain.OnNotify:\tCan't lock hatch -- pwrOn=%d hatchOpen=%d cabinDraining=%d." % (pwrOn,hatchOpen,cabinDraining))
             return
 
         if id==actOpenHatchAbv.id:

--- a/Python/x2wayLever.py
+++ b/Python/x2wayLever.py
@@ -67,11 +67,11 @@ class x2wayLever(ptResponder):
         
         version = 1
         self.version = version
-        print "__init__x2wayLever v.", version
+        print("__init__x2wayLever v.", version)
 
     def OnFirstUpdate(self):
         if self.SDL == None:
-            print "x2wayLever.OnFirstUpdate():\tERROR---missing SDL (%s)" % varstring.value
+            print("x2wayLever.OnFirstUpdate():\tERROR---missing SDL (%s)" % varstring.value)
             return
 
         self.SDL.setDefault("LvrPos",(0,)) # local only: set default lever position, Load() will correct if necessary
@@ -87,7 +87,7 @@ class x2wayLever(ptResponder):
         else:               # lever in position no.2
             actTo1.enable()
             actTo2.disable()
-        print "x2wayLever.Load():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value)
+        print("x2wayLever.Load():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
         
     def OnNotify(self,state,id,events):
     
@@ -103,12 +103,12 @@ class x2wayLever(ptResponder):
             elif id==respTo2.id or id==respTo1.id:
                 leverPos = -(leverPos-1)
                 self.SDL["LvrPos"] = (leverPos,)
-                print "x2wayLever.OnNotify:\tsending notify: '%s' moving to position %d" % (varstring.value,leverPos+1)
+                print("x2wayLever.OnNotify:\tsending notify: '%s' moving to position %d" % (varstring.value,leverPos+1))
                 note = ptNotify(self.key)
                 note.setActivate(1.0)
                 note.addVarNumber(varstring.value,leverPos)
                 note.send()
-                print "x2wayLever.OnNotify():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value)
+                print("x2wayLever.OnNotify():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
             else:
-                print "x2wayLever.OnNotify:\tERROR: unanticipated message source."
+                print("x2wayLever.OnNotify:\tERROR: unanticipated message source.")
             return

--- a/Python/x2wayLever.py
+++ b/Python/x2wayLever.py
@@ -67,16 +67,16 @@ class x2wayLever(ptResponder):
         
         version = 1
         self.version = version
-        print("__init__x2wayLever v.", version)
+        PtDebugPrint("__init__x2wayLever v.", version)
 
     def OnFirstUpdate(self):
         if self.SDL == None:
-            print("x2wayLever.OnFirstUpdate():\tERROR---missing SDL (%s)" % varstring.value)
+            PtDebugPrint("x2wayLever.OnFirstUpdate():\tERROR---missing SDL (%s)" % varstring.value)
             return
 
         self.SDL.setDefault("LvrPos",(0,)) # local only: set default lever position, Load() will correct if necessary
         actTo1.disable() # set default activator state, Load() will correct if necessary
-        #print "x2wayLever.OnFirstUpdate():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value)
+        #PtDebugPrint("x2wayLever.OnFirstUpdate():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
     
     #Load() gets called after OnFirstUpdate IF anyone has updated the server's SDL (SDL.setDefault above is local only)
     def Load(self):
@@ -87,7 +87,7 @@ class x2wayLever(ptResponder):
         else:               # lever in position no.2
             actTo1.enable()
             actTo2.disable()
-        print("x2wayLever.Load():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
+        PtDebugPrint("x2wayLever.Load():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
         
     def OnNotify(self,state,id,events):
     
@@ -103,12 +103,12 @@ class x2wayLever(ptResponder):
             elif id==respTo2.id or id==respTo1.id:
                 leverPos = -(leverPos-1)
                 self.SDL["LvrPos"] = (leverPos,)
-                print("x2wayLever.OnNotify:\tsending notify: '%s' moving to position %d" % (varstring.value,leverPos+1))
+                PtDebugPrint("x2wayLever.OnNotify:\tsending notify: '%s' moving to position %d" % (varstring.value,leverPos+1))
                 note = ptNotify(self.key)
                 note.setActivate(1.0)
                 note.addVarNumber(varstring.value,leverPos)
                 note.send()
-                print("x2wayLever.OnNotify():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
+                PtDebugPrint("x2wayLever.OnNotify():\tself.SDL[LvrPos]=%d (%s)" % (self.SDL["LvrPos"][0],varstring.value))
             else:
-                print("x2wayLever.OnNotify:\tERROR: unanticipated message source.")
+                PtDebugPrint("x2wayLever.OnNotify:\tERROR: unanticipated message source.")
             return

--- a/Python/xAgeSDLBoolCondResp.py
+++ b/Python/xAgeSDLBoolCondResp.py
@@ -84,7 +84,7 @@ class xAgeSDLBoolCondResp(ptResponder):
             return
 
         ageSDL = PtGetAgeSDL()
-        #print "DEBUG: xAgeSDLBoolCondResp.OnServerInitComplete()\tRegistered var is: %s = %s" % (strSDLVar.value, ageSDL[strSDLVar.value][0])
+        #PtDebugPrint("DEBUG: xAgeSDLBoolCondResp.OnServerInitComplete()\tRegistered var is: %s = %s" % (strSDLVar.value, ageSDL[strSDLVar.value][0]))
         if ageSDL[strSDLVar.value][0] == boolOnTrue.value:
             respResponder.run(self.key, fastforward=boolInitFF.value)
             PtDebugPrint("DEBUG: xAgeSDLBoolCondResp.OnServerInitComplete():\tRunning responder on %s, fastforward=%d" % (self.sceneobject.getName(), boolInitFF.value))

--- a/Python/xAgeSDLIntActEnabler.py
+++ b/Python/xAgeSDLIntActEnabler.py
@@ -63,7 +63,7 @@ class xAgeSDLIntActEnabler(ptResponder):
         version = 1
         self.version = version
         self.enabledStateList = []
-        print("__init__xAgeSDLIntActEnabler v.", version)
+        PtDebugPrint("__init__xAgeSDLIntActEnabler v.", version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAgeSDLIntActEnabler.py
+++ b/Python/xAgeSDLIntActEnabler.py
@@ -63,7 +63,7 @@ class xAgeSDLIntActEnabler(ptResponder):
         version = 1
         self.version = version
         self.enabledStateList = []
-        print "__init__xAgeSDLIntActEnabler v.", version
+        print("__init__xAgeSDLIntActEnabler v.", version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAgeSDLIntRespList.py
+++ b/Python/xAgeSDLIntRespList.py
@@ -72,7 +72,7 @@ class xAgeSDLIntRespList(ptResponder):
         ptModifier.__init__(self)
         self.id = 5307
         self.version = 2
-        print("__init__xAgeSDLIntRespList v.", self.version)
+        PtDebugPrint("__init__xAgeSDLIntRespList v.", self.version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAgeSDLIntRespList.py
+++ b/Python/xAgeSDLIntRespList.py
@@ -72,7 +72,7 @@ class xAgeSDLIntRespList(ptResponder):
         ptModifier.__init__(self)
         self.id = 5307
         self.version = 2
-        print "__init__xAgeSDLIntRespList v.", self.version
+        print("__init__xAgeSDLIntRespList v.", self.version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAgeSDLIntStartStopResp.py
+++ b/Python/xAgeSDLIntStartStopResp.py
@@ -68,7 +68,7 @@ class xAgeSDLIntStartStopResp(ptResponder):
         version = 1
         self.version = version
         self.enabledStateList = []
-        print "__init__xAgeSDLIntStartStopResp v.", version
+        print("__init__xAgeSDLIntStartStopResp v.", version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAgeSDLIntStartStopResp.py
+++ b/Python/xAgeSDLIntStartStopResp.py
@@ -68,7 +68,7 @@ class xAgeSDLIntStartStopResp(ptResponder):
         version = 1
         self.version = version
         self.enabledStateList = []
-        print("__init__xAgeSDLIntStartStopResp v.", version)
+        PtDebugPrint("__init__xAgeSDLIntStartStopResp v.", version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAgeSDLIntStateListResp.py
+++ b/Python/xAgeSDLIntStateListResp.py
@@ -123,7 +123,7 @@ class xAgeSDLIntStateListResp(ptResponder):
         version = 1
         self.version = version
         self.enabledStateList = []
-        print("__init__xAgeSDLIntStateListResp v", version)
+        PtDebugPrint("__init__xAgeSDLIntStateListResp v", version)
     
     def OnFirstUpdate(self):
         if not strSDLVarName.value:
@@ -160,7 +160,7 @@ class xAgeSDLIntStateListResp(ptResponder):
             PtDebugPrint("ERROR: xAgeSDLIntStateListResp.OnServerInitComplete():\tPlease enter states in the format: (val,stateNum)(val,stateNum)")
             """
             import sys
-            print "ERROR: Caught Exception: ", sys.exc_type, " --> ", sys.exc_value
+            PtDebugPrint("ERROR: Caught Exception: ", sys.exc_type, " --> ", sys.exc_value)
             """
             return
 

--- a/Python/xAgeSDLIntStateListResp.py
+++ b/Python/xAgeSDLIntStateListResp.py
@@ -123,7 +123,7 @@ class xAgeSDLIntStateListResp(ptResponder):
         version = 1
         self.version = version
         self.enabledStateList = []
-        print "__init__xAgeSDLIntStateListResp v", version
+        print("__init__xAgeSDLIntStateListResp v", version)
     
     def OnFirstUpdate(self):
         if not strSDLVarName.value:
@@ -198,7 +198,7 @@ class xAgeSDLIntStateListResp(ptResponder):
 
 
     def UpdateState(self, SDLval, avatar, fastforward):
-        if  self.dictStates.has_key(SDLval):  #Run the responder only if we have the state
+        if  SDLval in self.dictStates:  #Run the responder only if we have the state
             PtDebugPrint("DEBUG: xAgeSDLIntStateListResp.OnSDLNotify: running state responder: %s" % self.dictStates[SDLval])
             respEnterState.run(self.key,state=self.dictStates[SDLval], avatar=avatar, fastforward=fastforward)
         else:

--- a/Python/xAgeSDLVarSet.py
+++ b/Python/xAgeSDLVarSet.py
@@ -71,7 +71,7 @@ class xAgeSDLVarSet(ptResponder):
         version = 2
         self.version = version
         self.enabledStateDict = {}
-        print "__init__xAgeSDLVarSet v.", version
+        print("__init__xAgeSDLVarSet v.", version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:
@@ -112,7 +112,7 @@ class xAgeSDLVarSet(ptResponder):
         PtDebugPrint("DEBUG: xAgeSDLVarSet.OnServerInitComplete:\tCurrent SDL value = %d" % SDLvalue)
         
         # Check if the current SDL value represents a state in the dictionary and set the other SDL value to the value in the dictionary (yay for values!)
-        if  self.enabledStateDict.has_key(int(SDLvalue)):
+        if  int(SDLvalue) in self.enabledStateDict:
             ageSDL[stringSDLVarToSet.value] = (self.enabledStateDict[int(SDLvalue)],)
             if stringSDLVarToSet:
                 ageSDL.setTagString(stringSDLVarToSet.value,stringTag.value)
@@ -133,7 +133,7 @@ class xAgeSDLVarSet(ptResponder):
         SDLvalue = ageSDL[stringSDLVarName.value][0]
         
         # Check if the current SDL value represents a state in the dictionary and set the other SDL value to the value in the dictionary (yay for values!)
-        if  self.enabledStateDict.has_key(int(SDLvalue)):
+        if  int(SDLvalue) in self.enabledStateDict:
             ageSDL[stringSDLVarToSet.value] = (self.enabledStateDict[int(SDLvalue)],)
             if stringSDLVarToSet:
                 ageSDL.setTagString(stringSDLVarToSet.value,stringTag.value)

--- a/Python/xAgeSDLVarSet.py
+++ b/Python/xAgeSDLVarSet.py
@@ -71,7 +71,7 @@ class xAgeSDLVarSet(ptResponder):
         version = 2
         self.version = version
         self.enabledStateDict = {}
-        print("__init__xAgeSDLVarSet v.", version)
+        PtDebugPrint("__init__xAgeSDLVarSet v.", version)
     
     def OnFirstUpdate(self):
         if not stringSDLVarName.value:

--- a/Python/xAvatarCustomization.py
+++ b/Python/xAvatarCustomization.py
@@ -1013,7 +1013,7 @@ class xAvatarCustomization(ptModifier):
                             else:
                                 PtChangeAvatar("Female")
                     elif btnID == kAvatarCameraID:
-                        print "ACA: Taking a picture!"
+                        print("ACA: Taking a picture!")
                         picCam = ptCamera()
                         picCam.setAspectRatio(1)
                         AvCustGUI.dialog.hide()
@@ -1049,10 +1049,10 @@ class xAvatarCustomization(ptModifier):
         avatar = PtGetLocalAvatar()
         currentgender = avatar.avatar.getAvatarClothingGroup()
         if currentgender == 1:
-            print "Female Screenshot"
+            print("Female Screenshot")
             TestMap.textmap.drawImageClipped(0, 0, image, 55, 250, 512, 512, 0)
         else:
-            print "Male Screenshot"
+            print("Male Screenshot")
             TestMap.textmap.drawImageClipped(0, 0, image, 55, 80, 512, 512, 0)
         TestMap.textmap.flush()
         PtAtTimeCallback(self.key, 0, 999)
@@ -1230,10 +1230,10 @@ class xAvatarCustomization(ptModifier):
                 clothingName = "02_MTorso09_01"
             clothingList = avatar.avatar.getWardrobeClothingList()
             if clothingName not in clothingList:
-                print "adding Yeesha reward clothing %s to wardrobe" % (clothingName)
+                print("adding Yeesha reward clothing %s to wardrobe" % (clothingName))
                 avatar.avatar.addWardrobeClothingItem(clothingName,ptColor().white(),ptColor().black())
             else:
-                print "player already has Yeesha reward clothing, doing nothing"
+                print("player already has Yeesha reward clothing, doing nothing")
             folder = vault.getChronicleFolder()
             if folder is not None:
                 folder.removeNode(entry)
@@ -1290,10 +1290,10 @@ class xAvatarCustomization(ptModifier):
             newImage = TestMap.textmap.getImage()
             basePath = PtGetUserPath() + U"\\Avatars\\"
             if not PtCreateDir(basePath):
-                print U"xAvatarCustomization::OnTimer(): Unable to create \"" + basePath + "\" directory. Avatar pic is NOT saved."
+                print(U"xAvatarCustomization::OnTimer(): Unable to create \"" + basePath + "\" directory. Avatar pic is NOT saved.")
                 return
             filename = basePath + unicode(PtGetLocalPlayer().getPlayerID()) + U".jpg"
-            print U"xAvatarCustomization::OnTimer(): Saving avatar pic to \"" + filename + U"\""
+            print(U"xAvatarCustomization::OnTimer(): Saving avatar pic to \"" + filename + U"\"")
             newImage.saveAsJPEG(filename, 90)
 
     def IUpdateAllControls(self):

--- a/Python/xAvatarCustomization.py
+++ b/Python/xAvatarCustomization.py
@@ -1013,7 +1013,7 @@ class xAvatarCustomization(ptModifier):
                             else:
                                 PtChangeAvatar("Female")
                     elif btnID == kAvatarCameraID:
-                        print("ACA: Taking a picture!")
+                        PtDebugPrint("ACA: Taking a picture!")
                         picCam = ptCamera()
                         picCam.setAspectRatio(1)
                         AvCustGUI.dialog.hide()
@@ -1049,10 +1049,10 @@ class xAvatarCustomization(ptModifier):
         avatar = PtGetLocalAvatar()
         currentgender = avatar.avatar.getAvatarClothingGroup()
         if currentgender == 1:
-            print("Female Screenshot")
+            PtDebugPrint("Female Screenshot")
             TestMap.textmap.drawImageClipped(0, 0, image, 55, 250, 512, 512, 0)
         else:
-            print("Male Screenshot")
+            PtDebugPrint("Male Screenshot")
             TestMap.textmap.drawImageClipped(0, 0, image, 55, 80, 512, 512, 0)
         TestMap.textmap.flush()
         PtAtTimeCallback(self.key, 0, 999)
@@ -1230,10 +1230,10 @@ class xAvatarCustomization(ptModifier):
                 clothingName = "02_MTorso09_01"
             clothingList = avatar.avatar.getWardrobeClothingList()
             if clothingName not in clothingList:
-                print("adding Yeesha reward clothing %s to wardrobe" % (clothingName))
+                PtDebugPrint("adding Yeesha reward clothing %s to wardrobe" % (clothingName))
                 avatar.avatar.addWardrobeClothingItem(clothingName,ptColor().white(),ptColor().black())
             else:
-                print("player already has Yeesha reward clothing, doing nothing")
+                PtDebugPrint("player already has Yeesha reward clothing, doing nothing")
             folder = vault.getChronicleFolder()
             if folder is not None:
                 folder.removeNode(entry)
@@ -1290,10 +1290,10 @@ class xAvatarCustomization(ptModifier):
             newImage = TestMap.textmap.getImage()
             basePath = PtGetUserPath() + U"\\Avatars\\"
             if not PtCreateDir(basePath):
-                print(U"xAvatarCustomization::OnTimer(): Unable to create \"" + basePath + "\" directory. Avatar pic is NOT saved.")
+                PtDebugPrint(U"xAvatarCustomization::OnTimer(): Unable to create \"" + basePath + "\" directory. Avatar pic is NOT saved.")
                 return
             filename = basePath + unicode(PtGetLocalPlayer().getPlayerID()) + U".jpg"
-            print(U"xAvatarCustomization::OnTimer(): Saving avatar pic to \"" + filename + U"\"")
+            PtDebugPrint(U"xAvatarCustomization::OnTimer(): Saving avatar pic to \"" + filename + U"\"")
             newImage.saveAsJPEG(filename, 90)
 
     def IUpdateAllControls(self):

--- a/Python/xBlueSpiral.py
+++ b/Python/xBlueSpiral.py
@@ -117,7 +117,7 @@ class xBlueSpiral(ptResponder, object):
         self._spinning = False
         self._doorOpen = False
         random.seed()
-        print "xBlueSpiral: init  version = %d" % self.version
+        print("xBlueSpiral: init  version = %d" % self.version)
         random.seed()
 
     def _clothmap_get(self):
@@ -290,9 +290,9 @@ class xBlueSpiral(ptResponder, object):
             for i in xrange(len(copy)):
                 copy[i] = self.clothmap[copy[i]] + 1
             # For you l337 haxxors out there...
-            print "--- Blue Spiral Solution IDs ---"
-            print repr(copy)
-            print "--------------------------------"
+            print("--- Blue Spiral Solution IDs ---")
+            print(repr(copy))
+            print("--------------------------------")
             PtAtTimeCallback(self.key, 2, kUpdateDoorDisplay)
             return
 

--- a/Python/xBlueSpiral.py
+++ b/Python/xBlueSpiral.py
@@ -117,7 +117,7 @@ class xBlueSpiral(ptResponder, object):
         self._spinning = False
         self._doorOpen = False
         random.seed()
-        print("xBlueSpiral: init  version = %d" % self.version)
+        PtDebugPrint("xBlueSpiral: init  version = %d" % self.version)
         random.seed()
 
     def _clothmap_get(self):
@@ -290,9 +290,9 @@ class xBlueSpiral(ptResponder, object):
             for i in xrange(len(copy)):
                 copy[i] = self.clothmap[copy[i]] + 1
             # For you l337 haxxors out there...
-            print("--- Blue Spiral Solution IDs ---")
-            print(repr(copy))
-            print("--------------------------------")
+            PtDebugPrint("--- Blue Spiral Solution IDs ---")
+            PtDebugPrint(repr(copy))
+            PtDebugPrint("--------------------------------")
             PtAtTimeCallback(self.key, 2, kUpdateDoorDisplay)
             return
 

--- a/Python/xBugsGoAway.py
+++ b/Python/xBugsGoAway.py
@@ -82,15 +82,15 @@ class xBugsGoAway(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print("xBugsGoAway.OnServerInitComplete() - failed to get local avatar")
+            PtDebugPrint("xBugsGoAway.OnServerInitComplete() - failed to get local avatar")
             return
         
         self.bugCount = self.IGetBugCount()
-        print("xBugsGoAway.OnServerInitComplete() - Linking in with "+str(self.bugCount)+" bugs")
+        PtDebugPrint("xBugsGoAway.OnServerInitComplete() - Linking in with "+str(self.bugCount)+" bugs")
 
         if (self.bugCount != 0):
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             PtKillParticles(10.0,1,avatar.getKey())
             PtSetLightAnimStart(avatar.getKey(),bugLightObjectName,False)
-            print("xBugsGoAway.OnServerInitComplete() - Killing all bugs")
+            PtDebugPrint("xBugsGoAway.OnServerInitComplete() - Killing all bugs")
             self.ISaveBugCount(0)

--- a/Python/xBugsGoAway.py
+++ b/Python/xBugsGoAway.py
@@ -82,15 +82,15 @@ class xBugsGoAway(ptResponder):
         try:
             avatar = PtGetLocalAvatar()
         except:
-            print "xBugsGoAway.OnServerInitComplete() - failed to get local avatar"
+            print("xBugsGoAway.OnServerInitComplete() - failed to get local avatar")
             return
         
         self.bugCount = self.IGetBugCount()
-        print"xBugsGoAway.OnServerInitComplete() - Linking in with "+str(self.bugCount)+" bugs"
+        print("xBugsGoAway.OnServerInitComplete() - Linking in with "+str(self.bugCount)+" bugs")
 
         if (self.bugCount != 0):
             PtSetParticleDissentPoint(0,0,10000,avatar.getKey())
             PtKillParticles(10.0,1,avatar.getKey())
             PtSetLightAnimStart(avatar.getKey(),bugLightObjectName,False)
-            print "xBugsGoAway.OnServerInitComplete() - Killing all bugs"
+            print("xBugsGoAway.OnServerInitComplete() - Killing all bugs")
             self.ISaveBugCount(0)

--- a/Python/xButtonLeverSwitch.py
+++ b/Python/xButtonLeverSwitch.py
@@ -65,7 +65,7 @@ class xButtonLeverSwitch(ptResponder):
         
         version = 1
         self.version = version
-        print "__init__xButtonLeverSwitch v.", version
+        print("__init__xButtonLeverSwitch v.", version)
         
     def OnNotify(self,state,id,events):
 	
@@ -73,11 +73,11 @@ class xButtonLeverSwitch(ptResponder):
 		if id==act.id:
 			resp.run(self.key,events=events)
 		elif id==resp.id:
-			print "xButtonLeverSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value
+			print("xButtonLeverSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value)
 	                note = ptNotify(self.key)
 	                note.setActivate(1.0)
 	                note.addVarNumber(varstring.value,1.0)
 	                note.send()
 	        else:
-			print "xButtonLeverSwitch.OnNotify:\tERROR: unanticipated message source."
+			print("xButtonLeverSwitch.OnNotify:\tERROR: unanticipated message source.")
 			return

--- a/Python/xButtonLeverSwitch.py
+++ b/Python/xButtonLeverSwitch.py
@@ -65,7 +65,7 @@ class xButtonLeverSwitch(ptResponder):
         
         version = 1
         self.version = version
-        print("__init__xButtonLeverSwitch v.", version)
+        PtDebugPrint("__init__xButtonLeverSwitch v.", version)
         
     def OnNotify(self,state,id,events):
 	
@@ -73,11 +73,11 @@ class xButtonLeverSwitch(ptResponder):
 		if id==act.id:
 			resp.run(self.key,events=events)
 		elif id==resp.id:
-			print("xButtonLeverSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value)
+			PtDebugPrint("xButtonLeverSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value)
 	                note = ptNotify(self.key)
 	                note.setActivate(1.0)
 	                note.addVarNumber(varstring.value,1.0)
 	                note.send()
 	        else:
-			print("xButtonLeverSwitch.OnNotify:\tERROR: unanticipated message source.")
+			PtDebugPrint("xButtonLeverSwitch.OnNotify:\tERROR: unanticipated message source.")
 			return

--- a/Python/xButtonLeverSwitchPowered.py
+++ b/Python/xButtonLeverSwitchPowered.py
@@ -68,11 +68,11 @@ class xButtonLeverSwitchPowered(ptResponder):
         
         version = 1
         self.version = version
-        print "__init__xButtonLeverSwitchPowered v.", version
+        print("__init__xButtonLeverSwitchPowered v.", version)
 
     def OnServerInitComplete(self):
         if self.SDL == None:
-            print "xButtonLeverSwitchPowered.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value
+            print("xButtonLeverSwitchPowered.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
             return
         if enabled.value:
             self.SDL.setDefault("enabled",(1,)) # local only: set default lever position, Load() will correct if necessary
@@ -91,21 +91,21 @@ class xButtonLeverSwitchPowered(ptResponder):
                                     elif event[3] == 0:
                                         self.SDL["enabled"] = (0,)
                                     else:
-                                        print "xButtonLeverSwitchPowered.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0])
+                                        print("xButtonLeverSwitchPowered.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
                                         return
-                                    print "xButtonLeverSwitchPowered.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0])
+                                    print("xButtonLeverSwitchPowered.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
 
                 if id==actClick.id:
                         if self.SDL["enabled"][0]:
                                 respOn.run(self.key,events=events)
-                                print "xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (powered)" % varstring.value
+                                print("xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (powered)" % varstring.value)
                         else:
                                 respOff.run(self.key,events=events)
-                                print "xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (not powered)" % varstring.value
+                                print("xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (not powered)" % varstring.value)
                         return
                         
                 if id==respOn.id:
-                        print "xButtonLeverSwitchPowered.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value
+                        print("xButtonLeverSwitchPowered.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value)
                         note = ptNotify(self.key)
                         note.setActivate(1.0)
                         note.addVarNumber(varstring.value,1.0)

--- a/Python/xButtonLeverSwitchPowered.py
+++ b/Python/xButtonLeverSwitchPowered.py
@@ -68,11 +68,11 @@ class xButtonLeverSwitchPowered(ptResponder):
         
         version = 1
         self.version = version
-        print("__init__xButtonLeverSwitchPowered v.", version)
+        PtDebugPrint("__init__xButtonLeverSwitchPowered v.", version)
 
     def OnServerInitComplete(self):
         if self.SDL == None:
-            print("xButtonLeverSwitchPowered.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
+            PtDebugPrint("xButtonLeverSwitchPowered.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
             return
         if enabled.value:
             self.SDL.setDefault("enabled",(1,)) # local only: set default lever position, Load() will correct if necessary
@@ -91,21 +91,21 @@ class xButtonLeverSwitchPowered(ptResponder):
                                     elif event[3] == 0:
                                         self.SDL["enabled"] = (0,)
                                     else:
-                                        print("xButtonLeverSwitchPowered.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
+                                        PtDebugPrint("xButtonLeverSwitchPowered.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
                                         return
-                                    print("xButtonLeverSwitchPowered.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
+                                    PtDebugPrint("xButtonLeverSwitchPowered.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
 
                 if id==actClick.id:
                         if self.SDL["enabled"][0]:
                                 respOn.run(self.key,events=events)
-                                print("xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (powered)" % varstring.value)
+                                PtDebugPrint("xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (powered)" % varstring.value)
                         else:
                                 respOff.run(self.key,events=events)
-                                print("xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (not powered)" % varstring.value)
+                                PtDebugPrint("xButtonLeverSwitchPowered.OnNotify:\t'%s' activated (not powered)" % varstring.value)
                         return
                         
                 if id==respOn.id:
-                        print("xButtonLeverSwitchPowered.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value)
+                        PtDebugPrint("xButtonLeverSwitchPowered.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % varstring.value)
                         note = ptNotify(self.key)
                         note.setActivate(1.0)
                         note.addVarNumber(varstring.value,1.0)

--- a/Python/xCalendarStar.py
+++ b/Python/xCalendarStar.py
@@ -129,21 +129,21 @@ class xCalendarStar(ptResponder):
             PtDebugPrint("DEBUG: xCalendarStar.OnNotify():\t local player requesting %s change via %s" % (sdlCalStar.value,rgnCalStar.value[0].getName()) )
 
         if not self.GotPage():
-            print "xCalendarStar.OnNotify(): do NOT have YeeshaPage20 (the Calendar Pinnacle) yet"
+            print("xCalendarStar.OnNotify(): do NOT have YeeshaPage20 (the Calendar Pinnacle) yet")
             return            
         else:
-            print "xCalendarStar.OnNotify():  have YeeshaPage20 (the Calendar Pinnacle)"
+            print("xCalendarStar.OnNotify():  have YeeshaPage20 (the Calendar Pinnacle)")
 
             if AgeStartedIn == PtGetAgeName():
                 psnlSDL = xPsnlVaultSDL()
             if not boolCalStar:
-                print "xCalendarStar.OnNotify(): getting star's stone: ",sdlCalStar.value
+                print("xCalendarStar.OnNotify(): getting star's stone: ",sdlCalStar.value)
                 psnlSDL[sdlCalStar.value] = (1,)
                 respCalStar.run(self.key)
                 boolCalStar = 1
                 PtSendKIMessageInt(kStartBookAlert,0)
             else:
-                print "xCalendarStar.OnNotify(): already have the stone: ",sdlCalStar.value
+                print("xCalendarStar.OnNotify(): already have the stone: ",sdlCalStar.value)
 
 
     def GotPage(self):
@@ -154,7 +154,7 @@ class xCalendarStar(ptResponder):
             ypageSDL = psnlSDL.findVar("YeeshaPage20")
             if ypageSDL:
                 size, state = divmod(ypageSDL.getInt(), 10)
-                print "YeeshaPage20 = ",state
+                print("YeeshaPage20 = ",state)
                 if state:
                     return 1
         return 0

--- a/Python/xCalendarStar.py
+++ b/Python/xCalendarStar.py
@@ -129,21 +129,21 @@ class xCalendarStar(ptResponder):
             PtDebugPrint("DEBUG: xCalendarStar.OnNotify():\t local player requesting %s change via %s" % (sdlCalStar.value,rgnCalStar.value[0].getName()) )
 
         if not self.GotPage():
-            print("xCalendarStar.OnNotify(): do NOT have YeeshaPage20 (the Calendar Pinnacle) yet")
+            PtDebugPrint("xCalendarStar.OnNotify(): do NOT have YeeshaPage20 (the Calendar Pinnacle) yet")
             return            
         else:
-            print("xCalendarStar.OnNotify():  have YeeshaPage20 (the Calendar Pinnacle)")
+            PtDebugPrint("xCalendarStar.OnNotify():  have YeeshaPage20 (the Calendar Pinnacle)")
 
             if AgeStartedIn == PtGetAgeName():
                 psnlSDL = xPsnlVaultSDL()
             if not boolCalStar:
-                print("xCalendarStar.OnNotify(): getting star's stone: ",sdlCalStar.value)
+                PtDebugPrint("xCalendarStar.OnNotify(): getting star's stone: ",sdlCalStar.value)
                 psnlSDL[sdlCalStar.value] = (1,)
                 respCalStar.run(self.key)
                 boolCalStar = 1
                 PtSendKIMessageInt(kStartBookAlert,0)
             else:
-                print("xCalendarStar.OnNotify(): already have the stone: ",sdlCalStar.value)
+                PtDebugPrint("xCalendarStar.OnNotify(): already have the stone: ",sdlCalStar.value)
 
 
     def GotPage(self):
@@ -154,7 +154,7 @@ class xCalendarStar(ptResponder):
             ypageSDL = psnlSDL.findVar("YeeshaPage20")
             if ypageSDL:
                 size, state = divmod(ypageSDL.getInt(), 10)
-                print("YeeshaPage20 = ",state)
+                PtDebugPrint("YeeshaPage20 = ",state)
                 if state:
                     return 1
         return 0

--- a/Python/xCheat.py
+++ b/Python/xCheat.py
@@ -55,9 +55,9 @@ def ListYeeshaPages(args):
     if psnlSDL:
         for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
             FoundValue = psnlSDL.findVar(sdlvar)
-            print "%s is %d" % (sdlvar, FoundValue.getInt())
+            print("%s is %d" % (sdlvar, FoundValue.getInt()))
     else:
-        print "Could not find personal age SDL"
+        print("Could not find personal age SDL")
 
 
 def GetAllYeeshaPages(args):
@@ -68,16 +68,16 @@ def GetAllYeeshaPages(args):
     if psnlSDL:
         if args == "0":
             newval = 0
-            print "xCheat.GetYeeshaPage(): removing all Yeesha pages..."
+            print("xCheat.GetYeeshaPage(): removing all Yeesha pages...")
         else:
             newval = 1
-            print "xCheat.GetYeeshaPage(): adding all Yeesha pages..."
+            print("xCheat.GetYeeshaPage(): adding all Yeesha pages...")
         for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
             FoundValue = psnlSDL.findVar(sdlvar)
             FoundValue.setInt(newval)
         vault.updatePsnlAgeSDL(psnlSDL)
     else:
-        print "Could not find personal age SDL"
+        print("Could not find personal age SDL")
 
 
 def GetYeeshaPage(args):
@@ -86,7 +86,7 @@ def GetYeeshaPage(args):
     vault = Plasma.ptVault()
     psnlSDL = vault.getPsnlAgeSDL()
     if not args:
-        print "xCheat.GetYeeshaPage(): ERROR.  Must provide a Yeesha Page number."
+        print("xCheat.GetYeeshaPage(): ERROR.  Must provide a Yeesha Page number.")
         return
     thispage = "YeeshaPage" + args
     if psnlSDL:
@@ -95,11 +95,11 @@ def GetYeeshaPage(args):
                 FoundValue = psnlSDL.findVar(sdlvar)
                 FoundValue.setInt(1)
                 vault.updatePsnlAgeSDL(psnlSDL)
-                print "xCheat.GetYeeshaPage(): Done. Have added: ",sdlvar
+                print("xCheat.GetYeeshaPage(): Done. Have added: ",sdlvar)
                 return
-        print "xCheat.GetYeeshaPage(): ERROR.  Could not find Yeesha page: ",thispage
+        print("xCheat.GetYeeshaPage(): ERROR.  Could not find Yeesha page: ",thispage)
     else:
-        print "xCheat.GetYeeshaPage(): ERROR.  Could not find personal age SDL"
+        print("xCheat.GetYeeshaPage(): ERROR.  Could not find personal age SDL")
 
 
 def GetAgeJourneyCloths(args):
@@ -192,7 +192,7 @@ def GenerateCleftSolution(args):
             newnode.chronicleSetValue("1," + ageVal + "," + str(v + 1))
             #newnode.chronicleSetValue("1," + str(solutionlist[v]) + "," + str(v + 1))
             entry.addNode(newnode)
-            print "%s solution is %s" % (agelist[v], ageVal)
+            print("%s solution is %s" % (agelist[v], ageVal))
 
 
 def ResetEnding(args):
@@ -222,9 +222,9 @@ def SndWhatIsLogTrack(args):
 def SndIsLogMode(args):
     import xSndLogTracks
     if xSndLogTracks.IsLogMode():
-        print "yes"
+        print("yes")
     else:
-        print "not yet"
+        print("not yet")
 
 
 def SndSetLogMode(args):
@@ -313,7 +313,7 @@ def GZGetMarkers(args):
                     newgotten = markerGottenNumber + markersToGet
                     if newgotten > markerToGetNumber:
                         newgotten = markerToGetNumber
-                    print "Updating markers gotten to %d from %d" % (newgotten,markerToGetNumber)
+                    print("Updating markers gotten to %d from %d" % (newgotten,markerToGetNumber))
                     upstring = "%d %s:%s %d:%d" % (markerGame,markerGottenColor,markerToGetColor,newgotten,markerToGetNumber)
                     entry.chronicleSetValue(upstring)
                     entry.save()
@@ -330,19 +330,19 @@ def GZGetMarkers(args):
                                     markers = markers[:markerIdx] + PlasmaKITypes.kGZMarkerCaptured + markers[-(len(markers)-(markerIdx+1)):]
                                 else:
                                     markers = markers[:markerIdx] + PlasmaKITypes.kGZMarkerCaptured
-                                print "Update marker #%d - out string is '%s'" % (markerIdx+1,markers)
+                                print("Update marker #%d - out string is '%s'" % (markerIdx+1,markers))
                                 entry.chronicleSetValue(markers)
                                 entry.save()
                     # update the 
                     Plasma.PtSendKIMessage(PlasmaKITypes.kGZUpdated,0)
                     return
                 except ValueError:
-                    print "xKI:GZ - error trying to read GZGames Chronicle '%s'" % (gameString)
+                    print("xKI:GZ - error trying to read GZGames Chronicle '%s'" % (gameString))
             else:
-                print "xKI:GZ - error GZGames string formation error (len=%d)" % (len(gargs))
+                print("xKI:GZ - error GZGames string formation error (len=%d)" % (len(gargs)))
         else:
             # if there is none, then error
-            print "Error - there is no GZMarker game going!"
+            print("Error - there is no GZMarker game going!")
 
 
 def GiveMeMarkerTag(args):
@@ -451,7 +451,7 @@ def ShowHiddenFolder(args):
                     break
     if jfolder:
         # need to try to find the game
-        print "Hidden folder contents:"
+        print("Hidden folder contents:")
         folderRefs = jfolder.getChildNodeRefList()
         for jref in folderRefs:
             jnode = jref.getChild()
@@ -459,9 +459,9 @@ def ShowHiddenFolder(args):
             # is it a marker folder list?
             if jnode is not None:
                 # is it named the right one?
-                print "markerFolder - ",jnode.folderGetName()
+                print("markerFolder - ",jnode.folderGetName())
     else:
-        print "There is no Hidden folder"
+        print("There is no Hidden folder")
 
 
 def RemoveHiddenContent(args):
@@ -482,10 +482,10 @@ def RemoveHiddenContent(args):
                     jfolder = agefolder
                     break
     if jfolder:
-        print "Removing content"
+        print("Removing content")
         jfolder.removeAllNodes()
     else:
-        print "There is no Hidden folder"
+        print("There is no Hidden folder")
 
 
 #=======================================================
@@ -498,7 +498,7 @@ def RemoveHiddenContent(args):
 def _DumpEm(f,markerfolder,mfNumber):
     lines = 0
     tab = ""
-    print "  -dumping %s" % (markerfolder.getFolderName())
+    print("  -dumping %s" % (markerfolder.getFolderName()))
     f.write("#\n")
     f.write("# %s\n" %(markerfolder.getFolderName()))
     f.write("MG%02d = [ " % (mfNumber))
@@ -524,7 +524,7 @@ def _DumpEm(f,markerfolder,mfNumber):
             numMarkers += 1
     f.write("  ]\\\n]\n")
     lines += 2
-    print "      with %d markers" % (numMarkers)
+    print("      with %d markers" % (numMarkers))
     return lines
 
 
@@ -533,7 +533,7 @@ def DumpMarkers(args):
     import Plasma
     arglist = args.split()
     if len(arglist) < 2:
-        print 'ERROR - not enough arguments - DumpMarkers "filename foldername [markername]")'
+        print('ERROR - not enough arguments - DumpMarkers "filename foldername [markername]")')
         return
     filename = arglist[0]
     dfile = open(filename,'w+')
@@ -577,13 +577,13 @@ def DumpMarkers(args):
                         lines += _DumpEm(dfile,jentry,totalmfs+1)
                         totalmfs += 1
         else:
-            print "Could not find folder"
+            print("Could not find folder")
     else:
-        print "Master age journal folders could not be found"
+        print("Master age journal folders could not be found")
     sess = "s"
     if totalmfs == 1:
         sess = ""
-    print "==Wrote %d markerfolder%s. %d lines total==" % (totalmfs,sess,lines)
+    print("==Wrote %d markerfolder%s. %d lines total==" % (totalmfs,sess,lines))
     dfile.write("mgs = [")
     for mg in range(totalmfs):
         dfile.write("(MG%02d,'MG%02d')," % (mg+1,mg+1))
@@ -597,13 +597,13 @@ def ImportGames(args):
     import PlasmaVaultConstants
     arglist = args.split()
     if len(arglist) < 2:
-        print 'ERROR - not enough arguments - ImportMarkers "filename foldername")'
+        print('ERROR - not enough arguments - ImportMarkers "filename foldername")')
         return
     filename = arglist[0]
     try:
         dfile = open(filename+'.py','r')
     except IOError:
-        print "ERROR - file %d could not be found" % (filename+'.py')
+        print("ERROR - file %d could not be found" % (filename+'.py'))
         return
     dfile.close()
     argresidual = args[len(filename)+1:]
@@ -641,13 +641,13 @@ def ImportMarkers(args):
     import PlasmaVaultConstants
     arglist = args.split()
     if len(arglist) < 2:
-        print 'ERROR - not enough arguments - ImportMarkers "filename foldername")'
+        print('ERROR - not enough arguments - ImportMarkers "filename foldername")')
         return
     filename = arglist[0]
     try:
         dfile = open(filename+'.py','r')
     except IOError:
-        print "ERROR - file %d could not be found" % (filename+'.py')
+        print("ERROR - file %d could not be found" % (filename+'.py'))
         return
     dfile.close()
     argresidual = args[len(filename)+1:]
@@ -694,7 +694,7 @@ def GetChildInfo(args):
     import Plasma
     vault = Plasma.ptVault()
     hoodGUID = vault.getLinkToMyNeighborhood().getAgeInfo().getAgeInstanceGuid()
-    print "hoodGUID: ",hoodGUID
+    print("hoodGUID: ",hoodGUID)
 
     parentname = None
     agevault = Plasma.ptAgeVault()
@@ -703,21 +703,21 @@ def GetChildInfo(args):
     parent = ageinfo.getParentAgeLink()
     if parent == None:
         agename = ageinfo.getAgeFilename()
-        print "not a child age.  age = ",agename
+        print("not a child age.  age = ",agename)
         #print "with linking rules: ",agerules
         return
     parentinfo = parent.getAgeInfo()
     parentname = parentinfo.getAgeFilename()
     parentGUID = parentinfo.getAgeInstanceGuid()
-    print "parentGUID: ",parentGUID
+    print("parentGUID: ",parentGUID)
     
     if parentname == "Neighborhood":
         if hoodGUID == parentGUID:
-            print "child of hood:  yes"
+            print("child of hood:  yes")
         else:
-            print "child of hood:  different"
+            print("child of hood:  different")
     else:
-        print "child of hood:  no"
+        print("child of hood:  no")
     #print "linking rules: ",agerules
 
 
@@ -737,7 +737,7 @@ def GetSDL(varName):
     try:
         ageSDL = Plasma.PtGetAgeSDL()
     except:
-        print("xCheat.GetSDL(): Unable to retrieve SDL for '{}'.".format(ageName))
+        print(("xCheat.GetSDL(): Unable to retrieve SDL for '{}'.".format(ageName)))
         return
 
     varList = []
@@ -764,17 +764,17 @@ def GetSDL(varName):
                     val = ""
                 else:
                     val = ageSDL[var][0]
-                print("xCheat.GetSDL(): {:>{width}}  =  {}".format(var, val, width=maxlen))
+                print(("xCheat.GetSDL(): {:>{width}}  =  {}".format(var, val, width=maxlen)))
             except:
-                print("xCheat.GetSDL(): Error retrieving value for '{}'.".format(var))
+                print(("xCheat.GetSDL(): Error retrieving value for '{}'.".format(var)))
     else:
         try:
             if len(ageSDL[varName]) == 0:
-                print("xCheat.GetSDL():  SDL variable '{}' is not set.".format(varName))
+                print(("xCheat.GetSDL():  SDL variable '{}' is not set.".format(varName)))
             else:
-                print("xCheat.GetSDL(): {}  =  {}".format(varName, ageSDL[varName][0]))
+                print(("xCheat.GetSDL(): {}  =  {}".format(varName, ageSDL[varName][0])))
         except:
-            print("xCheat.GetSDL(): SDL variable '{}' not found.".format(varName))
+            print(("xCheat.GetSDL(): SDL variable '{}' not found.".format(varName)))
             return
 
 
@@ -797,24 +797,24 @@ def SetSDL(varNameAndVal):
     try:
         newval = int(varNameAndValList[1])
     except ValueError:
-        print("xCheat.SetSDL(): Can't use '{}'. Only numerical SDL values are supported.".format(varNameAndValList[1]))
+        print(("xCheat.SetSDL(): Can't use '{}'. Only numerical SDL values are supported.".format(varNameAndValList[1])))
         return
 
     ageName = Plasma.PtGetAgeName()
     try:
         ageSDL = Plasma.PtGetAgeSDL()
     except:
-        print("xCheat.SetSDL(): Unable to retrieve SDL for '{}'.".format(ageName))
+        print(("xCheat.SetSDL(): Unable to retrieve SDL for '{}'.".format(ageName)))
         return
 
     try:
         oldval = ageSDL[varName][0]
     except KeyError:
-        print("xCheat.SetSDL(): SDL variable '{}' not found.".format(varName))
+        print(("xCheat.SetSDL(): SDL variable '{}' not found.".format(varName)))
         return
 
     if newval == oldval:
-        print("xCheat.SetSDL(): Not changing value, '{}' is already {}.".format(varName, newval))
+        print(("xCheat.SetSDL(): Not changing value, '{}' is already {}.".format(varName, newval)))
         return
 
     if ageName == "Personal":
@@ -828,7 +828,7 @@ def SetSDL(varNameAndVal):
         ageSDL.sendToClients(varName)
         ageSDL[varName] = (newval,)
 
-    print("xCheat.SetSDL(): Setting '{}' to {} (was {}).".format(varName, newval, oldval))
+    print(("xCheat.SetSDL(): Setting '{}' to {} (was {}).".format(varName, newval, oldval)))
 
 
 def InstaPellets(args):
@@ -838,11 +838,11 @@ def InstaPellets(args):
     if ageName == "Ercana":
         sdl = Plasma.PtGetAgeSDL()
         if args == "":
-            print "xCheat.InstantPellets: ERROR.  Must specify a recipe value as argument."
+            print("xCheat.InstantPellets: ERROR.  Must specify a recipe value as argument.")
         else:
             PelletsPresent = sdl["ercaPelletMachine"][0]
             if PelletsPresent:
-                print "xCheat.InstantPellets: ERROR.  Must flush current pellets before using this cheat."
+                print("xCheat.InstantPellets: ERROR.  Must flush current pellets before using this cheat.")
             else:
                 iarg = string.atoi(args)
                 if iarg == 0:
@@ -850,7 +850,7 @@ def InstaPellets(args):
                 recipeSDL = (iarg + 300)
                 if recipeSDL < 1:
                     recipeSDL = 1
-                print "xCheat.InstantPellets: 5 pellets now created with Recipe of %d." % (iarg)
+                print("xCheat.InstantPellets: 5 pellets now created with Recipe of %d." % (iarg))
                 sdl["ercaPellet1"] = (recipeSDL,)
                 sdl["ercaPellet2"] = (recipeSDL,)
                 sdl["ercaPellet3"] = (recipeSDL,)
@@ -876,12 +876,12 @@ def CheckRecipe(args):
                 break
         if testVal:
             recipe = (recipeSDL - 300)
-            print "xCheat.CheckRecipe: Recipe of current pellet(s) = %d." % (recipe)
+            print("xCheat.CheckRecipe: Recipe of current pellet(s) = %d." % (recipe))
         else:
-            print "xCheat.CheckRecipe: No pellets currently exist, therefore no recipe."
+            print("xCheat.CheckRecipe: No pellets currently exist, therefore no recipe.")
 
 
 def GetPlayerID(self):
     import Plasma
     playerID = Plasma.PtGetLocalPlayer().getPlayerID()
-    print "playerID = ",playerID
+    print("playerID = ",playerID)

--- a/Python/xCheat.py
+++ b/Python/xCheat.py
@@ -704,7 +704,7 @@ def GetChildInfo(args):
     if parent == None:
         agename = ageinfo.getAgeFilename()
         print("not a child age.  age = ",agename)
-        #print "with linking rules: ",agerules
+        #print("with linking rules: ",agerules)
         return
     parentinfo = parent.getAgeInfo()
     parentname = parentinfo.getAgeFilename()
@@ -718,7 +718,7 @@ def GetChildInfo(args):
             print("child of hood:  different")
     else:
         print("child of hood:  no")
-    #print "linking rules: ",agerules
+    #print("linking rules: ",agerules)
 
 
 def GetSDL(varName):

--- a/Python/xClearAge.py
+++ b/Python/xClearAge.py
@@ -63,11 +63,11 @@ class xClearAge(ptResponder):
         
         version = 1
         self.version = version
-        print "__init__xClearAge v.", version
+        print("__init__xClearAge v.", version)
         
     def OnNotify(self,state,id,events):
         if state:
             PtConsole("Net.ClearAgeInstanceGuid %s" % string.value)
-            print "Clearing %s" % string.value
+            print("Clearing %s" % string.value)
             
 #-------------

--- a/Python/xClearAge.py
+++ b/Python/xClearAge.py
@@ -63,11 +63,11 @@ class xClearAge(ptResponder):
         
         version = 1
         self.version = version
-        print("__init__xClearAge v.", version)
+        PtDebugPrint("__init__xClearAge v.", version)
         
     def OnNotify(self,state,id,events):
         if state:
             PtConsole("Net.ClearAgeInstanceGuid %s" % string.value)
-            print("Clearing %s" % string.value)
+            PtDebugPrint("Clearing %s" % string.value)
             
 #-------------

--- a/Python/xConcentration.py
+++ b/Python/xConcentration.py
@@ -86,7 +86,7 @@ class xConcentration(ptModifier):
         
         version = 1
         self.version = version
-        print "__init__xConcentration v.", version
+        print("__init__xConcentration v.", version)
         
     def OnServerInitComplete(self):
         global puz
@@ -95,19 +95,19 @@ class xConcentration(ptModifier):
         #puztuple=("xx",)
         #print puztuple[0]
         #puz = list(puztuple)
-        print puztuple[0], "Existing Value!"
+        print(puztuple[0], "Existing Value!")
         if puztuple[0] != puzname.value:
             puz = list(puztuple)
             puz=BuildPuzList()
             puz[0] = puzname.value
-            print puz[0],"firstupdate"
+            print(puz[0],"firstupdate")
             self.SDL["puz"] = tuple(puz) # writes it
 
         dtext.textmap.clearToColor(ptColor(0,0,0,0))
 
         
     def Load(self):
-        print "load XXXXXXXX"
+        print("load XXXXXXXX")
         global puz
         puz = self.SDL["puz"][1032]
         #if not puz[0]: #thing is empty, else we already have a list.
@@ -144,11 +144,11 @@ class xConcentration(ptModifier):
                         xSquare = round(xSquarepicked+.5)
                         ySquare = round(ySquarepicked+.5)
                             
-                        print TruePickx,"Truepickx=xSquarepicked",xSquarepicked,"Rounded:",xSquare
-                        print TruePicky,"Truepicky=ySquarepicked",ySquarepicked,"Rounded:",ySquare
+                        print(TruePickx,"Truepickx=xSquarepicked",xSquarepicked,"Rounded:",xSquare)
+                        print(TruePicky,"Truepicky=ySquarepicked",ySquarepicked,"Rounded:",ySquare)
                                             
                         pick = (int(ySquare-1) * matrix.value) + int(xSquare) #pick is the array location                     
-                        print "Pick=",whichpick," Square:",pick,"value=",puz[pick] 
+                        print("Pick=",whichpick," Square:",pick,"value=",puz[pick]) 
 
                         #Now do something with the pick
                         texX = 512
@@ -167,11 +167,11 @@ class xConcentration(ptModifier):
                         getFromX = texXBox * (imageSquareX)
                         getFromY = texYBox * (imageSquareY)
                         
-                        print imageSquareX,"GETFROM",imageSquareY
+                        print(imageSquareX,"GETFROM",imageSquareY)
                         
                         if puz[pick] == pick: # solved spot already
                             #play moot graphic.
-                            print "skippingpick"
+                            print("skippingpick")
                             pass
                         elif whichpick == 0 : #first selection
                             pick1 = pick
@@ -188,9 +188,9 @@ class xConcentration(ptModifier):
                                 puz[pick1] = puz[pick] 
                                 puz[pick] = pick # swap numbers
                                 self.SDL["puz"] = tuple(puz) # writes it
-                                print "MATCH:"
-                                print "Square:",pick1,"value=",puz[pick1]
-                                print "Square:",pick,"value=",puz[pick]
+                                print("MATCH:")
+                                print("Square:",pick1,"value=",puz[pick1])
+                                print("Square:",pick,"value=",puz[pick])
                                 dtext.textmap.clearToColor(black)
                             else:
                                 pass
@@ -209,7 +209,7 @@ def BuildPuzList():
     for x in range(1033): # fills the list with a number coinciding with its position
         p.append(x)
 
-    print "start list"    
+    print("start list")    
     for x in range(1,1032): # fill numbers
         p[x] = x
     for x in range(1,1032): # scrambles those numbers
@@ -217,7 +217,7 @@ def BuildPuzList():
         z=p[x]
         p[x] = p[y]
         p[y] = z
-        print x,",",p[x]
+        print(x,",",p[x])
 
     for x in range(1,1032): # makes sure there were no "put backs"
         if p[x] == x:
@@ -225,7 +225,7 @@ def BuildPuzList():
             z=p[x]
             p[x] = y
             p[y] = z
-            print x,",,,",p[x]
-    print "end list"
+            print(x,",,,",p[x])
+    print("end list")
     return p
         

--- a/Python/xConcentration.py
+++ b/Python/xConcentration.py
@@ -86,28 +86,28 @@ class xConcentration(ptModifier):
         
         version = 1
         self.version = version
-        print("__init__xConcentration v.", version)
+        PtDebugPrint("__init__xConcentration v.", version)
         
     def OnServerInitComplete(self):
         global puz
         self.SDL.setDefault("puz",(0,))
         puztuple = self.SDL["puz"]
         #puztuple=("xx",)
-        #print puztuple[0]
+        #PtDebugPrint(puztuple[0])
         #puz = list(puztuple)
-        print(puztuple[0], "Existing Value!")
+        PtDebugPrint(puztuple[0], "Existing Value!")
         if puztuple[0] != puzname.value:
             puz = list(puztuple)
             puz=BuildPuzList()
             puz[0] = puzname.value
-            print(puz[0],"firstupdate")
+            PtDebugPrint(puz[0],"firstupdate")
             self.SDL["puz"] = tuple(puz) # writes it
 
         dtext.textmap.clearToColor(ptColor(0,0,0,0))
 
         
     def Load(self):
-        print("load XXXXXXXX")
+        PtDebugPrint("load XXXXXXXX")
         global puz
         puz = self.SDL["puz"][1032]
         #if not puz[0]: #thing is empty, else we already have a list.
@@ -129,7 +129,7 @@ class xConcentration(ptModifier):
         ytotalsize = float(yfeet.value)
         xsquaresize = float(xtotalsize / float(matrix.value))
         ysquaresize = float(ytotalsize / float(matrix.value))
-        #print xsquaresize,"squaresize",ysquaresize
+        #PtDebugPrint(xsquaresize,"squaresize",ysquaresize)
         if state:
             if id == Click.id and PtWasLocallyNotified(self.key):
                 for event in events:
@@ -144,11 +144,11 @@ class xConcentration(ptModifier):
                         xSquare = round(xSquarepicked+.5)
                         ySquare = round(ySquarepicked+.5)
                             
-                        print(TruePickx,"Truepickx=xSquarepicked",xSquarepicked,"Rounded:",xSquare)
-                        print(TruePicky,"Truepicky=ySquarepicked",ySquarepicked,"Rounded:",ySquare)
+                        PtDebugPrint(TruePickx,"Truepickx=xSquarepicked",xSquarepicked,"Rounded:",xSquare)
+                        PtDebugPrint(TruePicky,"Truepicky=ySquarepicked",ySquarepicked,"Rounded:",ySquare)
                                             
                         pick = (int(ySquare-1) * matrix.value) + int(xSquare) #pick is the array location                     
-                        print("Pick=",whichpick," Square:",pick,"value=",puz[pick]) 
+                        PtDebugPrint("Pick=",whichpick," Square:",pick,"value=",puz[pick]) 
 
                         #Now do something with the pick
                         texX = 512
@@ -167,11 +167,11 @@ class xConcentration(ptModifier):
                         getFromX = texXBox * (imageSquareX)
                         getFromY = texYBox * (imageSquareY)
                         
-                        print(imageSquareX,"GETFROM",imageSquareY)
+                        PtDebugPrint(imageSquareX,"GETFROM",imageSquareY)
                         
                         if puz[pick] == pick: # solved spot already
                             #play moot graphic.
-                            print("skippingpick")
+                            PtDebugPrint("skippingpick")
                             pass
                         elif whichpick == 0 : #first selection
                             pick1 = pick
@@ -188,9 +188,9 @@ class xConcentration(ptModifier):
                                 puz[pick1] = puz[pick] 
                                 puz[pick] = pick # swap numbers
                                 self.SDL["puz"] = tuple(puz) # writes it
-                                print("MATCH:")
-                                print("Square:",pick1,"value=",puz[pick1])
-                                print("Square:",pick,"value=",puz[pick])
+                                PtDebugPrint("MATCH:")
+                                PtDebugPrint("Square:",pick1,"value=",puz[pick1])
+                                PtDebugPrint("Square:",pick,"value=",puz[pick])
                                 dtext.textmap.clearToColor(black)
                             else:
                                 pass
@@ -209,7 +209,7 @@ def BuildPuzList():
     for x in range(1033): # fills the list with a number coinciding with its position
         p.append(x)
 
-    print("start list")    
+    PtDebugPrint("start list")    
     for x in range(1,1032): # fill numbers
         p[x] = x
     for x in range(1,1032): # scrambles those numbers
@@ -217,7 +217,7 @@ def BuildPuzList():
         z=p[x]
         p[x] = p[y]
         p[y] = z
-        print(x,",",p[x])
+        PtDebugPrint(x,",",p[x])
 
     for x in range(1,1032): # makes sure there were no "put backs"
         if p[x] == x:
@@ -225,7 +225,7 @@ def BuildPuzList():
             z=p[x]
             p[x] = y
             p[y] = z
-            print(x,",,,",p[x])
-    print("end list")
+            PtDebugPrint(x,",,,",p[x])
+    PtDebugPrint("end list")
     return p
         

--- a/Python/xDialogStartUp.py
+++ b/Python/xDialogStartUp.py
@@ -183,7 +183,7 @@ class xDialogStartUp(ptResponder):
         self.id = 5340
         self.version = 3
         self.ageLink = None
-        print "xDialogStartUp: init  version = %d" % self.version
+        print("xDialogStartUp: init  version = %d" % self.version)
 
     ###########################
     def OnServerInitComplete(self):
@@ -270,11 +270,11 @@ class xDialogStartUp(ptResponder):
                 if  tagID == k4bExploreID: ## Explore Uru ##
                     if gSelectedSlot:
                         PtShowDialog("GUIDialog06a")
-                        print "Player selected."
+                        print("Player selected.")
                         
                         # start setting active player (we'll link out when this operation completes)
                         playerID = gPlayerList[gSelectedSlot-gMinusExplorer][1]
-                        print "Setting active player."
+                        print("Setting active player.")
                         PtSetActivePlayer(playerID)
                         
                     ## Or Else?? ##
@@ -373,7 +373,7 @@ class xDialogStartUp(ptResponder):
 
                             ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).setString(fixedPlayerName)
                         else:
-                            print "Creating Player"
+                            print("Creating Player")
                             PtShowDialog("GUIDialog06a")
                             ptGUIControlButton(GUIDiag6.dialog.getControlFromTag(k6PlayID)).disable()
                             PtCreatePlayer(fixedPlayerName, playerGender, "")  #                                                  <---
@@ -395,7 +395,7 @@ class xDialogStartUp(ptResponder):
         global gPlayerList
 
         if result != 0:
-            print "OnAccountUpdate type %u failed: %u" % (opType, result)
+            print("OnAccountUpdate type %u failed: %u" % (opType, result))
             PtHideDialog("GUIDialog06a")
             self.ToggleColor(GUIDiag4b, k4bPlayer03)
 
@@ -417,7 +417,7 @@ class xDialogStartUp(ptResponder):
             return
         
         if opType == PtAccountUpdateType.kActivePlayer:
-            print "Active player set."
+            print("Active player set.")
 
             pythonBox = PtFindSceneobject("OptionsDialog", "GUI")
             pmlist = pythonBox.getPythonMods()
@@ -441,13 +441,13 @@ class xDialogStartUp(ptResponder):
             self.ageLink.setAgeInfo(ageInfo)
             self.ageLink.setLinkingRules(PtLinkingRules.kOwnedBook)
 
-            print "Linking to %s" % (self.ageLink.getAgeInfo().getAgeFilename())
+            print("Linking to %s" % (self.ageLink.getAgeInfo().getAgeFilename()))
             respLinkOutSND.run(self.key)
             ptNetLinkingMgr().linkToAge(self.ageLink)
             self.ageLink = None
 
         elif opType == PtAccountUpdateType.kCreatePlayer:
-            print "Player created."	
+            print("Player created.")	
 
             # setup the link to ACA
             self.ageLink = ptAgeLinkStruct()
@@ -458,7 +458,7 @@ class xDialogStartUp(ptResponder):
             
 
             # start setting active player (we'll link out once this operation completes)
-            print "Setting active player."
+            print("Setting active player.")
             PtSetActivePlayer(playerInt)
 
         elif opType == PtAccountUpdateType.kDeletePlayer:
@@ -469,7 +469,7 @@ class xDialogStartUp(ptResponder):
             PtHideDialog("GUIDialog04c")
 
         else:
-            print "AccountUpdate - Unknown: optype = %d, result = %d, playerInt = %d" % (opType, result, playerInt)
+            print("AccountUpdate - Unknown: optype = %d, result = %d, playerInt = %d" % (opType, result, playerInt))
 
     ###########################
     def ToggleColor(self,dlgObj,tagID):
@@ -497,17 +497,17 @@ class xDialogStartUp(ptResponder):
         global gSelectedSlot
 
         if tagID and tagID != gSelectedSlot: ## If there's a currently selected slot, return it to normal ##
-            print "xDialogStartUp.SelectSlot: tagID = %d   gSelectedSlot = %d" % (tagID, gSelectedSlot)
+            print("xDialogStartUp.SelectSlot: tagID = %d   gSelectedSlot = %d" % (tagID, gSelectedSlot))
             if gSelectedSlot:
                 self.ToggleColor(dlgObj, gSelectedSlot)
                 ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(1)
-                print "xDialogStartUp.SelectSlot: Setting old slot to Interesting"
+                print("xDialogStartUp.SelectSlot: Setting old slot to Interesting")
 
             gSelectedSlot = tagID
             ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(0)
-            print "xDialogStartUp.SelectSlot: Setting gSelectedSlot to new val and removing Interesting"
+            print("xDialogStartUp.SelectSlot: Setting gSelectedSlot to new val and removing Interesting")
         elif tagID == 0:
-            print "xDialogStartUp.SelectSlot: Setting gSelectedSlot to %d" % (tagID)
+            print("xDialogStartUp.SelectSlot: Setting gSelectedSlot to %d" % (tagID))
             gSelectedSlot = tagID
 
     ###########################
@@ -523,7 +523,7 @@ class xDialogStartUp(ptResponder):
             for Explorer in ExplorerList:
                 gPlayerList.append(Explorer)
 
-        print "xDialogStartUp.InitPlayerList Enter: gPlayerList = %s" % (str(gPlayerList))
+        print("xDialogStartUp.InitPlayerList Enter: gPlayerList = %s" % (str(gPlayerList)))
 
         for tagID in listTxtBox: ## Setup The Slot Colors And Default Titles ##
             ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID)).setString("CREATE EXPLORER")
@@ -545,12 +545,12 @@ class xDialogStartUp(ptResponder):
             ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(listTxtBox[idx])).setStringW(unicode(player[0]))
             try:
                 filename = basePath + unicode(player[1]) + U".jpg"
-                print "xDialogStartUp: Trying to load \"" + filename + "\""
+                print("xDialogStartUp: Trying to load \"" + filename + "\"")
                 theImage = PtLoadJPEGFromDisk(filename, 0, 0)
                 TextMaps[idx].textmap.drawImage(0, 0, theImage, 0)
                 TextMaps[idx].textmap.flush()
             except:
-                print "xDialogStartUp: Load failed. This avatar probably doesn't have a snapshot"
+                print("xDialogStartUp: Load failed. This avatar probably doesn't have a snapshot")
 
         try:
             gPlayerList[0]
@@ -562,18 +562,18 @@ class xDialogStartUp(ptResponder):
 
         while len(gPlayerList) < 6:   ## Now That Slots Are Initialized, Fill Out The List ##
             gPlayerList.append(None)  ##    So We Don't Have Out Of Bounds Errors Later    ##
-        print "xDialogStartUp.InitPlayerList Exit: gPlayerList = %s" % (str(gPlayerList))
+        print("xDialogStartUp.InitPlayerList Exit: gPlayerList = %s" % (str(gPlayerList)))
 
     ###########################
     def PlayerListNotify(self,dlgObj,listHotSpot,toggle):
         global gSelectedSlot
 
         for tagID in listHotSpot:
-            print "xDialogStartUp.PlayerListNotify: setting tagID (%d) to Interesting = %d" % (tagID, toggle)
+            print("xDialogStartUp.PlayerListNotify: setting tagID (%d) to Interesting = %d" % (tagID, toggle))
             ptGUIControlButton(dlgObj.dialog.getControlFromTag(tagID)).setNotifyOnInteresting(toggle)
 
         if toggle and gSelectedSlot:
-            print "xDialogStartUp.PlayerListNotify: setting gSelectedSlot (%d) to not Interesting" % (gSelectedSlot)
+            print("xDialogStartUp.PlayerListNotify: setting gSelectedSlot (%d) to not Interesting" % (gSelectedSlot))
             ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(0)
 
         # Everyone is an explorer, so disable the button for visiting.

--- a/Python/xDialogStartUp.py
+++ b/Python/xDialogStartUp.py
@@ -183,7 +183,7 @@ class xDialogStartUp(ptResponder):
         self.id = 5340
         self.version = 3
         self.ageLink = None
-        print("xDialogStartUp: init  version = %d" % self.version)
+        PtDebugPrint("xDialogStartUp: init  version = %d" % self.version)
 
     ###########################
     def OnServerInitComplete(self):
@@ -231,7 +231,7 @@ class xDialogStartUp(ptResponder):
         global gMinusVisitor
         global gClickedWrongSlot
 
-        #print "xDialogStartUp: GUI Notify id=%d, event=%d control=" % (id,event),control
+        #PtDebugPrint("xDialogStartUp: GUI Notify id=%d, event=%d control=" % (id,event),control)
         if control:
             tagID = control.getTagID()
 
@@ -270,11 +270,11 @@ class xDialogStartUp(ptResponder):
                 if  tagID == k4bExploreID: ## Explore Uru ##
                     if gSelectedSlot:
                         PtShowDialog("GUIDialog06a")
-                        print("Player selected.")
+                        PtDebugPrint("Player selected.")
                         
                         # start setting active player (we'll link out when this operation completes)
                         playerID = gPlayerList[gSelectedSlot-gMinusExplorer][1]
-                        print("Setting active player.")
+                        PtDebugPrint("Setting active player.")
                         PtSetActivePlayer(playerID)
                         
                     ## Or Else?? ##
@@ -373,7 +373,7 @@ class xDialogStartUp(ptResponder):
 
                             ptGUIControlEditBox(GUIDiag6.dialog.getControlFromTag(k6NameID)).setString(fixedPlayerName)
                         else:
-                            print("Creating Player")
+                            PtDebugPrint("Creating Player")
                             PtShowDialog("GUIDialog06a")
                             ptGUIControlButton(GUIDiag6.dialog.getControlFromTag(k6PlayID)).disable()
                             PtCreatePlayer(fixedPlayerName, playerGender, "")  #                                                  <---
@@ -395,7 +395,7 @@ class xDialogStartUp(ptResponder):
         global gPlayerList
 
         if result != 0:
-            print("OnAccountUpdate type %u failed: %u" % (opType, result))
+            PtDebugPrint("OnAccountUpdate type %u failed: %u" % (opType, result))
             PtHideDialog("GUIDialog06a")
             self.ToggleColor(GUIDiag4b, k4bPlayer03)
 
@@ -417,7 +417,7 @@ class xDialogStartUp(ptResponder):
             return
         
         if opType == PtAccountUpdateType.kActivePlayer:
-            print("Active player set.")
+            PtDebugPrint("Active player set.")
 
             pythonBox = PtFindSceneobject("OptionsDialog", "GUI")
             pmlist = pythonBox.getPythonMods()
@@ -441,13 +441,13 @@ class xDialogStartUp(ptResponder):
             self.ageLink.setAgeInfo(ageInfo)
             self.ageLink.setLinkingRules(PtLinkingRules.kOwnedBook)
 
-            print("Linking to %s" % (self.ageLink.getAgeInfo().getAgeFilename()))
+            PtDebugPrint("Linking to %s" % (self.ageLink.getAgeInfo().getAgeFilename()))
             respLinkOutSND.run(self.key)
             ptNetLinkingMgr().linkToAge(self.ageLink)
             self.ageLink = None
 
         elif opType == PtAccountUpdateType.kCreatePlayer:
-            print("Player created.")	
+            PtDebugPrint("Player created.")	
 
             # setup the link to ACA
             self.ageLink = ptAgeLinkStruct()
@@ -458,7 +458,7 @@ class xDialogStartUp(ptResponder):
             
 
             # start setting active player (we'll link out once this operation completes)
-            print("Setting active player.")
+            PtDebugPrint("Setting active player.")
             PtSetActivePlayer(playerInt)
 
         elif opType == PtAccountUpdateType.kDeletePlayer:
@@ -469,7 +469,7 @@ class xDialogStartUp(ptResponder):
             PtHideDialog("GUIDialog04c")
 
         else:
-            print("AccountUpdate - Unknown: optype = %d, result = %d, playerInt = %d" % (opType, result, playerInt))
+            PtDebugPrint("AccountUpdate - Unknown: optype = %d, result = %d, playerInt = %d" % (opType, result, playerInt))
 
     ###########################
     def ToggleColor(self,dlgObj,tagID):
@@ -484,11 +484,11 @@ class xDialogStartUp(ptResponder):
         respToRun = gExp_HiLite[idx]
 
         if currentColor == gBlueColor:
-            #print "toggle tagID(%d) off" % (tagID)
+            #PtDebugPrint("toggle tagID(%d) off" % (tagID))
             ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID+10)).setForeColor(gTanColor)
             respToRun.run(self.key,state="out")
         else:
-            #print "toggle tagID(%d) on" % (tagID)
+            #PtDebugPrint("toggle tagID(%d) on" % (tagID))
             ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID+10)).setForeColor(gBlueColor)
             respToRun.run(self.key,state="in")
 
@@ -497,17 +497,17 @@ class xDialogStartUp(ptResponder):
         global gSelectedSlot
 
         if tagID and tagID != gSelectedSlot: ## If there's a currently selected slot, return it to normal ##
-            print("xDialogStartUp.SelectSlot: tagID = %d   gSelectedSlot = %d" % (tagID, gSelectedSlot))
+            PtDebugPrint("xDialogStartUp.SelectSlot: tagID = %d   gSelectedSlot = %d" % (tagID, gSelectedSlot))
             if gSelectedSlot:
                 self.ToggleColor(dlgObj, gSelectedSlot)
                 ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(1)
-                print("xDialogStartUp.SelectSlot: Setting old slot to Interesting")
+                PtDebugPrint("xDialogStartUp.SelectSlot: Setting old slot to Interesting")
 
             gSelectedSlot = tagID
             ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(0)
-            print("xDialogStartUp.SelectSlot: Setting gSelectedSlot to new val and removing Interesting")
+            PtDebugPrint("xDialogStartUp.SelectSlot: Setting gSelectedSlot to new val and removing Interesting")
         elif tagID == 0:
-            print("xDialogStartUp.SelectSlot: Setting gSelectedSlot to %d" % (tagID))
+            PtDebugPrint("xDialogStartUp.SelectSlot: Setting gSelectedSlot to %d" % (tagID))
             gSelectedSlot = tagID
 
     ###########################
@@ -523,7 +523,7 @@ class xDialogStartUp(ptResponder):
             for Explorer in ExplorerList:
                 gPlayerList.append(Explorer)
 
-        print("xDialogStartUp.InitPlayerList Enter: gPlayerList = %s" % (str(gPlayerList)))
+        PtDebugPrint("xDialogStartUp.InitPlayerList Enter: gPlayerList = %s" % (str(gPlayerList)))
 
         for tagID in listTxtBox: ## Setup The Slot Colors And Default Titles ##
             ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(tagID)).setString("CREATE EXPLORER")
@@ -545,12 +545,12 @@ class xDialogStartUp(ptResponder):
             ptGUIControlTextBox(dlgObj.dialog.getControlFromTag(listTxtBox[idx])).setStringW(unicode(player[0]))
             try:
                 filename = basePath + unicode(player[1]) + U".jpg"
-                print("xDialogStartUp: Trying to load \"" + filename + "\"")
+                PtDebugPrint("xDialogStartUp: Trying to load \"" + filename + "\"")
                 theImage = PtLoadJPEGFromDisk(filename, 0, 0)
                 TextMaps[idx].textmap.drawImage(0, 0, theImage, 0)
                 TextMaps[idx].textmap.flush()
             except:
-                print("xDialogStartUp: Load failed. This avatar probably doesn't have a snapshot")
+                PtDebugPrint("xDialogStartUp: Load failed. This avatar probably doesn't have a snapshot")
 
         try:
             gPlayerList[0]
@@ -562,18 +562,18 @@ class xDialogStartUp(ptResponder):
 
         while len(gPlayerList) < 6:   ## Now That Slots Are Initialized, Fill Out The List ##
             gPlayerList.append(None)  ##    So We Don't Have Out Of Bounds Errors Later    ##
-        print("xDialogStartUp.InitPlayerList Exit: gPlayerList = %s" % (str(gPlayerList)))
+        PtDebugPrint("xDialogStartUp.InitPlayerList Exit: gPlayerList = %s" % (str(gPlayerList)))
 
     ###########################
     def PlayerListNotify(self,dlgObj,listHotSpot,toggle):
         global gSelectedSlot
 
         for tagID in listHotSpot:
-            print("xDialogStartUp.PlayerListNotify: setting tagID (%d) to Interesting = %d" % (tagID, toggle))
+            PtDebugPrint("xDialogStartUp.PlayerListNotify: setting tagID (%d) to Interesting = %d" % (tagID, toggle))
             ptGUIControlButton(dlgObj.dialog.getControlFromTag(tagID)).setNotifyOnInteresting(toggle)
 
         if toggle and gSelectedSlot:
-            print("xDialogStartUp.PlayerListNotify: setting gSelectedSlot (%d) to not Interesting" % (gSelectedSlot))
+            PtDebugPrint("xDialogStartUp.PlayerListNotify: setting gSelectedSlot (%d) to not Interesting" % (gSelectedSlot))
             ptGUIControlButton(dlgObj.dialog.getControlFromTag(gSelectedSlot)).setNotifyOnInteresting(0)
 
         # Everyone is an explorer, so disable the button for visiting.

--- a/Python/xDialogToggle.py
+++ b/Python/xDialogToggle.py
@@ -87,7 +87,7 @@ class xDialogToggle(ptModifier):
         
         version = 1
         self.version = version
-        print "__init__xDialogToggle v.", version
+        print("__init__xDialogToggle v.", version)
     
     def IGetAgeFilename(self):
         "returns the .age file name of the age"
@@ -137,7 +137,7 @@ class xDialogToggle(ptModifier):
         PtLoadDialog(Vignette.value,self.key,self.IGetAgeFilename())
         if ( PtIsDialogLoaded(Vignette.value) ):
             PtShowDialog(Vignette.value)
-            print "dialog: %s goes up" % Vignette.value
+            print("dialog: %s goes up" % Vignette.value)
         # get control key events
         PtGetControlEvents(True,self.key)
 
@@ -147,9 +147,9 @@ class xDialogToggle(ptModifier):
         # exit every thing
         if Vignette.value:
             PtHideDialog(Vignette.value)
-            print "Dialog: %s goes down" % Vignette.value
+            print("Dialog: %s goes down" % Vignette.value)
         else:
-            print "WTH!!!"
+            print("WTH!!!")
         #disable the Control key events
         PtGetControlEvents(False,self.key)
         # re-enable the dialog for someone else to use

--- a/Python/xDialogToggle.py
+++ b/Python/xDialogToggle.py
@@ -87,7 +87,7 @@ class xDialogToggle(ptModifier):
         
         version = 1
         self.version = version
-        print("__init__xDialogToggle v.", version)
+        PtDebugPrint("__init__xDialogToggle v.", version)
     
     def IGetAgeFilename(self):
         "returns the .age file name of the age"
@@ -113,7 +113,7 @@ class xDialogToggle(ptModifier):
 
     def OnGUINotify(self,id,control,event):
         "Notifications from the vignette"
-        #print "GUI Notify id=%d, event=%d control=" % (id,event),control
+        #PtDebugPrint("GUI Notify id=%d, event=%d control=" % (id,event),control)
         if event == kAction:
             if control.getTagID() == kExit: #off
                 self.IQuitDialog()
@@ -137,7 +137,7 @@ class xDialogToggle(ptModifier):
         PtLoadDialog(Vignette.value,self.key,self.IGetAgeFilename())
         if ( PtIsDialogLoaded(Vignette.value) ):
             PtShowDialog(Vignette.value)
-            print("dialog: %s goes up" % Vignette.value)
+            PtDebugPrint("dialog: %s goes up" % Vignette.value)
         # get control key events
         PtGetControlEvents(True,self.key)
 
@@ -147,9 +147,9 @@ class xDialogToggle(ptModifier):
         # exit every thing
         if Vignette.value:
             PtHideDialog(Vignette.value)
-            print("Dialog: %s goes down" % Vignette.value)
+            PtDebugPrint("Dialog: %s goes down" % Vignette.value)
         else:
-            print("WTH!!!")
+            PtDebugPrint("WTH!!!")
         #disable the Control key events
         PtGetControlEvents(False,self.key)
         # re-enable the dialog for someone else to use

--- a/Python/xDisableFirstPersonCam.py
+++ b/Python/xDisableFirstPersonCam.py
@@ -62,7 +62,7 @@ class xDisableFirstPersonCam(ptResponder):
         self.id = 5220
 
         self.version = 1
-        print "__init__xDisableFirstPersonCam v.", self.version
+        print("__init__xDisableFirstPersonCam v.", self.version)
 
     def OnFirstUpdate(self):
         pass
@@ -75,13 +75,13 @@ class xDisableFirstPersonCam(ptResponder):
         if id == sitnode.id:
             for event in events:
                 if event[0] == 1 and event[1] == 1: # entering the no FPC region
-                    print "FP Disabled."
+                    print("FP Disabled.")
                     cam = ptCamera()
                     cam.undoFirstPerson()
                     cam.disableFirstPersonOverride()
 
 
                 elif event[0] == 1 and event[1] == 0: # exiting the no FPC region
-                    print "FP Enabled."
+                    print("FP Enabled.")
                     cam = ptCamera()
                     cam.enableFirstPersonOverride()

--- a/Python/xDisableFirstPersonCam.py
+++ b/Python/xDisableFirstPersonCam.py
@@ -62,7 +62,7 @@ class xDisableFirstPersonCam(ptResponder):
         self.id = 5220
 
         self.version = 1
-        print("__init__xDisableFirstPersonCam v.", self.version)
+        PtDebugPrint("__init__xDisableFirstPersonCam v.", self.version)
 
     def OnFirstUpdate(self):
         pass
@@ -75,13 +75,13 @@ class xDisableFirstPersonCam(ptResponder):
         if id == sitnode.id:
             for event in events:
                 if event[0] == 1 and event[1] == 1: # entering the no FPC region
-                    print("FP Disabled.")
+                    PtDebugPrint("FP Disabled.")
                     cam = ptCamera()
                     cam.undoFirstPerson()
                     cam.disableFirstPersonOverride()
 
 
                 elif event[0] == 1 and event[1] == 0: # exiting the no FPC region
-                    print("FP Enabled.")
+                    PtDebugPrint("FP Enabled.")
                     cam = ptCamera()
                     cam.enableFirstPersonOverride()

--- a/Python/xEnum.py
+++ b/Python/xEnum.py
@@ -83,12 +83,12 @@ class Enum:
 
 
     def __getattr__(self, attr):
-        if not self.lookup.has_key(attr):
+        if attr not in self.lookup:
             raise AttributeError
         return self.lookup[attr]
 
     def __getitem__(self, sub):
-        if not self.lookup.has_key(sub):
+        if sub not in self.lookup:
             raise AttributeError
         return self.lookup[sub]
 
@@ -106,9 +106,9 @@ class Enum:
 if __name__ == "__main__":
     animal = Enum("Cow, Pig, Dog = 5, Cat, Lizard")
 
-    print animal.Cow
-    print animal["Cow"]
-    print animal.Pig
-    print animal.Dog
-    print animal.Cat
-    print animal.Lizard
+    print(animal.Cow)
+    print(animal["Cow"])
+    print(animal.Pig)
+    print(animal.Dog)
+    print(animal.Cat)
+    print(animal.Lizard)

--- a/Python/xEventTrigger.py
+++ b/Python/xEventTrigger.py
@@ -80,7 +80,7 @@ class xEventTrigger(ptResponder):
             ageSDL = PtGetAgeSDL()
             PtDebugPrint("xEventTrigger: SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
             if VARname == EventName.value:
-                print "xEventTrigger: value is %f" % ageSDL[EventName.value]
+                print("xEventTrigger: value is %f" % ageSDL[EventName.value])
                 if ageSDL[EventName.value][0]:
                     #~ PtDebugPrint("Event %s is true!" % (VARname))
                     # are we paging things in?

--- a/Python/xEventTrigger.py
+++ b/Python/xEventTrigger.py
@@ -80,7 +80,7 @@ class xEventTrigger(ptResponder):
             ageSDL = PtGetAgeSDL()
             PtDebugPrint("xEventTrigger: SDLNotify - name = %s, SDLname = %s" % (VARname,SDLname))
             if VARname == EventName.value:
-                print("xEventTrigger: value is %f" % ageSDL[EventName.value])
+                PtDebugPrint("xEventTrigger: value is %f" % ageSDL[EventName.value])
                 if ageSDL[EventName.value][0]:
                     #~ PtDebugPrint("Event %s is true!" % (VARname))
                     # are we paging things in?

--- a/Python/xExitSubworld.py
+++ b/Python/xExitSubworld.py
@@ -84,7 +84,7 @@ class xExitSubworld(ptResponder):
                     avatar.avatar.exitSubWorld()
                     return
                 elif (id == safetyRgn.id):
-                    print "in safety region = ",entry
+                    print("in safety region = ",entry)
                     inSafetyRegion  = entry
                     return
         

--- a/Python/xExitSubworld.py
+++ b/Python/xExitSubworld.py
@@ -84,7 +84,7 @@ class xExitSubworld(ptResponder):
                     avatar.avatar.exitSubWorld()
                     return
                 elif (id == safetyRgn.id):
-                    print("in safety region = ",entry)
+                    PtDebugPrint("in safety region = ",entry)
                     inSafetyRegion  = entry
                     return
         

--- a/Python/xFogDistTweener.py
+++ b/Python/xFogDistTweener.py
@@ -85,7 +85,7 @@ class xFogDistTweener(ptMultiModifier):
         self.id = 5347
         version = 1
         self.version = version
-        print "__init__xFogDistTweener v.", version        
+        print("__init__xFogDistTweener v.", version)        
 
         self.PointA_RGBList = []
         self.PointB_RGBList = []
@@ -102,8 +102,8 @@ class xFogDistTweener(ptMultiModifier):
         self.PointB_RGBList[1] = float(self.PointB_RGBList[1])
         self.PointB_RGBList[2] = float(self.PointB_RGBList[2])
 
-        print "xFogDistTweener.OnFirstUpdate: PointA_RGB=(%s,%s,%s), PointB_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2], self.PointB_RGBList[0], self.PointB_RGBList[1], self.PointB_RGBList[2])
-        print "xFogDistTweener.OnFirstUpdate: PointA_SED=(%s,%s,%s), PointB_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value, PointB_Start.value, PointB_End.value, PointB_Density.value)
+        print("xFogDistTweener.OnFirstUpdate: PointA_RGB=(%s,%s,%s), PointB_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2], self.PointB_RGBList[0], self.PointB_RGBList[1], self.PointB_RGBList[2]))
+        print("xFogDistTweener.OnFirstUpdate: PointA_SED=(%s,%s,%s), PointB_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value, PointB_Start.value, PointB_End.value, PointB_Density.value))
         
         if not OnlyInRegion.value:
             PtAtTimeCallback(self.key, 0, 1)
@@ -112,17 +112,17 @@ class xFogDistTweener(ptMultiModifier):
     def OnNotify(self,state,id,events):
         global Enabled
 
-        print "xFogDistTweener.OnNotify: state=%s id=%d events=" % (state, id), events
+        print("xFogDistTweener.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == Region.id and OnlyInRegion.value and PtFindAvatar(events) == PtGetLocalAvatar():
-            print "xFogDistTweener.OnNotify: Region with fog settings triggered"
+            print("xFogDistTweener.OnNotify: Region with fog settings triggered")
             if events[0][1] == 1:
-                print "xFogDistTweener.OnNotify: Entered"
+                print("xFogDistTweener.OnNotify: Entered")
                 Enabled = 1
                 PtAtTimeCallback(self.key, 0, 1)
 
             elif events[0][1] == 0:
-                print "xFogDistTweener.OnNotify: Exited"
+                print("xFogDistTweener.OnNotify: Exited")
                 PtClearTimerCallbacks(self.key)
                 Enabled = 0
 
@@ -180,7 +180,7 @@ class xFogDistTweener(ptMultiModifier):
             PtFogSetDefExp2(NewE, NewD)
 
         else:
-            print "xFogDistTweener.UpdateFog: What type of Fog?"
+            print("xFogDistTweener.UpdateFog: What type of Fog?")
 
     ###########################
     def CalculateDistanceBetweenPoints(self):
@@ -214,7 +214,7 @@ class xFogDistTweener(ptMultiModifier):
             Temp_Avatar = ptPoint3(0,0,AvatarPos.getZ())
 
         else:
-            print "xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Dimension Specified!"
+            print("xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Dimension Specified!")
 
 
         if FogStyle.value == "Linear":
@@ -257,7 +257,7 @@ class xFogDistTweener(ptMultiModifier):
             Distance = Temp_A.distance(Temp_Avatar)
 
         else:
-            print "xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Fog Style Specified!"
+            print("xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Fog Style Specified!")
             Distance = 0
 
         totalDist = Temp_A.distance(Temp_B)

--- a/Python/xFogDistTweener.py
+++ b/Python/xFogDistTweener.py
@@ -85,7 +85,7 @@ class xFogDistTweener(ptMultiModifier):
         self.id = 5347
         version = 1
         self.version = version
-        print("__init__xFogDistTweener v.", version)        
+        PtDebugPrint("__init__xFogDistTweener v.", version)        
 
         self.PointA_RGBList = []
         self.PointB_RGBList = []
@@ -102,8 +102,8 @@ class xFogDistTweener(ptMultiModifier):
         self.PointB_RGBList[1] = float(self.PointB_RGBList[1])
         self.PointB_RGBList[2] = float(self.PointB_RGBList[2])
 
-        print("xFogDistTweener.OnFirstUpdate: PointA_RGB=(%s,%s,%s), PointB_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2], self.PointB_RGBList[0], self.PointB_RGBList[1], self.PointB_RGBList[2]))
-        print("xFogDistTweener.OnFirstUpdate: PointA_SED=(%s,%s,%s), PointB_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value, PointB_Start.value, PointB_End.value, PointB_Density.value))
+        PtDebugPrint("xFogDistTweener.OnFirstUpdate: PointA_RGB=(%s,%s,%s), PointB_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2], self.PointB_RGBList[0], self.PointB_RGBList[1], self.PointB_RGBList[2]))
+        PtDebugPrint("xFogDistTweener.OnFirstUpdate: PointA_SED=(%s,%s,%s), PointB_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value, PointB_Start.value, PointB_End.value, PointB_Density.value))
         
         if not OnlyInRegion.value:
             PtAtTimeCallback(self.key, 0, 1)
@@ -112,17 +112,17 @@ class xFogDistTweener(ptMultiModifier):
     def OnNotify(self,state,id,events):
         global Enabled
 
-        print("xFogDistTweener.OnNotify: state=%s id=%d events=" % (state, id), events)
+        PtDebugPrint("xFogDistTweener.OnNotify: state=%s id=%d events=" % (state, id), events)
 
         if id == Region.id and OnlyInRegion.value and PtFindAvatar(events) == PtGetLocalAvatar():
-            print("xFogDistTweener.OnNotify: Region with fog settings triggered")
+            PtDebugPrint("xFogDistTweener.OnNotify: Region with fog settings triggered")
             if events[0][1] == 1:
-                print("xFogDistTweener.OnNotify: Entered")
+                PtDebugPrint("xFogDistTweener.OnNotify: Entered")
                 Enabled = 1
                 PtAtTimeCallback(self.key, 0, 1)
 
             elif events[0][1] == 0:
-                print("xFogDistTweener.OnNotify: Exited")
+                PtDebugPrint("xFogDistTweener.OnNotify: Exited")
                 PtClearTimerCallbacks(self.key)
                 Enabled = 0
 
@@ -160,27 +160,27 @@ class xFogDistTweener(ptMultiModifier):
         NewE = PointA_End.value + ((PointB_End.value - PointA_End.value) * TweenPct)
         NewD = PointA_Density.value + ((PointB_Density.value - PointA_Density.value) * TweenPct)
 
-        #print "xFogDistTweener.UpdateFog: The new fog RGB is (%.3f, %.3f, %.3f)" % (NewR, NewG, NewB)
-        #print "xFogDistTweener.UpdateFog: The new fog Density is (%.3f, %.3f, %.3f)" % (NewS, NewE, NewD)
+        #PtDebugPrint("xFogDistTweener.UpdateFog: The new fog RGB is (%.3f, %.3f, %.3f)" % (NewR, NewG, NewB))
+        #PtDebugPrint("xFogDistTweener.UpdateFog: The new fog Density is (%.3f, %.3f, %.3f)" % (NewS, NewE, NewD))
 
         newfogcolor = ptColor(red=NewR, green=NewG, blue=NewB)
 
         PtFogSetDefColor(newfogcolor)
 
         if FogMode.value == "Linear":
-            #print "xFogDistTweener.UpdateFog: Using Linear Fog"
+            #PtDebugPrint("xFogDistTweener.UpdateFog: Using Linear Fog")
             PtFogSetDefLinear(NewS, NewE, NewD)
 
         elif FogMode.value == "Exponential":
-            #print "xFogDistTweener.UpdateFog: Using Exponential Fog"
+            #PtDebugPrint("xFogDistTweener.UpdateFog: Using Exponential Fog")
             PtFogSetDefExp(NewE, NewD)
 
         elif FogMode.value == "Exponential2":
-            #print "xFogDistTweener.UpdateFog: Using Exponential2 Fog"
+            #PtDebugPrint("xFogDistTweener.UpdateFog: Using Exponential2 Fog")
             PtFogSetDefExp2(NewE, NewD)
 
         else:
-            print("xFogDistTweener.UpdateFog: What type of Fog?")
+            PtDebugPrint("xFogDistTweener.UpdateFog: What type of Fog?")
 
     ###########################
     def CalculateDistanceBetweenPoints(self):
@@ -196,29 +196,29 @@ class xFogDistTweener(ptMultiModifier):
         Distance = 0
 
         if Dimensions.value == "XYZ":
-            #print "xFogDistTweener.CalculateDistanceBetweenPoints: Using XYZ"
+            #PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Using XYZ")
             Temp_A = PointAPos
             Temp_B = PointBPos
             Temp_Avatar = AvatarPos
 
         elif Dimensions.value == "XY":
-            #print "xFogDistTweener.CalculateDistanceBetweenPoints: Using XY"
+            #PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Using XY")
             Temp_A = ptPoint3(PointAPos.getX(),PointAPos.getY(),0)
             Temp_B = ptPoint3(PointBPos.getX(),PointBPos.getY(),0)
             Temp_Avatar = ptPoint3(AvatarPos.getX(),AvatarPos.getY(),0)
 
         elif Dimensions.value == "Z":
-            #print "xFogDistTweener.CalculateDistanceBetweenPoints: Using Z"
+            #PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Using Z")
             Temp_A = ptPoint3(0,0,PointAPos.getZ())
             Temp_B = ptPoint3(0,0,PointBPos.getZ())
             Temp_Avatar = ptPoint3(0,0,AvatarPos.getZ())
 
         else:
-            print("xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Dimension Specified!")
+            PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Dimension Specified!")
 
 
         if FogStyle.value == "Linear":
-            #print "xFogDistTweener.CalculateDistanceBetweenPoints: Using Linear Math"
+            #PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Using Linear Math")
             # Since Python can't do coordinate math, were going to break each XYZ value into it's own variable.
             # P1 is the equivilent of Point_A, P2 is the equivilent of Point_B, A is the equivilent of the Avatar point
             P1_X = float(Temp_A.getX())
@@ -253,11 +253,11 @@ class xFogDistTweener(ptMultiModifier):
             Distance = (Normalized_PnX * Pm_X) + (Normalized_PnY * Pm_Y) + (Normalized_PnZ * Pm_Z)
 
         elif FogStyle.value == "Radial":
-            #print "xFogDistTweener.CalculateDistanceBetweenPoints: Using Radial Math"
+            #PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Using Radial Math")
             Distance = Temp_A.distance(Temp_Avatar)
 
         else:
-            print("xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Fog Style Specified!")
+            PtDebugPrint("xFogDistTweener.CalculateDistanceBetweenPoints: Danger! No Fog Style Specified!")
             Distance = 0
 
         totalDist = Temp_A.distance(Temp_B)

--- a/Python/xFogSet.py
+++ b/Python/xFogSet.py
@@ -71,7 +71,7 @@ class xFogSet(ptMultiModifier):
         self.id = 5348
         version = 1
         self.version = version
-        print "__init__xFogSet v.", version        
+        print("__init__xFogSet v.", version)        
 
         self.PointA_RGBList = []
 
@@ -82,8 +82,8 @@ class xFogSet(ptMultiModifier):
         self.PointA_RGBList[1] = float(self.PointA_RGBList[1])
         self.PointA_RGBList[2] = float(self.PointA_RGBList[2])
 
-        print "xFogSet.OnFirstUpdate: PointA_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2])
-        print "xFogSet.OnFirstUpdate: PointA_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value)
+        print("xFogSet.OnFirstUpdate: PointA_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2]))
+        print("xFogSet.OnFirstUpdate: PointA_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value))
         
     ###########################
     def OnNotify(self,state,id,events):
@@ -106,16 +106,16 @@ class xFogSet(ptMultiModifier):
         PtFogSetDefColor(newfogcolor)
 
         if FogMode.value == "Linear":
-            print "xFogSet.UpdateFog: Using Linear Fog"
+            print("xFogSet.UpdateFog: Using Linear Fog")
             PtFogSetDefLinear(PointA_Start.value, PointA_End.value, PointA_Density.value)
 
         elif FogMode.value == "Exponential":
-            print "xFogSet.UpdateFog: Using Exponential Fog"
+            print("xFogSet.UpdateFog: Using Exponential Fog")
             PtFogSetDefExp(PointA_End.value, PointA_Density.value)
 
         elif FogMode.value == "Exponential2":
-            print "xFogSet.UpdateFog: Using Exponential2 Fog"
+            print("xFogSet.UpdateFog: Using Exponential2 Fog")
             PtFogSetDefExp2(PointA_End.value, PointA_Density.value)
 
         else:
-            print "xFogSet.UpdateFog: What type of Fog?"
+            print("xFogSet.UpdateFog: What type of Fog?")

--- a/Python/xFogSet.py
+++ b/Python/xFogSet.py
@@ -71,7 +71,7 @@ class xFogSet(ptMultiModifier):
         self.id = 5348
         version = 1
         self.version = version
-        print("__init__xFogSet v.", version)        
+        PtDebugPrint("__init__xFogSet v.", version)        
 
         self.PointA_RGBList = []
 
@@ -82,8 +82,8 @@ class xFogSet(ptMultiModifier):
         self.PointA_RGBList[1] = float(self.PointA_RGBList[1])
         self.PointA_RGBList[2] = float(self.PointA_RGBList[2])
 
-        print("xFogSet.OnFirstUpdate: PointA_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2]))
-        print("xFogSet.OnFirstUpdate: PointA_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value))
+        PtDebugPrint("xFogSet.OnFirstUpdate: PointA_RGB=(%s,%s,%s)" % (self.PointA_RGBList[0], self.PointA_RGBList[1], self.PointA_RGBList[2]))
+        PtDebugPrint("xFogSet.OnFirstUpdate: PointA_SED=(%s,%s,%s)" % (PointA_Start.value, PointA_End.value, PointA_Density.value))
         
     ###########################
     def OnNotify(self,state,id,events):
@@ -106,16 +106,16 @@ class xFogSet(ptMultiModifier):
         PtFogSetDefColor(newfogcolor)
 
         if FogMode.value == "Linear":
-            print("xFogSet.UpdateFog: Using Linear Fog")
+            PtDebugPrint("xFogSet.UpdateFog: Using Linear Fog")
             PtFogSetDefLinear(PointA_Start.value, PointA_End.value, PointA_Density.value)
 
         elif FogMode.value == "Exponential":
-            print("xFogSet.UpdateFog: Using Exponential Fog")
+            PtDebugPrint("xFogSet.UpdateFog: Using Exponential Fog")
             PtFogSetDefExp(PointA_End.value, PointA_Density.value)
 
         elif FogMode.value == "Exponential2":
-            print("xFogSet.UpdateFog: Using Exponential2 Fog")
+            PtDebugPrint("xFogSet.UpdateFog: Using Exponential2 Fog")
             PtFogSetDefExp2(PointA_End.value, PointA_Density.value)
 
         else:
-            print("xFogSet.UpdateFog: What type of Fog?")
+            PtDebugPrint("xFogSet.UpdateFog: What type of Fog?")

--- a/Python/xHighLevelStarTrekDoor.py
+++ b/Python/xHighLevelStarTrekDoor.py
@@ -101,12 +101,12 @@ class xHighLevelStarTrekDoor(ptModifier):
             self.SDL['DoorState'] = (0,)
             self.DoorState = self.SDL['DoorState'][0]
          
-        print "xHighLevelStarTrekDoor: self.SDL = %d" % self.DoorState
-        print "xHighLevelStarTrekDoor: Player List = %d" % len(PtGetPlayerList())
+        print("xHighLevelStarTrekDoor: self.SDL = %d" % self.DoorState)
+        print("xHighLevelStarTrekDoor: Player List = %d" % len(PtGetPlayerList()))
 
         if len(PtGetPlayerList()) > 0:
             
-            print "xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states."
+            print("xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states.")
 
             if self.DoorState == doorSDLstates['opening'] or self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opentoclose']:
                 respOpenDoor.run(self.key,netPropagate=0)
@@ -141,11 +141,11 @@ class xHighLevelStarTrekDoor(ptModifier):
         ageSDL = PtGetAgeSDL()
         if VARname == strDoorEnabledVar.value:
             self.DoorEnabled = ageSDL[strDoorEnabledVar.value][0]
-            print "HighLevelStarTrekDoor.OnSDLNotify: updated doorEnabled to %d" % self.DoorEnabled
+            print("HighLevelStarTrekDoor.OnSDLNotify: updated doorEnabled to %d" % self.DoorEnabled)
         elif VARname == strDoorClosedVar.value:
             doorClosed = ageSDL[strDoorClosedVar.value][0]
-            print "HighLevelStarTrekDoor.OnSDLNotify: Door Closed SDL Updated to: %d" % doorClosed
-            print "HighLevelStarTrekDoor.OnSDLNotify: Player who updated SDL: ", playerID
+            print("HighLevelStarTrekDoor.OnSDLNotify: Door Closed SDL Updated to: %d" % doorClosed)
+            print("HighLevelStarTrekDoor.OnSDLNotify: Player who updated SDL: ", playerID)
             if playerID == 0 and self.sceneobject.isLocallyOwned():
                 if doorClosed == 0:
                     self.SendNote("respOpenDoor;1")
@@ -161,46 +161,46 @@ class xHighLevelStarTrekDoor(ptModifier):
         #Notify Section
         if id == (-1):
             if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
-                print "xHighLevelStarTrekDoor: Avatar who entered the region. ",events[0][1].lstrip("rgnTriggerEnter")
+                print("xHighLevelStarTrekDoor: Avatar who entered the region. ",events[0][1].lstrip("rgnTriggerEnter"))
                 if self.DoorState == doorSDLstates['closed']:            
                     self.UpdateDoorState(doorSDLstates['opening'])
-                    print "xHighLevelStarTrekDoor: Setting Door to opening."
+                    print("xHighLevelStarTrekDoor: Setting Door to opening.")
 
                 elif self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closing']:
                     self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    print "xHighLevelStarTrekDoor: Setting Door to closetoopen."
+                    print("xHighLevelStarTrekDoor: Setting Door to closetoopen.")
 
                 elif self.DoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['movingopen'])
-                    print "xHighLevelStarTrekDoor: Setting Door to movingopen."
+                    print("xHighLevelStarTrekDoor: Setting Door to movingopen.")
                 return
 
             elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():
-                print "xHighLevelStarTrekDoor: Avatar who exited the region. ",events[0][1].lstrip("rgnTriggerExit")
+                print("xHighLevelStarTrekDoor: Avatar who exited the region. ",events[0][1].lstrip("rgnTriggerExit"))
                 if self.DoorState == doorSDLstates['open']:
                     self.UpdateDoorState(doorSDLstates['closing'])
-                    print "xHighLevelStarTrekDoor: Setting Door to closing."
+                    print("xHighLevelStarTrekDoor: Setting Door to closing.")
 
                 elif self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opening']:
                     self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    print "xHighLevelStarTrekDoor: Setting Door to opentoclose."
+                    print("xHighLevelStarTrekDoor: Setting Door to opentoclose.")
 
                 elif self.DoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    print "xHighLevelStarTrekDoor: Setting Door to movingclosed."
+                    print("xHighLevelStarTrekDoor: Setting Door to movingclosed.")
                 return
 
             
             elif events[0][1].find('respOpenDoor') != -1 or events[0][1].find('respCloseDoor') != -1:
                 self.DoorStack.append(events[0][1])
-                print "xHighLevelStarTrekDoor: New list is: %s" % (str(self.DoorStack))
+                print("xHighLevelStarTrekDoor: New list is: %s" % (str(self.DoorStack)))
                 
                 if len(self.DoorStack) == 1:
-                    print "xHighLevelStarTrekDoor: List is only one command long, so I'm playing it"
+                    print("xHighLevelStarTrekDoor: List is only one command long, so I'm playing it")
                     code = self.DoorStack[0]
                     #print "xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime
                     #PtAtTimeCallback(self.key,self.respondertime,1)
-                    print "xHighLevelStarTrekDoor: Playing command: %s" % (code)
+                    print("xHighLevelStarTrekDoor: Playing command: %s" % (code))
                     self.ExecCode(code)
                     if self.DoorStack[0].find('fastforward=1') != -1:
                         self.UpdateRespStack()
@@ -210,11 +210,11 @@ class xHighLevelStarTrekDoor(ptModifier):
             elif events[0][1].find('DoorState') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1:
                 #print "xHighLevelStarTrekDoor: Events = ", events[0][1].lstrip('DoorState=')
                 curState = int(events[0][1].lstrip('DoorState='))
-                print "xHighLevelStarTrekDoor: Door State Updated to %d" % curState
+                print("xHighLevelStarTrekDoor: Door State Updated to %d" % curState)
                 #print "xHighLevelStarTrekDoor: Door State SDL Set to %d" % self.SDL['DoorState'][0]
                 if curState != self.DoorState:
                     self.DoorState = curState
-                    print "xHighLevelStarTrekDoor: Door state is now %d" % self.DoorState
+                    print("xHighLevelStarTrekDoor: Door state is now %d" % self.DoorState)
                 return
 
                     
@@ -230,7 +230,7 @@ class xHighLevelStarTrekDoor(ptModifier):
                     playerID = PtGetLocalPlayer().getPlayerID()
                     triggerstr = "rgnTriggerEnter%d" % playerID
                     self.SendNote(triggerstr)
-                    print "xHighLevelStarTrekDoor: Door region entered."
+                    print("xHighLevelStarTrekDoor: Door region entered.")
                             
 
                 #true when you leave the region
@@ -238,14 +238,14 @@ class xHighLevelStarTrekDoor(ptModifier):
                     playerID = PtGetLocalPlayer().getPlayerID()
                     triggerstr = "rgnTriggerExit%d" % playerID
                     self.SendNote(triggerstr)
-                    print "xHighLevelStarTrekDoor: Door region clear."
+                    print("xHighLevelStarTrekDoor: Door region clear.")
 
                         
         elif id == respOpenDoor.id:
             
             self.UpdateRespStack()
             
-            print "xHighLevelStarTrekDoor: Door is now open."
+            print("xHighLevelStarTrekDoor: Door is now open.")
             if self.sceneobject.isLocallyOwned():
                 if self.DoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['closing'])
@@ -257,7 +257,7 @@ class xHighLevelStarTrekDoor(ptModifier):
 
             self.UpdateRespStack()
             
-            print "xHighLevelStarTrekDoor: Door is now closed."
+            print("xHighLevelStarTrekDoor: Door is now closed.")
             if self.sceneobject.isLocallyOwned():
                 if self.DoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['opening'])
@@ -281,11 +281,11 @@ class xHighLevelStarTrekDoor(ptModifier):
         #PtClearTimerCallbacks(self.key)
         #Updates the Responder List
         old = self.DoorStack.pop(0)
-        print "xHighLevelStarTrekDoor: Getting rid of Resp: %s" % (old)
+        print("xHighLevelStarTrekDoor: Getting rid of Resp: %s" % (old))
         if len(self.DoorStack):
-            print "xHighLevelStarTrekDoor: There's at lest one more Resp to play."
+            print("xHighLevelStarTrekDoor: There's at lest one more Resp to play.")
             code = self.DoorStack[0]            
-            print "Playing command: %s" % (code)
+            print("Playing command: %s" % (code))
             #print "xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime
             #PtAtTimeCallback(self.key,self.respondertime,1)
             self.ExecCode(code)
@@ -306,18 +306,18 @@ class xHighLevelStarTrekDoor(ptModifier):
 
             if self.DoorState == doorSDLstates['opening']:
                 self.SendNote("respOpenDoor;0")
-                print "xHighLevelStarTrekDoor: Notifying Clients to play Open Door Responder"
+                print("xHighLevelStarTrekDoor: Notifying Clients to play Open Door Responder")
 
             elif self.DoorState == doorSDLstates['closing']:
                 self.SendNote("respCloseDoor;0")
-                print "xHighLevelStarTrekDoor: Notifying Clients to play Close Door Responder"
+                print("xHighLevelStarTrekDoor: Notifying Clients to play Close Door Responder")
 
             elif self.DoorState == doorSDLstates['open']:
-                print "xHighLevelStarTrekDoor: Updating Age SDL to Open"
+                print("xHighLevelStarTrekDoor: Updating Age SDL to Open")
                 ageSDL[strDoorClosedVar.value] = (0,)
 
             elif self.DoorState == doorSDLstates['closed']:
-                print "xHighLevelStarTrekDoor: Updating Age SDL to Closed"
+                print("xHighLevelStarTrekDoor: Updating Age SDL to Closed")
                 ageSDL[strDoorClosedVar.value] = (1,)
 
     ##########################################
@@ -327,7 +327,7 @@ class xHighLevelStarTrekDoor(ptModifier):
     ##########################################
     def OnTimer(self,TimerID):
         if self.sceneobject.isLocallyOwned():
-            print "xHighLevelStarTrekDoor: Timer Came Back"
+            print("xHighLevelStarTrekDoor: Timer Came Back")
             if self.DoorState == doorSDLstates['opentoclose']:
                 self.UpdateDoorState(doorSDLstates['closing'])
 
@@ -356,8 +356,8 @@ class xHighLevelStarTrekDoor(ptModifier):
                 else:
                     respCloseDoor.run(self.key,netPropagate=0)
             else:
-                print "xHighLevelStarTrekDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag)
+                print("xHighLevelStarTrekDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
                 self.DoorStack.pop(0)
         except:
-            print "xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.DoorStack.pop(0)

--- a/Python/xHighLevelStarTrekDoor.py
+++ b/Python/xHighLevelStarTrekDoor.py
@@ -101,12 +101,12 @@ class xHighLevelStarTrekDoor(ptModifier):
             self.SDL['DoorState'] = (0,)
             self.DoorState = self.SDL['DoorState'][0]
          
-        print("xHighLevelStarTrekDoor: self.SDL = %d" % self.DoorState)
-        print("xHighLevelStarTrekDoor: Player List = %d" % len(PtGetPlayerList()))
+        PtDebugPrint("xHighLevelStarTrekDoor: self.SDL = %d" % self.DoorState)
+        PtDebugPrint("xHighLevelStarTrekDoor: Player List = %d" % len(PtGetPlayerList()))
 
         if len(PtGetPlayerList()) > 0:
             
-            print("xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states.")
+            PtDebugPrint("xHighLevelStarTrekDoor: Somebody is already in the age. Attempting to sync states.")
 
             if self.DoorState == doorSDLstates['opening'] or self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opentoclose']:
                 respOpenDoor.run(self.key,netPropagate=0)
@@ -115,7 +115,7 @@ class xHighLevelStarTrekDoor(ptModifier):
                 '''
                 respOpenDoor.run(self.key,fastforward=1)
                 self.DoorState = doorSDLstates['open']
-                print "xHighLevelStarTrekDoor: Door is open."
+                PtDebugPrint("xHighLevelStarTrekDoor: Door is open.")
                 '''
             
             elif self.DoorState == doorSDLstates['closing'] or self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closetoopen']:
@@ -124,7 +124,7 @@ class xHighLevelStarTrekDoor(ptModifier):
                 '''
                 respCloseDoor.run(self.key,fastforward=1)
                 self.DoorState = doorSDLstates['closed']
-                print "xHighLevelStarTrekDoor: Door is closed."
+                PtDebugPrint("xHighLevelStarTrekDoor: Door is closed.")
                 '''
             
             elif self.DoorState == doorSDLstates['open']:
@@ -141,11 +141,11 @@ class xHighLevelStarTrekDoor(ptModifier):
         ageSDL = PtGetAgeSDL()
         if VARname == strDoorEnabledVar.value:
             self.DoorEnabled = ageSDL[strDoorEnabledVar.value][0]
-            print("HighLevelStarTrekDoor.OnSDLNotify: updated doorEnabled to %d" % self.DoorEnabled)
+            PtDebugPrint("HighLevelStarTrekDoor.OnSDLNotify: updated doorEnabled to %d" % self.DoorEnabled)
         elif VARname == strDoorClosedVar.value:
             doorClosed = ageSDL[strDoorClosedVar.value][0]
-            print("HighLevelStarTrekDoor.OnSDLNotify: Door Closed SDL Updated to: %d" % doorClosed)
-            print("HighLevelStarTrekDoor.OnSDLNotify: Player who updated SDL: ", playerID)
+            PtDebugPrint("HighLevelStarTrekDoor.OnSDLNotify: Door Closed SDL Updated to: %d" % doorClosed)
+            PtDebugPrint("HighLevelStarTrekDoor.OnSDLNotify: Player who updated SDL: ", playerID)
             if playerID == 0 and self.sceneobject.isLocallyOwned():
                 if doorClosed == 0:
                     self.SendNote("respOpenDoor;1")
@@ -161,46 +161,46 @@ class xHighLevelStarTrekDoor(ptModifier):
         #Notify Section
         if id == (-1):
             if events[0][1].find('rgnTriggerEnter') != -1 and self.sceneobject.isLocallyOwned():
-                print("xHighLevelStarTrekDoor: Avatar who entered the region. ",events[0][1].lstrip("rgnTriggerEnter"))
+                PtDebugPrint("xHighLevelStarTrekDoor: Avatar who entered the region. ",events[0][1].lstrip("rgnTriggerEnter"))
                 if self.DoorState == doorSDLstates['closed']:            
                     self.UpdateDoorState(doorSDLstates['opening'])
-                    print("xHighLevelStarTrekDoor: Setting Door to opening.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opening.")
 
                 elif self.DoorState == doorSDLstates['movingclosed'] or self.DoorState == doorSDLstates['closing']:
                     self.UpdateDoorState(doorSDLstates['closetoopen'])
-                    print("xHighLevelStarTrekDoor: Setting Door to closetoopen.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closetoopen.")
 
                 elif self.DoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['movingopen'])
-                    print("xHighLevelStarTrekDoor: Setting Door to movingopen.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingopen.")
                 return
 
             elif events[0][1].find('rgnTriggerExit') != -1 and self.sceneobject.isLocallyOwned():
-                print("xHighLevelStarTrekDoor: Avatar who exited the region. ",events[0][1].lstrip("rgnTriggerExit"))
+                PtDebugPrint("xHighLevelStarTrekDoor: Avatar who exited the region. ",events[0][1].lstrip("rgnTriggerExit"))
                 if self.DoorState == doorSDLstates['open']:
                     self.UpdateDoorState(doorSDLstates['closing'])
-                    print("xHighLevelStarTrekDoor: Setting Door to closing.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to closing.")
 
                 elif self.DoorState == doorSDLstates['movingopen'] or self.DoorState == doorSDLstates['opening']:
                     self.UpdateDoorState(doorSDLstates['opentoclose'])
-                    print("xHighLevelStarTrekDoor: Setting Door to opentoclose.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to opentoclose.")
 
                 elif self.DoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['movingclosed'])
-                    print("xHighLevelStarTrekDoor: Setting Door to movingclosed.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Setting Door to movingclosed.")
                 return
 
             
             elif events[0][1].find('respOpenDoor') != -1 or events[0][1].find('respCloseDoor') != -1:
                 self.DoorStack.append(events[0][1])
-                print("xHighLevelStarTrekDoor: New list is: %s" % (str(self.DoorStack)))
+                PtDebugPrint("xHighLevelStarTrekDoor: New list is: %s" % (str(self.DoorStack)))
                 
                 if len(self.DoorStack) == 1:
-                    print("xHighLevelStarTrekDoor: List is only one command long, so I'm playing it")
+                    PtDebugPrint("xHighLevelStarTrekDoor: List is only one command long, so I'm playing it")
                     code = self.DoorStack[0]
-                    #print "xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime
+                    #PtDebugPrint("xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime)
                     #PtAtTimeCallback(self.key,self.respondertime,1)
-                    print("xHighLevelStarTrekDoor: Playing command: %s" % (code))
+                    PtDebugPrint("xHighLevelStarTrekDoor: Playing command: %s" % (code))
                     self.ExecCode(code)
                     if self.DoorStack[0].find('fastforward=1') != -1:
                         self.UpdateRespStack()
@@ -208,13 +208,13 @@ class xHighLevelStarTrekDoor(ptModifier):
 
 
             elif events[0][1].find('DoorState') != -1 and events[0][1].find('rgnTriggerEnter') == -1 and events[0][1].find('rgnTriggerExit') == -1 and events[0][1].find('Responder') == -1:
-                #print "xHighLevelStarTrekDoor: Events = ", events[0][1].lstrip('DoorState=')
+                #PtDebugPrint("xHighLevelStarTrekDoor: Events = ", events[0][1].lstrip('DoorState='))
                 curState = int(events[0][1].lstrip('DoorState='))
-                print("xHighLevelStarTrekDoor: Door State Updated to %d" % curState)
-                #print "xHighLevelStarTrekDoor: Door State SDL Set to %d" % self.SDL['DoorState'][0]
+                PtDebugPrint("xHighLevelStarTrekDoor: Door State Updated to %d" % curState)
+                #PtDebugPrint("xHighLevelStarTrekDoor: Door State SDL Set to %d" % self.SDL['DoorState'][0])
                 if curState != self.DoorState:
                     self.DoorState = curState
-                    print("xHighLevelStarTrekDoor: Door state is now %d" % self.DoorState)
+                    PtDebugPrint("xHighLevelStarTrekDoor: Door state is now %d" % self.DoorState)
                 return
 
                     
@@ -230,7 +230,7 @@ class xHighLevelStarTrekDoor(ptModifier):
                     playerID = PtGetLocalPlayer().getPlayerID()
                     triggerstr = "rgnTriggerEnter%d" % playerID
                     self.SendNote(triggerstr)
-                    print("xHighLevelStarTrekDoor: Door region entered.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Door region entered.")
                             
 
                 #true when you leave the region
@@ -238,14 +238,14 @@ class xHighLevelStarTrekDoor(ptModifier):
                     playerID = PtGetLocalPlayer().getPlayerID()
                     triggerstr = "rgnTriggerExit%d" % playerID
                     self.SendNote(triggerstr)
-                    print("xHighLevelStarTrekDoor: Door region clear.")
+                    PtDebugPrint("xHighLevelStarTrekDoor: Door region clear.")
 
                         
         elif id == respOpenDoor.id:
             
             self.UpdateRespStack()
             
-            print("xHighLevelStarTrekDoor: Door is now open.")
+            PtDebugPrint("xHighLevelStarTrekDoor: Door is now open.")
             if self.sceneobject.isLocallyOwned():
                 if self.DoorState == doorSDLstates['opentoclose']:
                     self.UpdateDoorState(doorSDLstates['closing'])
@@ -257,7 +257,7 @@ class xHighLevelStarTrekDoor(ptModifier):
 
             self.UpdateRespStack()
             
-            print("xHighLevelStarTrekDoor: Door is now closed.")
+            PtDebugPrint("xHighLevelStarTrekDoor: Door is now closed.")
             if self.sceneobject.isLocallyOwned():
                 if self.DoorState == doorSDLstates['closetoopen']:
                     self.UpdateDoorState(doorSDLstates['opening'])
@@ -281,12 +281,12 @@ class xHighLevelStarTrekDoor(ptModifier):
         #PtClearTimerCallbacks(self.key)
         #Updates the Responder List
         old = self.DoorStack.pop(0)
-        print("xHighLevelStarTrekDoor: Getting rid of Resp: %s" % (old))
+        PtDebugPrint("xHighLevelStarTrekDoor: Getting rid of Resp: %s" % (old))
         if len(self.DoorStack):
-            print("xHighLevelStarTrekDoor: There's at lest one more Resp to play.")
+            PtDebugPrint("xHighLevelStarTrekDoor: There's at lest one more Resp to play.")
             code = self.DoorStack[0]            
-            print("Playing command: %s" % (code))
-            #print "xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime
+            PtDebugPrint("Playing command: %s" % (code))
+            #PtDebugPrint("xHighLevelStarTrekDoor: Timer set to : %d" % self.respondertime)
             #PtAtTimeCallback(self.key,self.respondertime,1)
             self.ExecCode(code)
             if self.DoorStack[0].find('fastforward=1') != -1:
@@ -306,18 +306,18 @@ class xHighLevelStarTrekDoor(ptModifier):
 
             if self.DoorState == doorSDLstates['opening']:
                 self.SendNote("respOpenDoor;0")
-                print("xHighLevelStarTrekDoor: Notifying Clients to play Open Door Responder")
+                PtDebugPrint("xHighLevelStarTrekDoor: Notifying Clients to play Open Door Responder")
 
             elif self.DoorState == doorSDLstates['closing']:
                 self.SendNote("respCloseDoor;0")
-                print("xHighLevelStarTrekDoor: Notifying Clients to play Close Door Responder")
+                PtDebugPrint("xHighLevelStarTrekDoor: Notifying Clients to play Close Door Responder")
 
             elif self.DoorState == doorSDLstates['open']:
-                print("xHighLevelStarTrekDoor: Updating Age SDL to Open")
+                PtDebugPrint("xHighLevelStarTrekDoor: Updating Age SDL to Open")
                 ageSDL[strDoorClosedVar.value] = (0,)
 
             elif self.DoorState == doorSDLstates['closed']:
-                print("xHighLevelStarTrekDoor: Updating Age SDL to Closed")
+                PtDebugPrint("xHighLevelStarTrekDoor: Updating Age SDL to Closed")
                 ageSDL[strDoorClosedVar.value] = (1,)
 
     ##########################################
@@ -327,7 +327,7 @@ class xHighLevelStarTrekDoor(ptModifier):
     ##########################################
     def OnTimer(self,TimerID):
         if self.sceneobject.isLocallyOwned():
-            print("xHighLevelStarTrekDoor: Timer Came Back")
+            PtDebugPrint("xHighLevelStarTrekDoor: Timer Came Back")
             if self.DoorState == doorSDLstates['opentoclose']:
                 self.UpdateDoorState(doorSDLstates['closing'])
 
@@ -356,8 +356,8 @@ class xHighLevelStarTrekDoor(ptModifier):
                 else:
                     respCloseDoor.run(self.key,netPropagate=0)
             else:
-                print("xHighLevelStarTrekDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
+                PtDebugPrint("xHighLevelStarTrekDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
                 self.DoorStack.pop(0)
         except:
-            print("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.DoorStack.pop(0)

--- a/Python/xIniAudio.py
+++ b/Python/xIniAudio.py
@@ -80,11 +80,11 @@ def ConstructFilenameAndPath():
             localNameAndPath = U"init/" + gFilename
             if PtFileExists(localNameAndPath):
                 gFilenameAndPath = localNameAndPath
-                print U"xIniAudio::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file"
+                print(U"xIniAudio::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file")
                 return
         # otherwise, use the standard init path
         gFilenameAndPath = PtGetInitPath() + U"/" + gFilename
-        print U"xIniAudio::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file"
+        print(U"xIniAudio::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file")
 
 def WriteIni():
     global gIniFile
@@ -322,7 +322,7 @@ def SetAudioMode(init, device, eax):
         else:
             gIniFile.addEntry("Audio.Initialize " + val)
 
-        print device
+        print(device)
         if entryDev:
             entryDev.setValue(0, "\"" + device + "\"")
         else:

--- a/Python/xIniAudio.py
+++ b/Python/xIniAudio.py
@@ -80,11 +80,11 @@ def ConstructFilenameAndPath():
             localNameAndPath = U"init/" + gFilename
             if PtFileExists(localNameAndPath):
                 gFilenameAndPath = localNameAndPath
-                print(U"xIniAudio::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file")
+                PtDebugPrint(U"xIniAudio::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file")
                 return
         # otherwise, use the standard init path
         gFilenameAndPath = PtGetInitPath() + U"/" + gFilename
-        print(U"xIniAudio::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file")
+        PtDebugPrint(U"xIniAudio::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file")
 
 def WriteIni():
     global gIniFile
@@ -322,7 +322,7 @@ def SetAudioMode(init, device, eax):
         else:
             gIniFile.addEntry("Audio.Initialize " + val)
 
-        print(device)
+        PtDebugPrint(device)
         if entryDev:
             entryDev.setValue(0, "\"" + device + "\"")
         else:

--- a/Python/xIniDisplay.py
+++ b/Python/xIniDisplay.py
@@ -75,11 +75,11 @@ def ConstructFilenameAndPath():
             localNameAndPath = U"init/" + gFilename
             if PtFileExists(localNameAndPath):
                 gFilenameAndPath = localNameAndPath
-                print(U"xIniDisplay::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file")
+                PtDebugPrint(U"xIniDisplay::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file")
                 return
         # otherwise, use the standard init path
         gFilenameAndPath = PtGetInitPath() + U"/" + gFilename
-        print(U"xIniDisplay::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file")
+        PtDebugPrint(U"xIniDisplay::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file")
 
 def WriteIni():
     global gIniFile

--- a/Python/xIniDisplay.py
+++ b/Python/xIniDisplay.py
@@ -75,11 +75,11 @@ def ConstructFilenameAndPath():
             localNameAndPath = U"init/" + gFilename
             if PtFileExists(localNameAndPath):
                 gFilenameAndPath = localNameAndPath
-                print U"xIniDisplay::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file"
+                print(U"xIniDisplay::ConstructFilenameAndPath(): Using internal \"" + gFilenameAndPath + U"\" file")
                 return
         # otherwise, use the standard init path
         gFilenameAndPath = PtGetInitPath() + U"/" + gFilename
-        print U"xIniDisplay::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file"
+        print(U"xIniDisplay::ConstructFilenameAndPath(): Using user-level \"" + gFilenameAndPath + U"\" file")
 
 def WriteIni():
     global gIniFile

--- a/Python/xIniHelper.py
+++ b/Python/xIniHelper.py
@@ -131,12 +131,12 @@ class iniFile:
                     self.entries.append(iniEntry(l))
                 f.close()
             except:
-                print "[INI processing] Error while reading %s" % (filename)
+                print("[INI processing] Error while reading %s" % (filename))
 
     def __repr__(self):
         line = ""
         for entry in self.entries:
-            line += `entry`
+            line += repr(entry)
         return line
 
     def isEmpty(self):

--- a/Python/xIniHelper.py
+++ b/Python/xIniHelper.py
@@ -131,7 +131,7 @@ class iniFile:
                     self.entries.append(iniEntry(l))
                 f.close()
             except:
-                print("[INI processing] Error while reading %s" % (filename))
+                PtDebugPrint("[INI processing] Error while reading %s" % (filename))
 
     def __repr__(self):
         line = ""

--- a/Python/xInvite.py
+++ b/Python/xInvite.py
@@ -173,6 +173,6 @@ def DeleteInvitation(params=None):
 
 def MeChat(params=None):
     if (params == None):
-        print 'xChatExtend:MeCmd: If you have nothing to say, why say anything at all?'
+        print('xChatExtend:MeCmd: If you have nothing to say, why say anything at all?')
         return 
     PtSendKIMessage(kKIChatStatusMsg, ('%s %s' % (PtGetLocalPlayer().getPlayerName(), params)))

--- a/Python/xInvite.py
+++ b/Python/xInvite.py
@@ -173,6 +173,6 @@ def DeleteInvitation(params=None):
 
 def MeChat(params=None):
     if (params == None):
-        print('xChatExtend:MeCmd: If you have nothing to say, why say anything at all?')
+        PtDebugPrint('xChatExtend:MeCmd: If you have nothing to say, why say anything at all?')
         return 
     PtSendKIMessage(kKIChatStatusMsg, ('%s %s' % (PtGetLocalPlayer().getPlayerName(), params)))

--- a/Python/xJourneyClothGate.py
+++ b/Python/xJourneyClothGate.py
@@ -141,7 +141,7 @@ class xJourneyClothGate(ptResponder):
         if not state:
             return
         
-        print("##")
+        PtDebugPrint("##")
 
         if id == rgnLink.id:
             vault = ptVault()
@@ -178,7 +178,7 @@ class xJourneyClothGate(ptResponder):
                 except:
                     PtDebugPrint("ERROR: xJourneyClothGate.OnServerInitComplete():\tERROR reading age SDL")
             
-            print("OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed)
+            PtDebugPrint("OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed)
             if not GateCurrentlyClosed:
                 PtDebugPrint ("The gate is already open.")
                 return
@@ -221,10 +221,10 @@ class xJourneyClothGate(ptResponder):
         PtAtTimeCallback(self.key,5,TimerID.kResetGate)         
 
         if not PtWasLocallyNotified(self.key):
-            print("Somebody touched the Journey Cloth Gate")
+            PtDebugPrint("Somebody touched the Journey Cloth Gate")
             return
 
-        print("You clicked on the Gate")
+        PtDebugPrint("You clicked on the Gate")
         vault = ptVault()
             
         entry = vault.findChronicleEntry("JourneyClothProgress")
@@ -240,23 +240,23 @@ class xJourneyClothGate(ptResponder):
             length = len(FoundJCs)
             all = len(AllCloths)
 
-            print("You've found the following %d Journey Cloths: %s" % (length, FoundJCs))
+            PtDebugPrint("You've found the following %d Journey Cloths: %s" % (length, FoundJCs))
             
             if length < 0 or length > all: 
-                print("xJourneyClothGate: ERROR: Unexpected length value received.")
+                PtDebugPrint("xJourneyClothGate: ERROR: Unexpected length value received.")
                 return
                 
             for each in FoundJCs:
                 if each not in AllCloths:
-                    print("Unexpected value in the Chronicle:", each)
+                    PtDebugPrint("Unexpected value in the Chronicle:", each)
                     return
 
             if length < all:
-                print("There are more Cloths out there. Get to work.")
+                PtDebugPrint("There are more Cloths out there. Get to work.")
                 PalmGlowWeak.run(self.key)
                 
             elif length == all:
-                print("All expected Cloths were found. Opening Door.")
+                PtDebugPrint("All expected Cloths were found. Opening Door.")
                 PalmGlowStrong.run(self.key)
                 self.ToggleSDL("fromOutside")
 
@@ -284,7 +284,7 @@ class xJourneyClothGate(ptResponder):
                 PtDebugPrint("ERROR: xJourneyClothGate.ToggleSDL():\tERROR reading age SDL")
                 GateCurrentlyClosed = False
     
-            print("ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed)
+            PtDebugPrint("ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed)
     
     
             # Toggle the sdl value

--- a/Python/xJourneyClothGate.py
+++ b/Python/xJourneyClothGate.py
@@ -141,7 +141,7 @@ class xJourneyClothGate(ptResponder):
         if not state:
             return
         
-        print "##"
+        print("##")
 
         if id == rgnLink.id:
             vault = ptVault()
@@ -178,7 +178,7 @@ class xJourneyClothGate(ptResponder):
                 except:
                     PtDebugPrint("ERROR: xJourneyClothGate.OnServerInitComplete():\tERROR reading age SDL")
             
-            print "OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed
+            print("OnNotify: GateCurrentlyClosed = " , GateCurrentlyClosed)
             if not GateCurrentlyClosed:
                 PtDebugPrint ("The gate is already open.")
                 return
@@ -221,10 +221,10 @@ class xJourneyClothGate(ptResponder):
         PtAtTimeCallback(self.key,5,TimerID.kResetGate)         
 
         if not PtWasLocallyNotified(self.key):
-            print "Somebody touched the Journey Cloth Gate"
+            print("Somebody touched the Journey Cloth Gate")
             return
 
-        print "You clicked on the Gate"
+        print("You clicked on the Gate")
         vault = ptVault()
             
         entry = vault.findChronicleEntry("JourneyClothProgress")
@@ -240,23 +240,23 @@ class xJourneyClothGate(ptResponder):
             length = len(FoundJCs)
             all = len(AllCloths)
 
-            print "You've found the following %d Journey Cloths: %s" % (length, FoundJCs)
+            print("You've found the following %d Journey Cloths: %s" % (length, FoundJCs))
             
             if length < 0 or length > all: 
-                print "xJourneyClothGate: ERROR: Unexpected length value received."
+                print("xJourneyClothGate: ERROR: Unexpected length value received.")
                 return
                 
             for each in FoundJCs:
                 if each not in AllCloths:
-                    print "Unexpected value in the Chronicle:", each
+                    print("Unexpected value in the Chronicle:", each)
                     return
 
             if length < all:
-                print "There are more Cloths out there. Get to work."
+                print("There are more Cloths out there. Get to work.")
                 PalmGlowWeak.run(self.key)
                 
             elif length == all:
-                print "All expected Cloths were found. Opening Door."
+                print("All expected Cloths were found. Opening Door.")
                 PalmGlowStrong.run(self.key)
                 self.ToggleSDL("fromOutside")
 
@@ -284,7 +284,7 @@ class xJourneyClothGate(ptResponder):
                 PtDebugPrint("ERROR: xJourneyClothGate.ToggleSDL():\tERROR reading age SDL")
                 GateCurrentlyClosed = False
     
-            print "ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed
+            print("ToggleSDL: GateCurrentlyClosed = ", GateCurrentlyClosed)
     
     
             # Toggle the sdl value

--- a/Python/xJourneyCloths.py
+++ b/Python/xJourneyCloths.py
@@ -99,7 +99,7 @@ class xJourneyCloths(ptModifier):
         self.id = 5226
         version = 7
         self.version = version
-        print "__init__xJourneyCloths v.", version
+        print("__init__xJourneyCloths v.", version)
         random.seed()
 
     def OnNotify(self,state,id,events):
@@ -116,38 +116,38 @@ class xJourneyCloths(ptModifier):
             OneShotResp.run(self.key, events=events) # run the oneshot
             return
         
-        print "###"
+        print("###")
         # every client sets the following timer locally
         PtAtTimeCallback(self.key,11,1) 
 
         if not PtWasLocallyNotified(self.key):
-            print "Somebody touched JourneyCloth", ClothLetter.value
+            print("Somebody touched JourneyCloth", ClothLetter.value)
             return
         
-        print "You clicked on cloth ", ClothLetter.value
+        print("You clicked on cloth ", ClothLetter.value)
         vault = ptVault()
             
         entry = vault.findChronicleEntry("JourneyClothProgress")
         if entry is None: # is this the player's first Journey Cloth?
-            print "First cloth found."
+            print("First cloth found.")
 
-            print "trying to update JourneyClothProgress to: ", ClothLetter.value
+            print("trying to update JourneyClothProgress to: ", ClothLetter.value)
             vault = ptVault() 
             vault.addChronicleEntry("JourneyClothProgress",0,"%s" % (ClothLetter.value))
             self.IPlayHandAnim(1)
         
         else:
             FoundJCs = entry.chronicleGetValue()
-            print "previously found JCs: ", FoundJCs
+            print("previously found JCs: ", FoundJCs)
             if ClothLetter.value in FoundJCs:
-                print "You've already found this cloth."
+                print("You've already found this cloth.")
 
                 
             else:
-                print "This is a new cloth to you"
+                print("This is a new cloth to you")
                 
                 FoundJCs = FoundJCs + ClothLetter.value
-                print "trying to update JourneyClothProgress to ", FoundJCs
+                print("trying to update JourneyClothProgress to ", FoundJCs)
 
                 entry.chronicleSetValue("%s" % (FoundJCs)) 
                 entry.save() 
@@ -166,7 +166,7 @@ class xJourneyCloths(ptModifier):
         PtDebugPrint ("You've found %s JourneyCloths" % (length))
 
         if length < 0 or length > 11:
-            print "xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow."
+            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
         
         if length == 1:
             HandAnim01.run(self.key)
@@ -202,11 +202,11 @@ class xJourneyCloths(ptModifier):
             HandAnim10.run(self.key)
 
         else: 
-            print "xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow."
+            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
             
     def RandomBahroSounds(self):
         whichsound = random.randint(1, 4)
-        print "whichsound = ", whichsound
+        print("whichsound = ", whichsound)
         
         if whichsound == 1:
             PlayBahro01.run(self.key)
@@ -224,7 +224,7 @@ class xJourneyCloths(ptModifier):
         
         if wingflap > 1:
             whichflap = random.randint(1, 4)
-            print "whichflap = ", whichflap
+            print("whichflap = ", whichflap)
             
             if whichflap == 1:
                 BahroWing01.run(self.key)
@@ -239,7 +239,7 @@ class xJourneyCloths(ptModifier):
                 BahroWing04.run(self.key)
                 
         else: 
-            print "no wingflap is heard."
+            print("no wingflap is heard.")
             
     def OnTimer(self,id):
         global ClothInUse

--- a/Python/xJourneyCloths.py
+++ b/Python/xJourneyCloths.py
@@ -99,7 +99,7 @@ class xJourneyCloths(ptModifier):
         self.id = 5226
         version = 7
         self.version = version
-        print("__init__xJourneyCloths v.", version)
+        PtDebugPrint("__init__xJourneyCloths v.", version)
         random.seed()
 
     def OnNotify(self,state,id,events):
@@ -116,38 +116,38 @@ class xJourneyCloths(ptModifier):
             OneShotResp.run(self.key, events=events) # run the oneshot
             return
         
-        print("###")
+        PtDebugPrint("###")
         # every client sets the following timer locally
         PtAtTimeCallback(self.key,11,1) 
 
         if not PtWasLocallyNotified(self.key):
-            print("Somebody touched JourneyCloth", ClothLetter.value)
+            PtDebugPrint("Somebody touched JourneyCloth", ClothLetter.value)
             return
         
-        print("You clicked on cloth ", ClothLetter.value)
+        PtDebugPrint("You clicked on cloth ", ClothLetter.value)
         vault = ptVault()
             
         entry = vault.findChronicleEntry("JourneyClothProgress")
         if entry is None: # is this the player's first Journey Cloth?
-            print("First cloth found.")
+            PtDebugPrint("First cloth found.")
 
-            print("trying to update JourneyClothProgress to: ", ClothLetter.value)
+            PtDebugPrint("trying to update JourneyClothProgress to: ", ClothLetter.value)
             vault = ptVault() 
             vault.addChronicleEntry("JourneyClothProgress",0,"%s" % (ClothLetter.value))
             self.IPlayHandAnim(1)
         
         else:
             FoundJCs = entry.chronicleGetValue()
-            print("previously found JCs: ", FoundJCs)
+            PtDebugPrint("previously found JCs: ", FoundJCs)
             if ClothLetter.value in FoundJCs:
-                print("You've already found this cloth.")
+                PtDebugPrint("You've already found this cloth.")
 
                 
             else:
-                print("This is a new cloth to you")
+                PtDebugPrint("This is a new cloth to you")
                 
                 FoundJCs = FoundJCs + ClothLetter.value
-                print("trying to update JourneyClothProgress to ", FoundJCs)
+                PtDebugPrint("trying to update JourneyClothProgress to ", FoundJCs)
 
                 entry.chronicleSetValue("%s" % (FoundJCs)) 
                 entry.save() 
@@ -166,7 +166,7 @@ class xJourneyCloths(ptModifier):
         PtDebugPrint ("You've found %s JourneyCloths" % (length))
 
         if length < 0 or length > 11:
-            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
+            PtDebugPrint("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
         
         if length == 1:
             HandAnim01.run(self.key)
@@ -202,11 +202,11 @@ class xJourneyCloths(ptModifier):
             HandAnim10.run(self.key)
 
         else: 
-            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
+            PtDebugPrint("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
             
     def RandomBahroSounds(self):
         whichsound = random.randint(1, 4)
-        print("whichsound = ", whichsound)
+        PtDebugPrint("whichsound = ", whichsound)
         
         if whichsound == 1:
             PlayBahro01.run(self.key)
@@ -224,7 +224,7 @@ class xJourneyCloths(ptModifier):
         
         if wingflap > 1:
             whichflap = random.randint(1, 4)
-            print("whichflap = ", whichflap)
+            PtDebugPrint("whichflap = ", whichflap)
             
             if whichflap == 1:
                 BahroWing01.run(self.key)
@@ -239,7 +239,7 @@ class xJourneyCloths(ptModifier):
                 BahroWing04.run(self.key)
                 
         else: 
-            print("no wingflap is heard.")
+            PtDebugPrint("no wingflap is heard.")
             
     def OnTimer(self,id):
         global ClothInUse

--- a/Python/xJourneyClothsGen2.py
+++ b/Python/xJourneyClothsGen2.py
@@ -112,7 +112,7 @@ class xJourneyClothsGen2(ptModifier):
         ptModifier.__init__(self)
         self.id = 5308
         self.version = 8
-        print "DEBUG: xJourneyClothsGen2.__init__: v.", self.version
+        print("DEBUG: xJourneyClothsGen2.__init__: v.", self.version)
 
     def OnFirstUpdate(self):
         xRandom.seed()
@@ -133,20 +133,20 @@ class xJourneyClothsGen2(ptModifier):
         spTitle = spawnPoint.getTitle()
         spName = spawnPoint.getName()
 
-        print "spawned into", spName, ", this JC handles", soSpawnpoint.value.getName()
+        print("spawned into", spName, ", this JC handles", soSpawnpoint.value.getName())
         if spTitle.endswith("SavePoint") and spName == soSpawnpoint.value.getName():
-            print "restoring camera stack for save point", spTitle, spName
+            print("restoring camera stack for save point", spTitle, spName)
 
             # Restore camera stack
             camstack = spawnPoint.getCameraStack()
-            print "camera stack:", camstack
+            print("camera stack:", camstack)
             if camstack != "":
                 PtClearCameraStack()
                 camlist = camstack.split(CAM_DIVIDER)
 
                 age = PtGetAgeName()
                 for x in camlist:
-                    print "adding camera: |" + str(x) + "|"
+                    print("adding camera: |" + str(x) + "|")
                     try:
                         PtRebuildCameraStack(x, age)
                     except:
@@ -193,7 +193,7 @@ class xJourneyClothsGen2(ptModifier):
                     for x in range(numcams):
                         camstack += (PtGetCameraNumber(x+1) + CAM_DIVIDER)
                     camstack = camstack[:-1]
-                    print "camera stack:", camstack
+                    print("camera stack:", camstack)
                     
                     #commenting these out, as they've been moved to the beginning of the OneShotResp conditional
                     #vault = ptVault()
@@ -260,7 +260,7 @@ class xJourneyClothsGen2(ptModifier):
         PtDebugPrint ("You've found %s JourneyCloths" % (length))
 
         if length < 0 or length > 7:
-            print "xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow."
+            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
         
         if length == 1:
             HandAnim01.run(self.key)
@@ -291,11 +291,11 @@ class xJourneyClothsGen2(ptModifier):
             HandGlowFullAudio.run(self.key)
 
         else: 
-            print "xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow."
+            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
             
     def RandomBahroSounds(self):
         whichsound = xRandom.random.randint(1, 4)
-        print "whichsound = ", whichsound
+        print("whichsound = ", whichsound)
         
         if whichsound == 1:
             PlayBahro01.run(self.key)
@@ -314,7 +314,7 @@ class xJourneyClothsGen2(ptModifier):
         if wingflap > 1:
             #whichflap = xRandom.random.randint(1, 4)
             whichflap = whichsound
-            print "whichflap = ", whichflap
+            print("whichflap = ", whichflap)
             
             if whichflap == 1:
                 BahroWing01.run(self.key)
@@ -329,7 +329,7 @@ class xJourneyClothsGen2(ptModifier):
                 BahroWing04.run(self.key)
                 
         else: 
-            print "no wingflap is heard."
+            print("no wingflap is heard.")
             
     def OnTimer(self,id):
         global ClothInUse
@@ -339,19 +339,19 @@ class xJourneyClothsGen2(ptModifier):
             Activator.enable()
             
         elif id == TimerID.AddSavePoint:
-            print "###"
+            print("###")
             # every client sets the following timer locally
             PtAtTimeCallback(self.key,11,TimerID.AddJCProgress) 
 
             if not PtWasLocallyNotified(self.key):
-                print "Somebody touched JourneyCloth", ClothLetter.value
+                print("Somebody touched JourneyCloth", ClothLetter.value)
                 return
 
 ##            vault = ptVault()
 ##            if vault.amOwnerOfCurrentAge():
 ##                PtEnableMovementKeys()
             
-            print "You clicked on cloth ", ClothLetter.value
+            print("You clicked on cloth ", ClothLetter.value)
             vault = ptVault()
                 
             entry = vault.findChronicleEntry("JourneyClothProgress")
@@ -364,22 +364,22 @@ class xJourneyClothsGen2(ptModifier):
                 currentAgeChron = self.GetCurrentAgeChronicle(entry)
 
                 if currentAgeChron is None:
-                    print "You haven't found a JC in this age before, adding it now"
+                    print("You haven't found a JC in this age before, adding it now")
                     
                     currentAgeChron = self.AddNodeWithCurrentValue(entry)
                     FoundJCs = ClothLetter.value
                     self.RandomBahroSounds()
                 else:
                     FoundJCs = currentAgeChron.chronicleGetValue()
-                    print "previously found JCs: ", FoundJCs
+                    print("previously found JCs: ", FoundJCs)
                     if ClothLetter.value in FoundJCs:
-                        print "You've already found this cloth."
+                        print("You've already found this cloth.")
                         
                     else:
-                        print "This is a new cloth to you"
+                        print("This is a new cloth to you")
                         
                         FoundJCs = FoundJCs + ClothLetter.value
-                        print "trying to update JourneyClothProgress to ", FoundJCs
+                        print("trying to update JourneyClothProgress to ", FoundJCs)
 
                         currentAgeChron.chronicleSetValue("%s" % (FoundJCs)) 
                         currentAgeChron.save() 

--- a/Python/xJourneyClothsGen2.py
+++ b/Python/xJourneyClothsGen2.py
@@ -112,7 +112,7 @@ class xJourneyClothsGen2(ptModifier):
         ptModifier.__init__(self)
         self.id = 5308
         self.version = 8
-        print("DEBUG: xJourneyClothsGen2.__init__: v.", self.version)
+        PtDebugPrint("DEBUG: xJourneyClothsGen2.__init__: v.", self.version)
 
     def OnFirstUpdate(self):
         xRandom.seed()
@@ -133,20 +133,20 @@ class xJourneyClothsGen2(ptModifier):
         spTitle = spawnPoint.getTitle()
         spName = spawnPoint.getName()
 
-        print("spawned into", spName, ", this JC handles", soSpawnpoint.value.getName())
+        PtDebugPrint("spawned into", spName, ", this JC handles", soSpawnpoint.value.getName())
         if spTitle.endswith("SavePoint") and spName == soSpawnpoint.value.getName():
-            print("restoring camera stack for save point", spTitle, spName)
+            PtDebugPrint("restoring camera stack for save point", spTitle, spName)
 
             # Restore camera stack
             camstack = spawnPoint.getCameraStack()
-            print("camera stack:", camstack)
+            PtDebugPrint("camera stack:", camstack)
             if camstack != "":
                 PtClearCameraStack()
                 camlist = camstack.split(CAM_DIVIDER)
 
                 age = PtGetAgeName()
                 for x in camlist:
-                    print("adding camera: |" + str(x) + "|")
+                    PtDebugPrint("adding camera: |" + str(x) + "|")
                     try:
                         PtRebuildCameraStack(x, age)
                     except:
@@ -193,7 +193,7 @@ class xJourneyClothsGen2(ptModifier):
                     for x in range(numcams):
                         camstack += (PtGetCameraNumber(x+1) + CAM_DIVIDER)
                     camstack = camstack[:-1]
-                    print("camera stack:", camstack)
+                    PtDebugPrint("camera stack:", camstack)
                     
                     #commenting these out, as they've been moved to the beginning of the OneShotResp conditional
                     #vault = ptVault()
@@ -260,7 +260,7 @@ class xJourneyClothsGen2(ptModifier):
         PtDebugPrint ("You've found %s JourneyCloths" % (length))
 
         if length < 0 or length > 7:
-            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
+            PtDebugPrint("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
         
         if length == 1:
             HandAnim01.run(self.key)
@@ -291,11 +291,11 @@ class xJourneyClothsGen2(ptModifier):
             HandGlowFullAudio.run(self.key)
 
         else: 
-            print("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
+            PtDebugPrint("xJourneyCloths.HandGlow: ERROR: Unexpected length value received. No hand glow.")
             
     def RandomBahroSounds(self):
         whichsound = xRandom.random.randint(1, 4)
-        print("whichsound = ", whichsound)
+        PtDebugPrint("whichsound = ", whichsound)
         
         if whichsound == 1:
             PlayBahro01.run(self.key)
@@ -314,7 +314,7 @@ class xJourneyClothsGen2(ptModifier):
         if wingflap > 1:
             #whichflap = xRandom.random.randint(1, 4)
             whichflap = whichsound
-            print("whichflap = ", whichflap)
+            PtDebugPrint("whichflap = ", whichflap)
             
             if whichflap == 1:
                 BahroWing01.run(self.key)
@@ -329,7 +329,7 @@ class xJourneyClothsGen2(ptModifier):
                 BahroWing04.run(self.key)
                 
         else: 
-            print("no wingflap is heard.")
+            PtDebugPrint("no wingflap is heard.")
             
     def OnTimer(self,id):
         global ClothInUse
@@ -339,19 +339,19 @@ class xJourneyClothsGen2(ptModifier):
             Activator.enable()
             
         elif id == TimerID.AddSavePoint:
-            print("###")
+            PtDebugPrint("###")
             # every client sets the following timer locally
             PtAtTimeCallback(self.key,11,TimerID.AddJCProgress) 
 
             if not PtWasLocallyNotified(self.key):
-                print("Somebody touched JourneyCloth", ClothLetter.value)
+                PtDebugPrint("Somebody touched JourneyCloth", ClothLetter.value)
                 return
 
 ##            vault = ptVault()
 ##            if vault.amOwnerOfCurrentAge():
 ##                PtEnableMovementKeys()
             
-            print("You clicked on cloth ", ClothLetter.value)
+            PtDebugPrint("You clicked on cloth ", ClothLetter.value)
             vault = ptVault()
                 
             entry = vault.findChronicleEntry("JourneyClothProgress")
@@ -364,22 +364,22 @@ class xJourneyClothsGen2(ptModifier):
                 currentAgeChron = self.GetCurrentAgeChronicle(entry)
 
                 if currentAgeChron is None:
-                    print("You haven't found a JC in this age before, adding it now")
+                    PtDebugPrint("You haven't found a JC in this age before, adding it now")
                     
                     currentAgeChron = self.AddNodeWithCurrentValue(entry)
                     FoundJCs = ClothLetter.value
                     self.RandomBahroSounds()
                 else:
                     FoundJCs = currentAgeChron.chronicleGetValue()
-                    print("previously found JCs: ", FoundJCs)
+                    PtDebugPrint("previously found JCs: ", FoundJCs)
                     if ClothLetter.value in FoundJCs:
-                        print("You've already found this cloth.")
+                        PtDebugPrint("You've already found this cloth.")
                         
                     else:
-                        print("This is a new cloth to you")
+                        PtDebugPrint("This is a new cloth to you")
                         
                         FoundJCs = FoundJCs + ClothLetter.value
-                        print("trying to update JourneyClothProgress to ", FoundJCs)
+                        PtDebugPrint("trying to update JourneyClothProgress to ", FoundJCs)
 
                         currentAgeChron.chronicleSetValue("%s" % (FoundJCs)) 
                         currentAgeChron.save() 

--- a/Python/xLinkingBookGUIPopup.py
+++ b/Python/xLinkingBookGUIPopup.py
@@ -293,7 +293,7 @@ class xLinkingBookGUIPopup(ptModifier):
                             PtSetOfferBookMode(self.key, self.IGetAgeFilename(), self.IGetAgeInstanceName())
                             PtSetShareSpawnPoint(self.IGetAgeSpawnPoint())
                             if self.IGetAgeFilename() == "PelletBahroCave":
-                                print "using Adam's plasma-magical 'PtSetShareAgeInstanceGuid' with pelletcaveguid = ",pelletCaveGUID
+                                print("using Adam's plasma-magical 'PtSetShareAgeInstanceGuid' with pelletcaveguid = ",pelletCaveGUID)
                                 PtSetShareAgeInstanceGuid(pelletCaveGUID)
                             ClosedBookToShare = 1
                             self.HideBook()
@@ -456,10 +456,10 @@ class xLinkingBookGUIPopup(ptModifier):
             # age panel names are misleading, this is really for the Pellet Cave
             elif agePanel == "BahroCaveUpper":
                 pelletCaveGUID = str(self.OnClickToLinkToPelletCaveFromErcana())
-                print "pelletCaveGUID = ",pelletCaveGUID
+                print("pelletCaveGUID = ",pelletCaveGUID)
             elif agePanel == "BahroCaveLower":
                 pelletCaveGUID = str(self.OnClickToLinkToPelletCaveFromAhnonay())
-                print "pelletCaveGUID = ",pelletCaveGUID
+                print("pelletCaveGUID = ",pelletCaveGUID)
             try:
                 params = xLinkingBookDefs.xAgeLinkingBooks[agePanel]
                 if len(params) == 6:
@@ -499,7 +499,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
 
     def IShowBookTreasure(self):
-        print "Show the linking book with all its treasure pages"
+        print("Show the linking book with all its treasure pages")
         global gLinkingBook
         global CurrentPage
         global SpawnPointTitle_Dict
@@ -519,7 +519,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 showOpen = 1  # start the book at the page where they left off
 
         # did we find an agePanel to link with?
-        print "agePanel = ",agePanel
+        print("agePanel = ",agePanel)
         if agePanel:
             if agePanel == "Cleft":
                 vault = ptVault()
@@ -535,14 +535,14 @@ class xLinkingBookGUIPopup(ptModifier):
                 SpawnPointName_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'DisabledDesert'}
 
             elif (agePanel == "CleftWithTomahna") and ptVault().amOwnerOfCurrentAge():
-                print "setting up cleft and tomahna spawn points"
+                print("setting up cleft and tomahna spawn points")
                 SpawnPointTitle_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'Tomahna', xLinkingBookDefs.kFirstLinkPanelID + 1: 'Cleft'}
                 SpawnPointName_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'SpawnPointTomahna01', xLinkingBookDefs.kFirstLinkPanelID + 1: 'LinkInPointDefault'}
 
             elif agePanel == "city":
                 self.BuildCityBook()
                 agePanel = SpawnPointTitle_Dict[xLinkingBookDefs.kFirstLinkPanelID]
-                print "agePanel2 = ",agePanel
+                print("agePanel2 = ",agePanel)
             elif agePanel == "Neighborhood":
                 agevault = ptAgeVault()
                 nblink = self.GetOwnedAgeLink(agevault, "Neighborhood")
@@ -552,11 +552,11 @@ class xLinkingBookGUIPopup(ptModifier):
                 else:
                     self.BuildTreasureLinks(agePanel)
             else:
-                print "setting up spawn points"
+                print("setting up spawn points")
                 self.BuildTreasureLinks(agePanel)
 
-            print SpawnPointTitle_Dict
-            print SpawnPointName_Dict
+            print(SpawnPointTitle_Dict)
+            print(SpawnPointName_Dict)
             
             # start with the first page
             
@@ -629,7 +629,7 @@ class xLinkingBookGUIPopup(ptModifier):
                         PtDebugPrint("xLinkingBookGUIPopup: could not find treasure book page %s's linking panel" % (SpawnPointTitle_Dict[linkID]),level=kErrorLevel)
                     
             if allPagesDef != "":
-                print allPagesDef
+                print(allPagesDef)
                 PtSendKIMessage(kDisableKIandBB,0)
                 gLinkingBook = ptBook(allPagesDef,self.key)
                 gLinkingBook.setSize( width, height )
@@ -711,11 +711,11 @@ class xLinkingBookGUIPopup(ptModifier):
             tmpLink = NodeRef.getChild().upcastToAgeLinkNode()
             if tmpLink:
                 linkAge = tmpLink.getAgeInfo().getAgeFilename()
-                print "BuildCityBook():  linkAge = ",linkAge
+                print("BuildCityBook():  linkAge = ",linkAge)
                 sps = tmpLink.getSpawnPoints()
                 for sp in sps:
-                    print "before, sp title = ",sp.getTitle()
-                    print "before, sp name = ",sp.getName()
+                    print("before, sp title = ",sp.getTitle())
+                    print("before, sp name = ",sp.getName())
 
 #                if linkAge == "city" or linkAge == "Descent":
 #                    spawnPoints.extend(tmpLink.getSpawnPoints())
@@ -734,12 +734,12 @@ class xLinkingBookGUIPopup(ptModifier):
 
         x = xLinkingBookDefs.kFirstLinkPanelID
         for sp in spawnPoints:
-            print "after, sp title = ",sp.getTitle()
-            print "after, sp name = ",sp.getName()
+            print("after, sp title = ",sp.getTitle())
+            print("after, sp name = ",sp.getName())
             if sp.getTitle() in xLinkingBookDefs.CityBookLinks:
                 SpawnPointTitle_Dict[x] = sp.getTitle()
                 if sp.getName() == "p":
-                    print "shouldn't be a 'p' as the spawnpoint name"
+                    print("shouldn't be a 'p' as the spawnpoint name")
                     SpawnPointName_Dict[x] = "LinkInPointDefault"
                 else:
                     SpawnPointName_Dict[x] = sp.getName()
@@ -755,28 +755,28 @@ class xLinkingBookGUIPopup(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print "valCityLinks = ",valCityLinks
+            print("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print "CityLinks = ",CityLinks
+            print("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
                 entryCityLinks.chronicleSetValue(NewLinks)
                 entryCityLinks.save()
-                print "xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel
+                print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
                 valCityLinks = entryCityLinks.chronicleGetValue()
                 CityLinks = valCityLinks.split(",")
-                print "xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks
+                print("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
-                print "xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel
+                print("xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
         else:
             vault.addChronicleEntry("CityBookLinks",0,agePanel)
-            print "xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel
+            print("xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
         
         psnlSDL = xPsnlVaultSDL()
         GotBook = psnlSDL["psnlGotCityBook"][0]
         if not GotBook:
             psnlSDL["psnlGotCityBook"] = (1,)
-            print "xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1"
+            print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1")
 
 
     def IGetCityLinksChron(self):
@@ -785,7 +785,7 @@ class xLinkingBookGUIPopup(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print "xLinkingBookGUIPopup.IGetCityLinksChron(): valCityLinks = ",valCityLinks
+            print("xLinkingBookGUIPopup.IGetCityLinksChron(): valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
         return CityLinks	
 
@@ -829,7 +829,7 @@ class xLinkingBookGUIPopup(ptModifier):
         return 0
 
     def BuildTreasureLinks(self,ageRequested):
-        print "BuildTreasureLinks"
+        print("BuildTreasureLinks")
         global SpawnPointName_Dict
         global SpawnPointTitle_Dict
         global CurrentPage
@@ -896,7 +896,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 SpawnPointName_Dict[page] = spawnPoint.getName()
                 SpawnPointTitle_Dict[page] = spawnPoint.getTitle()
         # if we didn't find the default (original) then put the NotPossible link
-        print "HasFoundOriginalBook = ",HasFoundOriginalBook
+        print("HasFoundOriginalBook = ",HasFoundOriginalBook)
         if not HasFoundOriginalBook:
             if ageRequested == "Neighborhood":
                 PtDebugPrint("\tPage #1: You didn't find the original book, but you're looking at the neighborhood. The first panel shows %s" % (ageRequested))
@@ -964,7 +964,7 @@ class xLinkingBookGUIPopup(ptModifier):
         global gLinkingBook
         global kGrsnTeamBook
         if id == kGrsnTeamBook:
-            print "\nxLinkingBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book."
+            print("\nxLinkingBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book.")
             gLinkingBook.hide()
 
         elif id == kFirstPersonEnable:
@@ -1003,7 +1003,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
 
     def CheckAndRegisterAge(self, ageFileName, ageInstanceName):
-        print "CheckAndRegisterAge for: ",ageFileName,"; ",ageInstanceName
+        print("CheckAndRegisterAge for: ",ageFileName,"; ",ageInstanceName)
         vault = ptVault()
         ageStruct = ptAgeInfoStruct()
         ageStruct.setAgeFilename(ageFileName)
@@ -1033,11 +1033,11 @@ class xLinkingBookGUIPopup(ptModifier):
             link.setAgeInfo(info)
 
             ptVault().registerOwnedAge(link)
-            print "Registered age - ", ageFileName
+            print("Registered age - ", ageFileName)
 
 
     def FindOrCreateGUIDChron(self, ageFileName):
-        print "FindOrCreateGUIDChron for: ",ageFileName
+        print("FindOrCreateGUIDChron for: ",ageFileName)
         GUIDChronFound = 0
         ageDataFolder = None
         
@@ -1059,7 +1059,7 @@ class xLinkingBookGUIPopup(ptModifier):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "PelletCaveGUID":
                             GUIDChronFound = 1
-                            print "found pellet cave GUID: ", chron.getValue()
+                            print("found pellet cave GUID: ", chron.getValue())
                             return
                     #return
 
@@ -1070,27 +1070,27 @@ class xLinkingBookGUIPopup(ptModifier):
         if ageLinkNode:
             ageInfoNode = ageLinkNode.getAgeInfo()
             pelletCaveGUID = ageInfoNode.getAgeInstanceGuid()
-            print "found pelletCaveGUID age chron, = ",pelletCaveGUID
+            print("found pelletCaveGUID age chron, = ",pelletCaveGUID)
         
         if not ageDataFolder:
-            print "no ageDataFolder..."
+            print("no ageDataFolder...")
             ageStruct = ptAgeInfoStruct()
             ageStruct.setAgeFilename(ageFileName)
             ageLinkNode = vault.getOwnedAgeLink(ageStruct)
             if ageLinkNode:
-                print "got ageLinkNode, created AgeData folder"
+                print("got ageLinkNode, created AgeData folder")
                 ageInfoNode = ageLinkNode.getAgeInfo()
                 ageDataFolder = ptVaultFolderNode(0)
                 ageDataFolder.folderSetName("AgeData")
                 ageInfoNode.addNode(ageDataFolder)
 
         if not GUIDChronFound:
-            print "creating PelletCave GUID chron"
+            print("creating PelletCave GUID chron")
             newNode = ptVaultChronicleNode(0)
             newNode.chronicleSetName("PelletCaveGUID")
             newNode.chronicleSetValue(pelletCaveGUID)
             ageDataFolder.addNode(newNode)
-            print "created pelletCaveGUID age chron, = ",pelletCaveGUID
+            print("created pelletCaveGUID age chron, = ",pelletCaveGUID)
 
 
     def OnClickToLinkToPelletCaveFromErcana(self):
@@ -1107,7 +1107,7 @@ class xLinkingBookGUIPopup(ptModifier):
                     ageDataChild = ageDataChildRef.getChild()
                     chron = ageDataChild.upcastToChronicleNode()
                     if chron and chron.getName() == "PelletCaveGUID":
-                        print "Found pellet cave guid - ", chron.getValue()
+                        print("Found pellet cave guid - ", chron.getValue())
                         return chron.getValue()
                     return ""
 
@@ -1129,7 +1129,7 @@ class xLinkingBookGUIPopup(ptModifier):
                         ageDataChild = ageDataChildRef.getChild()
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "PelletCaveGUID":
-                            print "Found pellet cave guid - ", chron.getValue()
+                            print("Found pellet cave guid - ", chron.getValue())
                             return chron.getValue()
                     return ""
 
@@ -1157,7 +1157,7 @@ class xLinkingBookGUIPopup(ptModifier):
         als.setAgeInfo(info)
         als.setSpawnPoint(spawnPoint)
         als.setLinkingRules(PtLinkingRules.kBasicLink)
-        print "-- linking to pellet cave --"
+        print("-- linking to pellet cave --")
         linkMgr = ptNetLinkingMgr()
         linkMgr.linkToAge(als)
 

--- a/Python/xLinkingBookGUIPopup.py
+++ b/Python/xLinkingBookGUIPopup.py
@@ -293,7 +293,7 @@ class xLinkingBookGUIPopup(ptModifier):
                             PtSetOfferBookMode(self.key, self.IGetAgeFilename(), self.IGetAgeInstanceName())
                             PtSetShareSpawnPoint(self.IGetAgeSpawnPoint())
                             if self.IGetAgeFilename() == "PelletBahroCave":
-                                print("using Adam's plasma-magical 'PtSetShareAgeInstanceGuid' with pelletcaveguid = ",pelletCaveGUID)
+                                PtDebugPrint("using Adam's plasma-magical 'PtSetShareAgeInstanceGuid' with pelletcaveguid = ",pelletCaveGUID)
                                 PtSetShareAgeInstanceGuid(pelletCaveGUID)
                             ClosedBookToShare = 1
                             self.HideBook()
@@ -329,7 +329,7 @@ class xLinkingBookGUIPopup(ptModifier):
                                         note.send()
                                     else:
                                         agePanel = TargetAge.value
-                                        #print "agePanel = ",agePanel
+                                        #PtDebugPrint("agePanel = ",agePanel)
                                         if agePanel in xLinkingBookDefs.CityBookLinks:
                                             self.IDoCityLinksChron(agePanel)
                                         respLinkResponder.run(self.key,avatar=PtGetLocalAvatar(),netPropagate=0)
@@ -456,10 +456,10 @@ class xLinkingBookGUIPopup(ptModifier):
             # age panel names are misleading, this is really for the Pellet Cave
             elif agePanel == "BahroCaveUpper":
                 pelletCaveGUID = str(self.OnClickToLinkToPelletCaveFromErcana())
-                print("pelletCaveGUID = ",pelletCaveGUID)
+                PtDebugPrint("pelletCaveGUID = ",pelletCaveGUID)
             elif agePanel == "BahroCaveLower":
                 pelletCaveGUID = str(self.OnClickToLinkToPelletCaveFromAhnonay())
-                print("pelletCaveGUID = ",pelletCaveGUID)
+                PtDebugPrint("pelletCaveGUID = ",pelletCaveGUID)
             try:
                 params = xLinkingBookDefs.xAgeLinkingBooks[agePanel]
                 if len(params) == 6:
@@ -499,7 +499,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
 
     def IShowBookTreasure(self):
-        print("Show the linking book with all its treasure pages")
+        PtDebugPrint("Show the linking book with all its treasure pages")
         global gLinkingBook
         global CurrentPage
         global SpawnPointTitle_Dict
@@ -519,7 +519,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 showOpen = 1  # start the book at the page where they left off
 
         # did we find an agePanel to link with?
-        print("agePanel = ",agePanel)
+        PtDebugPrint("agePanel = ",agePanel)
         if agePanel:
             if agePanel == "Cleft":
                 vault = ptVault()
@@ -535,14 +535,14 @@ class xLinkingBookGUIPopup(ptModifier):
                 SpawnPointName_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'DisabledDesert'}
 
             elif (agePanel == "CleftWithTomahna") and ptVault().amOwnerOfCurrentAge():
-                print("setting up cleft and tomahna spawn points")
+                PtDebugPrint("setting up cleft and tomahna spawn points")
                 SpawnPointTitle_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'Tomahna', xLinkingBookDefs.kFirstLinkPanelID + 1: 'Cleft'}
                 SpawnPointName_Dict = {xLinkingBookDefs.kFirstLinkPanelID: 'SpawnPointTomahna01', xLinkingBookDefs.kFirstLinkPanelID + 1: 'LinkInPointDefault'}
 
             elif agePanel == "city":
                 self.BuildCityBook()
                 agePanel = SpawnPointTitle_Dict[xLinkingBookDefs.kFirstLinkPanelID]
-                print("agePanel2 = ",agePanel)
+                PtDebugPrint("agePanel2 = ",agePanel)
             elif agePanel == "Neighborhood":
                 agevault = ptAgeVault()
                 nblink = self.GetOwnedAgeLink(agevault, "Neighborhood")
@@ -552,11 +552,11 @@ class xLinkingBookGUIPopup(ptModifier):
                 else:
                     self.BuildTreasureLinks(agePanel)
             else:
-                print("setting up spawn points")
+                PtDebugPrint("setting up spawn points")
                 self.BuildTreasureLinks(agePanel)
 
-            print(SpawnPointTitle_Dict)
-            print(SpawnPointName_Dict)
+            PtDebugPrint(SpawnPointTitle_Dict)
+            PtDebugPrint(SpawnPointName_Dict)
             
             # start with the first page
             
@@ -629,7 +629,7 @@ class xLinkingBookGUIPopup(ptModifier):
                         PtDebugPrint("xLinkingBookGUIPopup: could not find treasure book page %s's linking panel" % (SpawnPointTitle_Dict[linkID]),level=kErrorLevel)
                     
             if allPagesDef != "":
-                print(allPagesDef)
+                PtDebugPrint(allPagesDef)
                 PtSendKIMessage(kDisableKIandBB,0)
                 gLinkingBook = ptBook(allPagesDef,self.key)
                 gLinkingBook.setSize( width, height )
@@ -711,11 +711,11 @@ class xLinkingBookGUIPopup(ptModifier):
             tmpLink = NodeRef.getChild().upcastToAgeLinkNode()
             if tmpLink:
                 linkAge = tmpLink.getAgeInfo().getAgeFilename()
-                print("BuildCityBook():  linkAge = ",linkAge)
+                PtDebugPrint("BuildCityBook():  linkAge = ",linkAge)
                 sps = tmpLink.getSpawnPoints()
                 for sp in sps:
-                    print("before, sp title = ",sp.getTitle())
-                    print("before, sp name = ",sp.getName())
+                    PtDebugPrint("before, sp title = ",sp.getTitle())
+                    PtDebugPrint("before, sp name = ",sp.getName())
 
 #                if linkAge == "city" or linkAge == "Descent":
 #                    spawnPoints.extend(tmpLink.getSpawnPoints())
@@ -734,12 +734,12 @@ class xLinkingBookGUIPopup(ptModifier):
 
         x = xLinkingBookDefs.kFirstLinkPanelID
         for sp in spawnPoints:
-            print("after, sp title = ",sp.getTitle())
-            print("after, sp name = ",sp.getName())
+            PtDebugPrint("after, sp title = ",sp.getTitle())
+            PtDebugPrint("after, sp name = ",sp.getName())
             if sp.getTitle() in xLinkingBookDefs.CityBookLinks:
                 SpawnPointTitle_Dict[x] = sp.getTitle()
                 if sp.getName() == "p":
-                    print("shouldn't be a 'p' as the spawnpoint name")
+                    PtDebugPrint("shouldn't be a 'p' as the spawnpoint name")
                     SpawnPointName_Dict[x] = "LinkInPointDefault"
                 else:
                     SpawnPointName_Dict[x] = sp.getName()
@@ -755,28 +755,28 @@ class xLinkingBookGUIPopup(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print("valCityLinks = ",valCityLinks)
+            PtDebugPrint("valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
-            print("CityLinks = ",CityLinks)
+            PtDebugPrint("CityLinks = ",CityLinks)
             if agePanel not in CityLinks:
                 NewLinks = valCityLinks + "," + agePanel
                 entryCityLinks.chronicleSetValue(NewLinks)
                 entryCityLinks.save()
-                print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
+                PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  setting citylinks chron entry to include: ",agePanel)
                 valCityLinks = entryCityLinks.chronicleGetValue()
                 CityLinks = valCityLinks.split(",")
-                print("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
+                PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  citylinks now = ",CityLinks)
             else:
-                print("xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
+                PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  do nothing, citylinks chron already contains: ",agePanel)
         else:
             vault.addChronicleEntry("CityBookLinks",0,agePanel)
-            print("xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
+            PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  creating citylinks chron entry and adding: ",agePanel)
         
         psnlSDL = xPsnlVaultSDL()
         GotBook = psnlSDL["psnlGotCityBook"][0]
         if not GotBook:
             psnlSDL["psnlGotCityBook"] = (1,)
-            print("xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1")
+            PtDebugPrint("xLinkingBookGUIPopup.IDoCityLinksChron():  setting SDL for city book to 1")
 
 
     def IGetCityLinksChron(self):
@@ -785,7 +785,7 @@ class xLinkingBookGUIPopup(ptModifier):
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
         if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
-            print("xLinkingBookGUIPopup.IGetCityLinksChron(): valCityLinks = ",valCityLinks)
+            PtDebugPrint("xLinkingBookGUIPopup.IGetCityLinksChron(): valCityLinks = ",valCityLinks)
             CityLinks = valCityLinks.split(",")
         return CityLinks	
 
@@ -829,7 +829,7 @@ class xLinkingBookGUIPopup(ptModifier):
         return 0
 
     def BuildTreasureLinks(self,ageRequested):
-        print("BuildTreasureLinks")
+        PtDebugPrint("BuildTreasureLinks")
         global SpawnPointName_Dict
         global SpawnPointTitle_Dict
         global CurrentPage
@@ -896,7 +896,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 SpawnPointName_Dict[page] = spawnPoint.getName()
                 SpawnPointTitle_Dict[page] = spawnPoint.getTitle()
         # if we didn't find the default (original) then put the NotPossible link
-        print("HasFoundOriginalBook = ",HasFoundOriginalBook)
+        PtDebugPrint("HasFoundOriginalBook = ",HasFoundOriginalBook)
         if not HasFoundOriginalBook:
             if ageRequested == "Neighborhood":
                 PtDebugPrint("\tPage #1: You didn't find the original book, but you're looking at the neighborhood. The first panel shows %s" % (ageRequested))
@@ -964,7 +964,7 @@ class xLinkingBookGUIPopup(ptModifier):
         global gLinkingBook
         global kGrsnTeamBook
         if id == kGrsnTeamBook:
-            print("\nxLinkingBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book.")
+            PtDebugPrint("\nxLinkingBookGUIPopup.OnTimer:Got timer callback. Removing popup for a grsn team book.")
             gLinkingBook.hide()
 
         elif id == kFirstPersonEnable:
@@ -982,7 +982,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 if not info:
                     continue
                 ageName = info.getAgeFilename()
-                #print "found %s, looking for %s" % (ageName, age)
+                #PtDebugPrint("found %s, looking for %s" % (ageName, age))
                 if ageName == age:
                     return link
 
@@ -1003,7 +1003,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
 
     def CheckAndRegisterAge(self, ageFileName, ageInstanceName):
-        print("CheckAndRegisterAge for: ",ageFileName,"; ",ageInstanceName)
+        PtDebugPrint("CheckAndRegisterAge for: ",ageFileName,"; ",ageInstanceName)
         vault = ptVault()
         ageStruct = ptAgeInfoStruct()
         ageStruct.setAgeFilename(ageFileName)
@@ -1033,11 +1033,11 @@ class xLinkingBookGUIPopup(ptModifier):
             link.setAgeInfo(info)
 
             ptVault().registerOwnedAge(link)
-            print("Registered age - ", ageFileName)
+            PtDebugPrint("Registered age - ", ageFileName)
 
 
     def FindOrCreateGUIDChron(self, ageFileName):
-        print("FindOrCreateGUIDChron for: ",ageFileName)
+        PtDebugPrint("FindOrCreateGUIDChron for: ",ageFileName)
         GUIDChronFound = 0
         ageDataFolder = None
         
@@ -1059,7 +1059,7 @@ class xLinkingBookGUIPopup(ptModifier):
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "PelletCaveGUID":
                             GUIDChronFound = 1
-                            print("found pellet cave GUID: ", chron.getValue())
+                            PtDebugPrint("found pellet cave GUID: ", chron.getValue())
                             return
                     #return
 
@@ -1070,27 +1070,27 @@ class xLinkingBookGUIPopup(ptModifier):
         if ageLinkNode:
             ageInfoNode = ageLinkNode.getAgeInfo()
             pelletCaveGUID = ageInfoNode.getAgeInstanceGuid()
-            print("found pelletCaveGUID age chron, = ",pelletCaveGUID)
+            PtDebugPrint("found pelletCaveGUID age chron, = ",pelletCaveGUID)
         
         if not ageDataFolder:
-            print("no ageDataFolder...")
+            PtDebugPrint("no ageDataFolder...")
             ageStruct = ptAgeInfoStruct()
             ageStruct.setAgeFilename(ageFileName)
             ageLinkNode = vault.getOwnedAgeLink(ageStruct)
             if ageLinkNode:
-                print("got ageLinkNode, created AgeData folder")
+                PtDebugPrint("got ageLinkNode, created AgeData folder")
                 ageInfoNode = ageLinkNode.getAgeInfo()
                 ageDataFolder = ptVaultFolderNode(0)
                 ageDataFolder.folderSetName("AgeData")
                 ageInfoNode.addNode(ageDataFolder)
 
         if not GUIDChronFound:
-            print("creating PelletCave GUID chron")
+            PtDebugPrint("creating PelletCave GUID chron")
             newNode = ptVaultChronicleNode(0)
             newNode.chronicleSetName("PelletCaveGUID")
             newNode.chronicleSetValue(pelletCaveGUID)
             ageDataFolder.addNode(newNode)
-            print("created pelletCaveGUID age chron, = ",pelletCaveGUID)
+            PtDebugPrint("created pelletCaveGUID age chron, = ",pelletCaveGUID)
 
 
     def OnClickToLinkToPelletCaveFromErcana(self):
@@ -1107,7 +1107,7 @@ class xLinkingBookGUIPopup(ptModifier):
                     ageDataChild = ageDataChildRef.getChild()
                     chron = ageDataChild.upcastToChronicleNode()
                     if chron and chron.getName() == "PelletCaveGUID":
-                        print("Found pellet cave guid - ", chron.getValue())
+                        PtDebugPrint("Found pellet cave guid - ", chron.getValue())
                         return chron.getValue()
                     return ""
 
@@ -1129,7 +1129,7 @@ class xLinkingBookGUIPopup(ptModifier):
                         ageDataChild = ageDataChildRef.getChild()
                         chron = ageDataChild.upcastToChronicleNode()
                         if chron and chron.getName() == "PelletCaveGUID":
-                            print("Found pellet cave guid - ", chron.getValue())
+                            PtDebugPrint("Found pellet cave guid - ", chron.getValue())
                             return chron.getValue()
                     return ""
 
@@ -1157,7 +1157,7 @@ class xLinkingBookGUIPopup(ptModifier):
         als.setAgeInfo(info)
         als.setSpawnPoint(spawnPoint)
         als.setLinkingRules(PtLinkingRules.kBasicLink)
-        print("-- linking to pellet cave --")
+        PtDebugPrint("-- linking to pellet cave --")
         linkMgr = ptNetLinkingMgr()
         linkMgr.linkToAge(als)
 

--- a/Python/xMusicBox.py
+++ b/Python/xMusicBox.py
@@ -169,7 +169,7 @@ class xMusicBox(ptModifier):
             sdlvarisvalid = sdlCurrentSongVar.value
 
             if islocalavatar and sdlvarisvalid:
-                print("Setting cur song var to: ", currentSong)
+                PtDebugPrint("Setting cur song var to: ", currentSong)
                 ageSDL = PtGetAgeSDL()
                 ageSDL[sdlCurrentSongVar.value] = currentSong
                 

--- a/Python/xMusicBox.py
+++ b/Python/xMusicBox.py
@@ -169,7 +169,7 @@ class xMusicBox(ptModifier):
             sdlvarisvalid = sdlCurrentSongVar.value
 
             if islocalavatar and sdlvarisvalid:
-                print "Setting cur song var to: ", currentSong
+                print("Setting cur song var to: ", currentSong)
                 ageSDL = PtGetAgeSDL()
                 ageSDL[sdlCurrentSongVar.value] = currentSong
                 

--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -523,7 +523,7 @@ class xOptionsMenu(ptModifier):
         PtDebugPrint("xOptionsMenu: Notify  state=%f, id=%d" % (state,id),level=kDebugDumpLevel)
 
         if id == -1:
-            print "Options Menu got notify, resetting First Visit status"
+            print("Options Menu got notify, resetting First Visit status")
             gFirstReltoVisit = True
             return
 
@@ -579,16 +579,16 @@ class xOptionsMenu(ptModifier):
                 if omID == kOptionsNavigationBtn:
                     OptionsMenuDlg.dialog.hide()
                     NavigationDlg.dialog.show()
-                    print "The Navigation dialog should show now..."
+                    print("The Navigation dialog should show now...")
                 elif omID == kOptionsGraphicSettingsBtn:
                     OptionsMenuDlg.dialog.hide()
                     GraphicsSettingsDlg.dialog.show()
-                    print "The graphics dialog should show now..."
+                    print("The graphics dialog should show now...")
                 elif omID == kOptionsAudioSettingsBtn:
                     self.InitAudioControlsGUI()
                     OptionsMenuDlg.dialog.hide()
                     AudioSettingsDlg.dialog.show()
-                    print "The audio dialog should show now..."
+                    print("The audio dialog should show now...")
                 elif omID == kOptionsKeyMapBtn:
                     OptionsMenuDlg.dialog.hide()
                     KeyMapDlg.dialog.show()
@@ -650,7 +650,7 @@ class xOptionsMenu(ptModifier):
                     gCurrentReleaseNotes = f.read()
                     f.close()
                 except:
-                    print "[TXT processing] Error while reading ReleaseNotes.txt"
+                    print("[TXT processing] Error while reading ReleaseNotes.txt")
             elif event == kShowHide:
                 if control.isEnabled():
                     # buttons localized
@@ -662,7 +662,7 @@ class xOptionsMenu(ptModifier):
                     textField = ptGUIControlMultiLineEdit(ReleaseNotesDlg.dialog.getControlFromTag(kReleaseTextArea))
                     textField.clearBuffer()
                     textField.insertString(gCurrentReleaseNotes)
-                    print textField.getString()
+                    print(textField.getString())
                     textField.setScrollPosition(1)
                     textField.setScrollPosition(0)
             elif event == kAction or event == kValueChanged:
@@ -822,7 +822,7 @@ class xOptionsMenu(ptModifier):
             global gClickToTurn
 
             if event == kDialogLoaded:
-                print "Yes, the Advanced Settings dialog loaded."
+                print("Yes, the Advanced Settings dialog loaded.")
             elif event == kShowHide:
                 if control.isEnabled():
                     self.IRefreshAdvSettings()
@@ -853,7 +853,7 @@ class xOptionsMenu(ptModifier):
 
             elif event == kAction or event == kValueChanged:
                 gsID = control.getTagID()
-                print "gsID = " + str(gsID)
+                print("gsID = " + str(gsID))
 
                 if gsID == kOptionsKeyMapBtn:
                     self.setNewChronicleVar("AdvSettings", (gMouseSensitivity + " " + gSmoothCam + " " + gMouseInvert + " " + gWalkAndPan + " " + gStayInFirstPerson + " " + gClickToTurn))
@@ -992,21 +992,21 @@ class xOptionsMenu(ptModifier):
 ###############################################
         elif id == ResetWarnDlg.id:
             if event == kDialogLoaded:
-                print "Yes, the ResetWarn Dialog loaded."
+                print("Yes, the ResetWarn Dialog loaded.")
                 pass
             elif event == kShowHide:
-                print "event = kShowHide = ", kShowHide
+                print("event = kShowHide = ", kShowHide)
                 pass                
             elif event == kAction or event == kValueChanged:
                 # test to see which control had the event
                 warnID = control.getTagID()
-                print "warnID = ",warnID
+                print("warnID = ",warnID)
                 if warnID == kResetWarningYes:
-                    print "I need to shut down Plasma now."
+                    print("I need to shut down Plasma now.")
                     self.WriteVideoControls()
                     PtConsole("App.Quit")
                 elif warnID == kResetWarningNo:
-                    print "close the dialog now."
+                    print("close the dialog now.")
                     ResetWarnDlg.dialog.hide()
                     if self.goingToCalibration:
                         PtLoadDialog("CalibrationGUI",self.key)
@@ -1024,7 +1024,7 @@ class xOptionsMenu(ptModifier):
             #~ print "navigation event = ", event
             #~ print "kShowHide = ",kShowHide, " kAction = ",kAction, " kValueChanged = ", kValueChanged
             if event == kDialogLoaded:
-                print "Yes, the Navigation dialog loaded."
+                print("Yes, the Navigation dialog loaded.")
                 pass
 
             elif event == kShowHide:
@@ -1042,7 +1042,7 @@ class xOptionsMenu(ptModifier):
 
             elif event == kAction or event == kValueChanged:
                 NavigationID = control.getTagID()
-                print "NavigationID = ", NavigationID                
+                print("NavigationID = ", NavigationID)                
                 if NavigationID == kKMOkBtn:
                     NavigationDlg.dialog.hide()
                 elif NavigationID == kKMGoBackBtn:
@@ -1053,7 +1053,7 @@ class xOptionsMenu(ptModifier):
                     AdvGameSettingDlg.dialog.show()
                 elif NavigationID == kNormNoviceRGID:
                     if control.getValue():
-                        print "CTT on"
+                        print("CTT on")
                         PtSetClickToTurn(1)
                         gClickToTurn = "1"
                         AdvSettingsString = self.getChronicleVar("AdvSettings")
@@ -1064,7 +1064,7 @@ class xOptionsMenu(ptModifier):
                         else:
                             self.setNewChronicleVar("AdvSettings", (AdvSettingsString[0:-1] + "1"))
                     else:
-                        print "CTT off"
+                        print("CTT off")
                         PtSetClickToTurn(0)
                         gClickToTurn = "0"
                         AdvSettingsString = self.getChronicleVar("AdvSettings")
@@ -1103,7 +1103,7 @@ class xOptionsMenu(ptModifier):
                     tagID = 0
                     
                 if tagID in [kKMOkBtn, kKMGoBackBtn, kOptionsCalibrationBtn]:
-                    print "self.restartWarn =", self.restartWarn
+                    print("self.restartWarn =", self.restartWarn)
                     if self.restartWarn:
                         GraphicsSettingsDlg.dialog.hide()
                         ResetWarnDlg.dialog.show()
@@ -1208,7 +1208,7 @@ class xOptionsMenu(ptModifier):
                     
         elif id == AudioSettingsDlg.id:
             if event == kDialogLoaded:
-                print "Yes, the Audio dialog loaded."
+                print("Yes, the Audio dialog loaded.")
                 
             elif event == kShowHide:
                 # reset the edit text lines
@@ -1322,18 +1322,18 @@ class xOptionsMenu(ptModifier):
                         audioModeCtrlTextBox.setString(audioDeviceName)
 
                     if audioDeviceName != prevAudioDeviceName:  #Only update the EAX checkbox when the mouse has been let up...
-                        print "Audio Device Name changed!"
+                        print("Audio Device Name changed!")
                         prevAudioDeviceName = audioDeviceName
                         EAXcheckbox = ptGUIControlCheckBox(AudioSettingsDlg.dialog.getControlFromTag(kAudioModeCBID03))
                         if not audio.supportsEAX(audioDeviceName):
-                            print "Disabling EAX checkbox"
+                            print("Disabling EAX checkbox")
                             #Disable EAX checkbox
                             EAXcheckbox.disable()
                             respDisableItems.run(self.key, state="disableEAX")
                             EAXcheckbox.setChecked(False)
                             ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kAudioModeEAXTextID)).setForeColor(ptColor(0.839, 0.785, 0.695, 1))
                         else:
-                            print "Enabling EAX checkbox"
+                            print("Enabling EAX checkbox")
                             #We don't need to automatically check the EAX box, but do enable the control
                             EAXcheckbox.enable()
                             respDisableItems.run(self.key, state="enableEAX")
@@ -1634,7 +1634,7 @@ class xOptionsMenu(ptModifier):
 
         if setMode:
             PtSetGraphicsOptions(width, height, colordepth, windowed == "true", antialias, aniso, vsync)
-            print "SETTING GAMMA"
+            print("SETTING GAMMA")
             PtSetGamma2(gamma)
             PtSetShadowVisDistance(shadow_quality)
 
@@ -1746,18 +1746,18 @@ class xOptionsMenu(ptModifier):
         if entry is None:
             # not found... add current level chronicle
             vault.addChronicleEntry(chronicleVar,kChronicleVarType,str(value))
-            print "%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar)
+            print("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
         else:
             entry.chronicleSetValue(str(value))
             entry.save()
-            print "%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue())
+            print("%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue()))
 
     def getChronicleVar(self, chronicleVar):
         kModuleName = "Personal"
         kChronicleVarType = 0
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleVar)
-        print "getChronicleVar.chronicleVar: " + chronicleVar
+        print("getChronicleVar.chronicleVar: " + chronicleVar)
         #print "getChronicleVar.Entry: " , entry
         if entry is None:
             # not found... add current level chronicle
@@ -1766,7 +1766,7 @@ class xOptionsMenu(ptModifier):
             return None
         else:
             value = entry.chronicleGetValue()
-            print "getChronicleVar(): " + chronicleVar + " = " + value
+            print("getChronicleVar(): " + chronicleVar + " = " + value)
             return value
         
     def IRefreshHelpSettings(self):
@@ -1789,7 +1789,7 @@ class xOptionsMenu(ptModifier):
         #~ soundPriKnob.setValue(audio.getPriorityCutoff()*(11.0/10.0))
         
         mouseSensKnob = ptGUIControlValue(AdvGameSettingDlg.dialog.getControlFromTag(kGSMouseTurnSensSlider))
-        print "IRefreshAdvSettings: PtGetMouseTurnSensitivity() = %d" % (PtGetMouseTurnSensitivity())
+        print("IRefreshAdvSettings: PtGetMouseTurnSensitivity() = %d" % (PtGetMouseTurnSensitivity()))
         sensitive = PtGetMouseTurnSensitivity() - 50.0
         if sensitive <= 0.0:
             mouseSensKnob.setValue(0.0)
@@ -1876,14 +1876,14 @@ class xOptionsMenu(ptModifier):
         for control_code in defaultControlCodeBindsOrdered:
             if isinstance(control_code, str):
                 key1 = KeyMapArray[counter]
-                print "Binding " + key1 + " to " + control_code
+                print("Binding " + key1 + " to " + control_code)
                 km.bindKeyToConsoleCommand(key1,control_code)
             else:
                 controlStr = km.convertControlCodeToString(control_code)
                 SubArray = KeyMapArray[counter].split("$")
                 key1 = SubArray[0]
                 key2 = SubArray[1]
-                print "Binding " + key1 + " & " + key2 + " to " + controlStr
+                print("Binding " + key1 + " & " + key2 + " to " + controlStr)
                 km.bindKey(key1,key2,controlStr)
             counter += 1
 

--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -523,7 +523,7 @@ class xOptionsMenu(ptModifier):
         PtDebugPrint("xOptionsMenu: Notify  state=%f, id=%d" % (state,id),level=kDebugDumpLevel)
 
         if id == -1:
-            print("Options Menu got notify, resetting First Visit status")
+            PtDebugPrint("Options Menu got notify, resetting First Visit status")
             gFirstReltoVisit = True
             return
 
@@ -579,16 +579,16 @@ class xOptionsMenu(ptModifier):
                 if omID == kOptionsNavigationBtn:
                     OptionsMenuDlg.dialog.hide()
                     NavigationDlg.dialog.show()
-                    print("The Navigation dialog should show now...")
+                    PtDebugPrint("The Navigation dialog should show now...")
                 elif omID == kOptionsGraphicSettingsBtn:
                     OptionsMenuDlg.dialog.hide()
                     GraphicsSettingsDlg.dialog.show()
-                    print("The graphics dialog should show now...")
+                    PtDebugPrint("The graphics dialog should show now...")
                 elif omID == kOptionsAudioSettingsBtn:
                     self.InitAudioControlsGUI()
                     OptionsMenuDlg.dialog.hide()
                     AudioSettingsDlg.dialog.show()
-                    print("The audio dialog should show now...")
+                    PtDebugPrint("The audio dialog should show now...")
                 elif omID == kOptionsKeyMapBtn:
                     OptionsMenuDlg.dialog.hide()
                     KeyMapDlg.dialog.show()
@@ -650,7 +650,7 @@ class xOptionsMenu(ptModifier):
                     gCurrentReleaseNotes = f.read()
                     f.close()
                 except:
-                    print("[TXT processing] Error while reading ReleaseNotes.txt")
+                    PtDebugPrint("[TXT processing] Error while reading ReleaseNotes.txt")
             elif event == kShowHide:
                 if control.isEnabled():
                     # buttons localized
@@ -662,7 +662,7 @@ class xOptionsMenu(ptModifier):
                     textField = ptGUIControlMultiLineEdit(ReleaseNotesDlg.dialog.getControlFromTag(kReleaseTextArea))
                     textField.clearBuffer()
                     textField.insertString(gCurrentReleaseNotes)
-                    print(textField.getString())
+                    PtDebugPrint(textField.getString())
                     textField.setScrollPosition(1)
                     textField.setScrollPosition(0)
             elif event == kAction or event == kValueChanged:
@@ -822,7 +822,7 @@ class xOptionsMenu(ptModifier):
             global gClickToTurn
 
             if event == kDialogLoaded:
-                print("Yes, the Advanced Settings dialog loaded.")
+                PtDebugPrint("Yes, the Advanced Settings dialog loaded.")
             elif event == kShowHide:
                 if control.isEnabled():
                     self.IRefreshAdvSettings()
@@ -853,7 +853,7 @@ class xOptionsMenu(ptModifier):
 
             elif event == kAction or event == kValueChanged:
                 gsID = control.getTagID()
-                print("gsID = " + str(gsID))
+                PtDebugPrint("gsID = " + str(gsID))
 
                 if gsID == kOptionsKeyMapBtn:
                     self.setNewChronicleVar("AdvSettings", (gMouseSensitivity + " " + gSmoothCam + " " + gMouseInvert + " " + gWalkAndPan + " " + gStayInFirstPerson + " " + gClickToTurn))
@@ -992,21 +992,21 @@ class xOptionsMenu(ptModifier):
 ###############################################
         elif id == ResetWarnDlg.id:
             if event == kDialogLoaded:
-                print("Yes, the ResetWarn Dialog loaded.")
+                PtDebugPrint("Yes, the ResetWarn Dialog loaded.")
                 pass
             elif event == kShowHide:
-                print("event = kShowHide = ", kShowHide)
+                PtDebugPrint("event = kShowHide = ", kShowHide)
                 pass                
             elif event == kAction or event == kValueChanged:
                 # test to see which control had the event
                 warnID = control.getTagID()
-                print("warnID = ",warnID)
+                PtDebugPrint("warnID = ",warnID)
                 if warnID == kResetWarningYes:
-                    print("I need to shut down Plasma now.")
+                    PtDebugPrint("I need to shut down Plasma now.")
                     self.WriteVideoControls()
                     PtConsole("App.Quit")
                 elif warnID == kResetWarningNo:
-                    print("close the dialog now.")
+                    PtDebugPrint("close the dialog now.")
                     ResetWarnDlg.dialog.hide()
                     if self.goingToCalibration:
                         PtLoadDialog("CalibrationGUI",self.key)
@@ -1021,10 +1021,10 @@ class xOptionsMenu(ptModifier):
 ##
 ###############################################
         elif id == NavigationDlg.id:
-            #~ print "navigation event = ", event
-            #~ print "kShowHide = ",kShowHide, " kAction = ",kAction, " kValueChanged = ", kValueChanged
+            #~ PtDebugPrint("navigation event = ", event)
+            #~ PtDebugPrint("kShowHide = ",kShowHide, " kAction = ",kAction, " kValueChanged = ", kValueChanged)
             if event == kDialogLoaded:
-                print("Yes, the Navigation dialog loaded.")
+                PtDebugPrint("Yes, the Navigation dialog loaded.")
                 pass
 
             elif event == kShowHide:
@@ -1042,7 +1042,7 @@ class xOptionsMenu(ptModifier):
 
             elif event == kAction or event == kValueChanged:
                 NavigationID = control.getTagID()
-                print("NavigationID = ", NavigationID)                
+                PtDebugPrint("NavigationID = ", NavigationID)                
                 if NavigationID == kKMOkBtn:
                     NavigationDlg.dialog.hide()
                 elif NavigationID == kKMGoBackBtn:
@@ -1053,7 +1053,7 @@ class xOptionsMenu(ptModifier):
                     AdvGameSettingDlg.dialog.show()
                 elif NavigationID == kNormNoviceRGID:
                     if control.getValue():
-                        print("CTT on")
+                        PtDebugPrint("CTT on")
                         PtSetClickToTurn(1)
                         gClickToTurn = "1"
                         AdvSettingsString = self.getChronicleVar("AdvSettings")
@@ -1064,7 +1064,7 @@ class xOptionsMenu(ptModifier):
                         else:
                             self.setNewChronicleVar("AdvSettings", (AdvSettingsString[0:-1] + "1"))
                     else:
-                        print("CTT off")
+                        PtDebugPrint("CTT off")
                         PtSetClickToTurn(0)
                         gClickToTurn = "0"
                         AdvSettingsString = self.getChronicleVar("AdvSettings")
@@ -1103,7 +1103,7 @@ class xOptionsMenu(ptModifier):
                     tagID = 0
                     
                 if tagID in [kKMOkBtn, kKMGoBackBtn, kOptionsCalibrationBtn]:
-                    print("self.restartWarn =", self.restartWarn)
+                    PtDebugPrint("self.restartWarn =", self.restartWarn)
                     if self.restartWarn:
                         GraphicsSettingsDlg.dialog.hide()
                         ResetWarnDlg.dialog.show()
@@ -1208,7 +1208,7 @@ class xOptionsMenu(ptModifier):
                     
         elif id == AudioSettingsDlg.id:
             if event == kDialogLoaded:
-                print("Yes, the Audio dialog loaded.")
+                PtDebugPrint("Yes, the Audio dialog loaded.")
                 
             elif event == kShowHide:
                 # reset the edit text lines
@@ -1308,7 +1308,7 @@ class xOptionsMenu(ptModifier):
                 elif tagID == kAudioModeID:
                     self.restartAudio = 1
                     audio = ptAudioControl()
-                    #~ print "Number of Audio Devices: %d" % (audio.getNumAudioDevices())
+                    #~ PtDebugPrint("Number of Audio Devices: %d" % (audio.getNumAudioDevices()))
                     audModeNum = audio.getNumAudioDevices() - 1
                     curSelection = round(control.getValue() * audModeNum)
                     intCurSelection = int(curSelection)
@@ -1322,18 +1322,18 @@ class xOptionsMenu(ptModifier):
                         audioModeCtrlTextBox.setString(audioDeviceName)
 
                     if audioDeviceName != prevAudioDeviceName:  #Only update the EAX checkbox when the mouse has been let up...
-                        print("Audio Device Name changed!")
+                        PtDebugPrint("Audio Device Name changed!")
                         prevAudioDeviceName = audioDeviceName
                         EAXcheckbox = ptGUIControlCheckBox(AudioSettingsDlg.dialog.getControlFromTag(kAudioModeCBID03))
                         if not audio.supportsEAX(audioDeviceName):
-                            print("Disabling EAX checkbox")
+                            PtDebugPrint("Disabling EAX checkbox")
                             #Disable EAX checkbox
                             EAXcheckbox.disable()
                             respDisableItems.run(self.key, state="disableEAX")
                             EAXcheckbox.setChecked(False)
                             ptGUIControlTextBox(AudioSettingsDlg.dialog.getControlFromTag(kAudioModeEAXTextID)).setForeColor(ptColor(0.839, 0.785, 0.695, 1))
                         else:
-                            print("Enabling EAX checkbox")
+                            PtDebugPrint("Enabling EAX checkbox")
                             #We don't need to automatically check the EAX box, but do enable the control
                             EAXcheckbox.enable()
                             respDisableItems.run(self.key, state="enableEAX")
@@ -1634,7 +1634,7 @@ class xOptionsMenu(ptModifier):
 
         if setMode:
             PtSetGraphicsOptions(width, height, colordepth, windowed == "true", antialias, aniso, vsync)
-            print("SETTING GAMMA")
+            PtDebugPrint("SETTING GAMMA")
             PtSetGamma2(gamma)
             PtSetShadowVisDistance(shadow_quality)
 
@@ -1746,19 +1746,19 @@ class xOptionsMenu(ptModifier):
         if entry is None:
             # not found... add current level chronicle
             vault.addChronicleEntry(chronicleVar,kChronicleVarType,str(value))
-            print("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
+            PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
         else:
             entry.chronicleSetValue(str(value))
             entry.save()
-            print("%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue()))
+            PtDebugPrint("%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue()))
 
     def getChronicleVar(self, chronicleVar):
         kModuleName = "Personal"
         kChronicleVarType = 0
         vault = ptVault()
         entry = vault.findChronicleEntry(chronicleVar)
-        print("getChronicleVar.chronicleVar: " + chronicleVar)
-        #print "getChronicleVar.Entry: " , entry
+        PtDebugPrint("getChronicleVar.chronicleVar: " + chronicleVar)
+        #PtDebugPrint("getChronicleVar.Entry: " , entry)
         if entry is None:
             # not found... add current level chronicle
             #vault.addChronicleEntry(chronicleVar,kChronicleVarType,"%d" %(0))
@@ -1766,7 +1766,7 @@ class xOptionsMenu(ptModifier):
             return None
         else:
             value = entry.chronicleGetValue()
-            print("getChronicleVar(): " + chronicleVar + " = " + value)
+            PtDebugPrint("getChronicleVar(): " + chronicleVar + " = " + value)
             return value
         
     def IRefreshHelpSettings(self):
@@ -1789,7 +1789,7 @@ class xOptionsMenu(ptModifier):
         #~ soundPriKnob.setValue(audio.getPriorityCutoff()*(11.0/10.0))
         
         mouseSensKnob = ptGUIControlValue(AdvGameSettingDlg.dialog.getControlFromTag(kGSMouseTurnSensSlider))
-        print("IRefreshAdvSettings: PtGetMouseTurnSensitivity() = %d" % (PtGetMouseTurnSensitivity()))
+        PtDebugPrint("IRefreshAdvSettings: PtGetMouseTurnSensitivity() = %d" % (PtGetMouseTurnSensitivity()))
         sensitive = PtGetMouseTurnSensitivity() - 50.0
         if sensitive <= 0.0:
             mouseSensKnob.setValue(0.0)
@@ -1876,14 +1876,14 @@ class xOptionsMenu(ptModifier):
         for control_code in defaultControlCodeBindsOrdered:
             if isinstance(control_code, str):
                 key1 = KeyMapArray[counter]
-                print("Binding " + key1 + " to " + control_code)
+                PtDebugPrint("Binding " + key1 + " to " + control_code)
                 km.bindKeyToConsoleCommand(key1,control_code)
             else:
                 controlStr = km.convertControlCodeToString(control_code)
                 SubArray = KeyMapArray[counter].split("$")
                 key1 = SubArray[0]
                 key2 = SubArray[1]
-                print("Binding " + key1 + " & " + key2 + " to " + controlStr)
+                PtDebugPrint("Binding " + key1 + " & " + key2 + " to " + controlStr)
                 km.bindKey(key1,key2,controlStr)
             counter += 1
 

--- a/Python/xPassiveIndicatorLight.py
+++ b/Python/xPassiveIndicatorLight.py
@@ -69,11 +69,11 @@ class xPassiveIndicatorLight(ptResponder):
         
         version = 2
         self.version = version
-        print "__init__xPassiveIndicatorLight v.", version
+        print("__init__xPassiveIndicatorLight v.", version)
 
     def OnServerInitComoplete(self):
         if self.SDL == None:
-            print "xPassiveIndicatorLight.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value
+            print("xPassiveIndicatorLight.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
             return
         self.SDL.setDefault("enabled",(0,))
 
@@ -92,9 +92,9 @@ class xPassiveIndicatorLight(ptResponder):
                             respOff.run(self.key,events=events)
 
                         else: #unexpected value 
-                            print "xPassiveIndicatorLight.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0])
+                            print("xPassiveIndicatorLight.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
                             return
-                        print "xPassiveIndicatorLight.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0])
+                        print("xPassiveIndicatorLight.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
 
 
 

--- a/Python/xPassiveIndicatorLight.py
+++ b/Python/xPassiveIndicatorLight.py
@@ -69,11 +69,11 @@ class xPassiveIndicatorLight(ptResponder):
         
         version = 2
         self.version = version
-        print("__init__xPassiveIndicatorLight v.", version)
+        PtDebugPrint("__init__xPassiveIndicatorLight v.", version)
 
     def OnServerInitComoplete(self):
         if self.SDL == None:
-            print("xPassiveIndicatorLight.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
+            PtDebugPrint("xPassiveIndicatorLight.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
             return
         self.SDL.setDefault("enabled",(0,))
 
@@ -92,9 +92,9 @@ class xPassiveIndicatorLight(ptResponder):
                             respOff.run(self.key,events=events)
 
                         else: #unexpected value 
-                            print("xPassiveIndicatorLight.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
+                            PtDebugPrint("xPassiveIndicatorLight.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
                             return
-                        print("xPassiveIndicatorLight.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
+                        PtDebugPrint("xPassiveIndicatorLight.OnNotify:\t'%s' got msg - power = %d" % (varstring.value,self.SDL["enabled"][0]))
 
 
 

--- a/Python/xPodBahroSymbol.py
+++ b/Python/xPodBahroSymbol.py
@@ -83,7 +83,7 @@ class xPodBahroSymbol(ptResponder):
         self.id = 5240
         version = 1
         self.version = version
-        print("__init__xPodBahroSymbol v.", version,".0")
+        PtDebugPrint("__init__xPodBahroSymbol v.", version,".0")
         random.seed()
 
     ###########################
@@ -93,21 +93,21 @@ class xPodBahroSymbol(ptResponder):
 
         if animMasterDayLight.value is not None:        
             timeIntoMasterAnim = PtGetAgeTimeOfDayPercent() * (DayFrameSize.value / 30.0)
-            print("xPodBahroSymbol.OnServerInitComplete: Master anim is skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed))
+            PtDebugPrint("xPodBahroSymbol.OnServerInitComplete: Master anim is skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed))
             animMasterDayLight.animation.skipToTime(timeIntoMasterAnim)
             animMasterDayLight.animation.speed(kDayAnimationSpeed)
             animMasterDayLight.animation.resume()
 
     ###########################
     def OnNotify(self,state,id,events):
-        print("xPodBahroSymbol.OnNotify:  state=%f id=%d events=" % (state,id),events)
+        PtDebugPrint("xPodBahroSymbol.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if id == respBahroSymbol.id:
             PtAtTimeCallback(self.key, 32, 3)
 
     ###########################
     def OnTimer(self,TimerID):
-        print("xPodBahroSymbol.OnTimer: callback id=%d" % (TimerID))
+        PtDebugPrint("xPodBahroSymbol.OnTimer: callback id=%d" % (TimerID))
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
                 respBahroSymbol.run(self.key, state="beginning")
@@ -126,20 +126,20 @@ class xPodBahroSymbol(ptResponder):
         if timeWhenSymbolAppearsToday > PtGetDniTime():
             timeTillSymbolAppears = timeWhenSymbolAppearsToday - PtGetDniTime()
             PtAtTimeCallback(self.key, timeTillSymbolAppears, 1)
-            print("xGlobalDoor.key: %d%s" % (random.randint(0,100), hex(int(timeTillSymbolAppears + 1234))))
+            PtDebugPrint("xGlobalDoor.key: %d%s" % (random.randint(0,100), hex(int(timeTillSymbolAppears + 1234))))
         else:
-            print("xPodBahroSymbol: You missed the symbol for today.")
+            PtDebugPrint("xPodBahroSymbol: You missed the symbol for today.")
 
         timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
         timeLeftToday += 1 # because we want it to go off right AFTER the day flips
         PtAtTimeCallback(self.key, timeLeftToday, 2)
-        print("xPodBahroSymbol: Tomorrow starts in %d seconds" % (timeLeftToday))
+        PtDebugPrint("xPodBahroSymbol: Tomorrow starts in %d seconds" % (timeLeftToday))
 
     ###########################
     def OnBackdoorMsg(self, target, param):
         if target == "bahro":
             if self.sceneobject.isLocallyOwned():
-                print("xPodBahroSymbol.OnBackdoorMsg: Work!")
+                PtDebugPrint("xPodBahroSymbol.OnBackdoorMsg: Work!")
                 if param == "appear":
                     PtAtTimeCallback(self.key, 1, 1)
 

--- a/Python/xPodBahroSymbol.py
+++ b/Python/xPodBahroSymbol.py
@@ -83,7 +83,7 @@ class xPodBahroSymbol(ptResponder):
         self.id = 5240
         version = 1
         self.version = version
-        print "__init__xPodBahroSymbol v.", version,".0"
+        print("__init__xPodBahroSymbol v.", version,".0")
         random.seed()
 
     ###########################
@@ -93,21 +93,21 @@ class xPodBahroSymbol(ptResponder):
 
         if animMasterDayLight.value is not None:        
             timeIntoMasterAnim = PtGetAgeTimeOfDayPercent() * (DayFrameSize.value / 30.0)
-            print "xPodBahroSymbol.OnServerInitComplete: Master anim is skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed)
+            print("xPodBahroSymbol.OnServerInitComplete: Master anim is skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed))
             animMasterDayLight.animation.skipToTime(timeIntoMasterAnim)
             animMasterDayLight.animation.speed(kDayAnimationSpeed)
             animMasterDayLight.animation.resume()
 
     ###########################
     def OnNotify(self,state,id,events):
-        print "xPodBahroSymbol.OnNotify:  state=%f id=%d events=" % (state,id),events
+        print("xPodBahroSymbol.OnNotify:  state=%f id=%d events=" % (state,id),events)
 
         if id == respBahroSymbol.id:
             PtAtTimeCallback(self.key, 32, 3)
 
     ###########################
     def OnTimer(self,TimerID):
-        print "xPodBahroSymbol.OnTimer: callback id=%d" % (TimerID)
+        print("xPodBahroSymbol.OnTimer: callback id=%d" % (TimerID))
         if self.sceneobject.isLocallyOwned():
             if TimerID == 1:
                 respBahroSymbol.run(self.key, state="beginning")
@@ -126,20 +126,20 @@ class xPodBahroSymbol(ptResponder):
         if timeWhenSymbolAppearsToday > PtGetDniTime():
             timeTillSymbolAppears = timeWhenSymbolAppearsToday - PtGetDniTime()
             PtAtTimeCallback(self.key, timeTillSymbolAppears, 1)
-            print "xGlobalDoor.key: %d%s" % (random.randint(0,100), hex(int(timeTillSymbolAppears + 1234)))
+            print("xGlobalDoor.key: %d%s" % (random.randint(0,100), hex(int(timeTillSymbolAppears + 1234))))
         else:
-            print "xPodBahroSymbol: You missed the symbol for today."
+            print("xPodBahroSymbol: You missed the symbol for today.")
 
         timeLeftToday = kDayLengthInSeconds - int(PtGetAgeTimeOfDayPercent() * kDayLengthInSeconds)
         timeLeftToday += 1 # because we want it to go off right AFTER the day flips
         PtAtTimeCallback(self.key, timeLeftToday, 2)
-        print "xPodBahroSymbol: Tomorrow starts in %d seconds" % (timeLeftToday)
+        print("xPodBahroSymbol: Tomorrow starts in %d seconds" % (timeLeftToday))
 
     ###########################
     def OnBackdoorMsg(self, target, param):
         if target == "bahro":
             if self.sceneobject.isLocallyOwned():
-                print "xPodBahroSymbol.OnBackdoorMsg: Work!"
+                print("xPodBahroSymbol.OnBackdoorMsg: Work!")
                 if param == "appear":
                     PtAtTimeCallback(self.key, 1, 1)
 

--- a/Python/xPodBattery.py
+++ b/Python/xPodBattery.py
@@ -123,14 +123,14 @@ class xPodBattery(ptResponder):
         self.id = 5242
         version = 5
         self.version = version
-        print "__init__xPodBattery v.", version
+        print("__init__xPodBattery v.", version)
 
     ###########################
     def OnServerInitComplete(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print "xPodBattery:\tERROR---Cannot find the Negilahn Age SDL"
+            print("xPodBattery:\tERROR---Cannot find the Negilahn Age SDL")
             ageSDL[SDLBatteryCharge.value] = (100, ) 
             ageSDL[SDLBatteryCapacity.value] = (100, ) 
             ageSDL[SDLBatteryLastUpdated.value] = (0,)
@@ -199,13 +199,13 @@ class xPodBattery(ptResponder):
         #if ageSDL[SDLSpotlight03.value][0]:
         #    respSpotlight03.run(self.key, state="1", fastforward=1)
 
-        print "xPodBattery: The Pod Battery has %s of a possible %s units." % (BatteryCharge, BatteryCapacity)
+        print("xPodBattery: The Pod Battery has %s of a possible %s units." % (BatteryCharge, BatteryCapacity))
         CurrentTime = PtGetDniTime()
         
         if len(PtGetPlayerList()) == 0:
             if BatteryLastUpdated == 0:
                 ageSDL[SDLBatteryLastUpdated.value] = (CurrentTime,)
-                print "xPodBattery: This is your first time here. The Battery has never been updated."
+                print("xPodBattery: This is your first time here. The Battery has never been updated.")
             else:
                 self.SimulateDrainDuringVacancy(CurrentTime, BatteryLastUpdated, BatteryCharge)
         
@@ -220,18 +220,18 @@ class xPodBattery(ptResponder):
         CurrentAgeTimeOfDay = AgeTimeOfDayPercent * kDayLengthInSeconds
         UnoccupiedDaylightSeconds = 0
 
-        print "xPodBattery.SimulateDrainDuringVacancy:"
-        print "\tCurrentTime: %d" % (CurrentTime) # current time in seconds since epoch Mountain time
-        print "\tBatteryLastUpdated: %d" % (BatteryLastUpdated) # last update in seconds since the epoch Mountain time
-        print "\tTimeSinceUpdate: %d" % (TimeSinceUpdate) # total seconds the pod was vacated
-        print "\tWholeDaysVacated: %d" % (WholeDaysVacated) # days the pod was vacated
-        print "\tFractionalDaysVacated: %d" % (FractionalDaysVacated) # seconds the pod was vacated minus whole days
-        print "\tAgeTimeOfDayPercent: %.2f%%" % (AgeTimeOfDayPercent*100) # percentage through the Negilahn day
-        print "\tCurrentAgeTimeOfDay: %.2f of %d" % (CurrentAgeTimeOfDay, kDayLengthInSeconds) # seconds into the Negilahn day
+        print("xPodBattery.SimulateDrainDuringVacancy:")
+        print("\tCurrentTime: %d" % (CurrentTime)) # current time in seconds since epoch Mountain time
+        print("\tBatteryLastUpdated: %d" % (BatteryLastUpdated)) # last update in seconds since the epoch Mountain time
+        print("\tTimeSinceUpdate: %d" % (TimeSinceUpdate)) # total seconds the pod was vacated
+        print("\tWholeDaysVacated: %d" % (WholeDaysVacated)) # days the pod was vacated
+        print("\tFractionalDaysVacated: %d" % (FractionalDaysVacated)) # seconds the pod was vacated minus whole days
+        print("\tAgeTimeOfDayPercent: %.2f%%" % (AgeTimeOfDayPercent*100)) # percentage through the Negilahn day
+        print("\tCurrentAgeTimeOfDay: %.2f of %d" % (CurrentAgeTimeOfDay, kDayLengthInSeconds)) # seconds into the Negilahn day
 
         if FractionalDaysVacated > CurrentAgeTimeOfDay:
             TimeOfDayVacated = kDayLengthInSeconds - (FractionalDaysVacated - CurrentAgeTimeOfDay)
-            print "\tThe pod was vacated at a time of day later than it is now."
+            print("\tThe pod was vacated at a time of day later than it is now.")
 
             if TimeOfDayVacated < kDayLengthInSeconds * fSunset.value:
                 UnoccupiedDaylightSeconds = (kDayLengthInSeconds * fSunset.value) - (TimeOfDayVacated - CurrentAgeTimeOfDay)
@@ -243,7 +243,7 @@ class xPodBattery(ptResponder):
 
         elif FractionalDaysVacated < CurrentAgeTimeOfDay:
             TimeOfDayVacated = CurrentAgeTimeOfDay - FractionalDaysVacated
-            print "\tThe Pod was vacated at a time of day earlier than it is now."
+            print("\tThe Pod was vacated at a time of day earlier than it is now.")
 
             if TimeOfDayVacated < kDayLengthInSeconds * fSunset.value:
                 if CurrentAgeTimeOfDay <= kDayLengthInSeconds * fSunset.value:
@@ -253,21 +253,21 @@ class xPodBattery(ptResponder):
 
         else:
             TimeOfDayVacated = CurrentAgeTimeOfDay
-            print "\tThe Pod was vacated at this exact time."
+            print("\tThe Pod was vacated at this exact time.")
 
         UnoccupiedDaylightSeconds += (WholeDaysVacated * kDayLengthInSeconds)
-        print "\tTimeOfDayVacated: %.2f of %d" % (TimeOfDayVacated, kDayLengthInSeconds) # seconds into the Negilahn day when the pod was vacated
-        print "\tUnoccupiedDaylightSeconds: %.2f" % (UnoccupiedDaylightSeconds) # seconds of daylight the pod was vacated
+        print("\tTimeOfDayVacated: %.2f of %d" % (TimeOfDayVacated, kDayLengthInSeconds)) # seconds into the Negilahn day when the pod was vacated
+        print("\tUnoccupiedDaylightSeconds: %.2f" % (UnoccupiedDaylightSeconds)) # seconds of daylight the pod was vacated
 
-        print "xPodBattery.SimulateDrainDuringVacancy: The following gadgets were left on while the Pod was vacant:"
+        print("xPodBattery.SimulateDrainDuringVacancy: The following gadgets were left on while the Pod was vacant:")
         self.CalculateCostPerCycle()
-        print "xPodBattery.SimulateDrainDuringVacancy: SimulateDrainDuringVacancy: CostThisCycle: %.4f" % (CostThisCycle)
+        print("xPodBattery.SimulateDrainDuringVacancy: SimulateDrainDuringVacancy: CostThisCycle: %.4f" % (CostThisCycle))
 
         CumulativeRecharge = (UnoccupiedDaylightSeconds / 3600.0) * kSunRechargeRate
         CumulativeDrain = (TimeSinceUpdate / 10.0) * CostThisCycle
 
-        print "\tCumulativeRecharge: %.2f" % (CumulativeRecharge) # units of rechange
-        print "\tCumulativeDrain: %.2f" % (CumulativeDrain) # units of discharge
+        print("\tCumulativeRecharge: %.2f" % (CumulativeRecharge)) # units of rechange
+        print("\tCumulativeDrain: %.2f" % (CumulativeDrain)) # units of discharge
 
         BatteryCharge += (CumulativeRecharge - CumulativeDrain)
         self.UpdateBatteryChargeSDL(BatteryCharge)
@@ -291,39 +291,39 @@ class xPodBattery(ptResponder):
         boolSpotlight03 = ageSDL[SDLSpotlight03.value][0]
 
         if boolPodLights and not boolEmergencyPower.value:
-            print "\tPodLights"
+            print("\tPodLights")
             CostThisCycle += (kPowerOnDrain * (kTimeIncrement / 3600.0))
 
         if boolSpeaker01 and not boolEmergencyPower.value:
-            print "\tSpeaker01"
+            print("\tSpeaker01")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
         if boolSpeaker02 and not boolEmergencyPower.value:
-            print "\tSpeaker02"
+            print("\tSpeaker02")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
         if boolSpeaker03 and not boolEmergencyPower.value:
-            print "\tSpeaker03"
+            print("\tSpeaker03")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
         if boolSpeaker04 and not boolEmergencyPower.value:
-            print "\tSpeaker04"
+            print("\tSpeaker04")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
 
         if boolSpotlight01 and not boolEmergencyPower.value:
-            print "\tSpotlight01"
+            print("\tSpotlight01")
             CostThisCycle += (kSpotlightOnDrain * (kTimeIncrement / 3600.0))
         if boolSpotlight02 and not boolEmergencyPower.value:
-            print "\tSpotlight02"
+            print("\tSpotlight02")
             CostThisCycle += (kSpotlightOnDrain * (kTimeIncrement / 3600.0))
         if boolSpotlight03 and not boolEmergencyPower.value:
-            print "\tSpotlight03"
+            print("\tSpotlight03")
             CostThisCycle += (kSpotlightOnDrain * (kTimeIncrement / 3600.0))
 
     ###########################
     def CalculatePowerDrain(self):
         global CostThisCycle
 
-        print "xPodBattery.CalculatePowerDrain: The following gadgets are currently turned on:"
+        print("xPodBattery.CalculatePowerDrain: The following gadgets are currently turned on:")
         self.CalculateCostPerCycle()
-        print "xPodBattery.CalculatePowerDrain: Over the last %s seconds, you drained the battery %.4f units." %(kTimeIncrement, CostThisCycle)
+        print("xPodBattery.CalculatePowerDrain: Over the last %s seconds, you drained the battery %.4f units." %(kTimeIncrement, CostThisCycle))
 
         RechargeFromSun = 0
         ageSDL = PtGetAgeSDL()
@@ -334,12 +334,12 @@ class xPodBattery(ptResponder):
         # If it's currently day, include recharge effect of the Sun
         if AgeTimeOfDayPercent >= fSunrise.value and AgeTimeOfDayPercent <= fSunset.value:
             RechargeFromSun = kSunRechargeRate * (kTimeIncrement / 3600.0)
-            print "xPodBattery.CalculatePowerDrain: The time is %.1f%% through the daytime, adding %.4f units to the battery." % (((AgeTimeOfDayPercent * 2) * 100), RechargeFromSun)
+            print("xPodBattery.CalculatePowerDrain: The time is %.1f%% through the daytime, adding %.4f units to the battery." % (((AgeTimeOfDayPercent * 2) * 100), RechargeFromSun))
             BatteryCharge += RechargeFromSun
 
         if (CostThisCycle - RechargeFromSun) > 0:
             EstimatedTimeLeft = BatteryCharge / (CostThisCycle * kTimeIncrement)
-            print "xPodBattery.CalculatePowerDrain: At this rate, you'll run out of power in %.2f minutes." % (EstimatedTimeLeft)
+            print("xPodBattery.CalculatePowerDrain: At this rate, you'll run out of power in %.2f minutes." % (EstimatedTimeLeft))
 
         self.UpdateBatteryChargeSDL(BatteryCharge)
 
@@ -355,7 +355,7 @@ class xPodBattery(ptResponder):
                 BatteryCharge = BatteryCapacity
 
         ageSDL[SDLBatteryCharge.value] = (BatteryCharge,)
-        print "xPodBattery.UpdateBatteryChargeSDL: The Pod Battery now has %.4f units." % (BatteryCharge)
+        print("xPodBattery.UpdateBatteryChargeSDL: The Pod Battery now has %.4f units." % (BatteryCharge))
 
         CurrentTime = PtGetDniTime()
         ageSDL[SDLBatteryLastUpdated.value] = (CurrentTime,)
@@ -372,7 +372,7 @@ class xPodBattery(ptResponder):
         global Avvie
         ageSDL = PtGetAgeSDL()
 
-        print "xPodBattery.OnNotify: state=%s id=%d events=" % (state, id), events
+        print("xPodBattery.OnNotify: state=%s id=%d events=" % (state, id), events)
         
         if id == actPodLights.id and state:
             Avvie = PtFindAvatar(events)
@@ -443,13 +443,13 @@ class xPodBattery(ptResponder):
     ###########################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
-        print "xPodBattery.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID)
+        print("xPodBattery.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
 
         if self.sceneobject.isLocallyOwned():
             if VARname == SDLPodLights.value:
                 respPodLights.run(self.key, state=str(ageSDL[SDLPodLights.value][0]))
                 if not ageSDL[SDLPodLights.value][0]:
-                    print "xPodBattery.OnSDLNotify(): Tripping all SDLs to negative"
+                    print("xPodBattery.OnSDLNotify(): Tripping all SDLs to negative")
                     respPodLightsTripped.run(self.key)
                     ageSDL[SDLSpeaker01.value] = (0,)
                     ageSDL[SDLSpeaker02.value] = (0,)

--- a/Python/xPodBattery.py
+++ b/Python/xPodBattery.py
@@ -123,14 +123,14 @@ class xPodBattery(ptResponder):
         self.id = 5242
         version = 5
         self.version = version
-        print("__init__xPodBattery v.", version)
+        PtDebugPrint("__init__xPodBattery v.", version)
 
     ###########################
     def OnServerInitComplete(self):
         try:
             ageSDL = PtGetAgeSDL()
         except:
-            print("xPodBattery:\tERROR---Cannot find the Negilahn Age SDL")
+            PtDebugPrint("xPodBattery:\tERROR---Cannot find the Negilahn Age SDL")
             ageSDL[SDLBatteryCharge.value] = (100, ) 
             ageSDL[SDLBatteryCapacity.value] = (100, ) 
             ageSDL[SDLBatteryLastUpdated.value] = (0,)
@@ -199,13 +199,13 @@ class xPodBattery(ptResponder):
         #if ageSDL[SDLSpotlight03.value][0]:
         #    respSpotlight03.run(self.key, state="1", fastforward=1)
 
-        print("xPodBattery: The Pod Battery has %s of a possible %s units." % (BatteryCharge, BatteryCapacity))
+        PtDebugPrint("xPodBattery: The Pod Battery has %s of a possible %s units." % (BatteryCharge, BatteryCapacity))
         CurrentTime = PtGetDniTime()
         
         if len(PtGetPlayerList()) == 0:
             if BatteryLastUpdated == 0:
                 ageSDL[SDLBatteryLastUpdated.value] = (CurrentTime,)
-                print("xPodBattery: This is your first time here. The Battery has never been updated.")
+                PtDebugPrint("xPodBattery: This is your first time here. The Battery has never been updated.")
             else:
                 self.SimulateDrainDuringVacancy(CurrentTime, BatteryLastUpdated, BatteryCharge)
         
@@ -220,18 +220,18 @@ class xPodBattery(ptResponder):
         CurrentAgeTimeOfDay = AgeTimeOfDayPercent * kDayLengthInSeconds
         UnoccupiedDaylightSeconds = 0
 
-        print("xPodBattery.SimulateDrainDuringVacancy:")
-        print("\tCurrentTime: %d" % (CurrentTime)) # current time in seconds since epoch Mountain time
-        print("\tBatteryLastUpdated: %d" % (BatteryLastUpdated)) # last update in seconds since the epoch Mountain time
-        print("\tTimeSinceUpdate: %d" % (TimeSinceUpdate)) # total seconds the pod was vacated
-        print("\tWholeDaysVacated: %d" % (WholeDaysVacated)) # days the pod was vacated
-        print("\tFractionalDaysVacated: %d" % (FractionalDaysVacated)) # seconds the pod was vacated minus whole days
-        print("\tAgeTimeOfDayPercent: %.2f%%" % (AgeTimeOfDayPercent*100)) # percentage through the Negilahn day
-        print("\tCurrentAgeTimeOfDay: %.2f of %d" % (CurrentAgeTimeOfDay, kDayLengthInSeconds)) # seconds into the Negilahn day
+        PtDebugPrint("xPodBattery.SimulateDrainDuringVacancy:")
+        PtDebugPrint("\tCurrentTime: %d" % (CurrentTime)) # current time in seconds since epoch Mountain time
+        PtDebugPrint("\tBatteryLastUpdated: %d" % (BatteryLastUpdated)) # last update in seconds since the epoch Mountain time
+        PtDebugPrint("\tTimeSinceUpdate: %d" % (TimeSinceUpdate)) # total seconds the pod was vacated
+        PtDebugPrint("\tWholeDaysVacated: %d" % (WholeDaysVacated)) # days the pod was vacated
+        PtDebugPrint("\tFractionalDaysVacated: %d" % (FractionalDaysVacated)) # seconds the pod was vacated minus whole days
+        PtDebugPrint("\tAgeTimeOfDayPercent: %.2f%%" % (AgeTimeOfDayPercent*100)) # percentage through the Negilahn day
+        PtDebugPrint("\tCurrentAgeTimeOfDay: %.2f of %d" % (CurrentAgeTimeOfDay, kDayLengthInSeconds)) # seconds into the Negilahn day
 
         if FractionalDaysVacated > CurrentAgeTimeOfDay:
             TimeOfDayVacated = kDayLengthInSeconds - (FractionalDaysVacated - CurrentAgeTimeOfDay)
-            print("\tThe pod was vacated at a time of day later than it is now.")
+            PtDebugPrint("\tThe pod was vacated at a time of day later than it is now.")
 
             if TimeOfDayVacated < kDayLengthInSeconds * fSunset.value:
                 UnoccupiedDaylightSeconds = (kDayLengthInSeconds * fSunset.value) - (TimeOfDayVacated - CurrentAgeTimeOfDay)
@@ -243,7 +243,7 @@ class xPodBattery(ptResponder):
 
         elif FractionalDaysVacated < CurrentAgeTimeOfDay:
             TimeOfDayVacated = CurrentAgeTimeOfDay - FractionalDaysVacated
-            print("\tThe Pod was vacated at a time of day earlier than it is now.")
+            PtDebugPrint("\tThe Pod was vacated at a time of day earlier than it is now.")
 
             if TimeOfDayVacated < kDayLengthInSeconds * fSunset.value:
                 if CurrentAgeTimeOfDay <= kDayLengthInSeconds * fSunset.value:
@@ -253,21 +253,21 @@ class xPodBattery(ptResponder):
 
         else:
             TimeOfDayVacated = CurrentAgeTimeOfDay
-            print("\tThe Pod was vacated at this exact time.")
+            PtDebugPrint("\tThe Pod was vacated at this exact time.")
 
         UnoccupiedDaylightSeconds += (WholeDaysVacated * kDayLengthInSeconds)
-        print("\tTimeOfDayVacated: %.2f of %d" % (TimeOfDayVacated, kDayLengthInSeconds)) # seconds into the Negilahn day when the pod was vacated
-        print("\tUnoccupiedDaylightSeconds: %.2f" % (UnoccupiedDaylightSeconds)) # seconds of daylight the pod was vacated
+        PtDebugPrint("\tTimeOfDayVacated: %.2f of %d" % (TimeOfDayVacated, kDayLengthInSeconds)) # seconds into the Negilahn day when the pod was vacated
+        PtDebugPrint("\tUnoccupiedDaylightSeconds: %.2f" % (UnoccupiedDaylightSeconds)) # seconds of daylight the pod was vacated
 
-        print("xPodBattery.SimulateDrainDuringVacancy: The following gadgets were left on while the Pod was vacant:")
+        PtDebugPrint("xPodBattery.SimulateDrainDuringVacancy: The following gadgets were left on while the Pod was vacant:")
         self.CalculateCostPerCycle()
-        print("xPodBattery.SimulateDrainDuringVacancy: SimulateDrainDuringVacancy: CostThisCycle: %.4f" % (CostThisCycle))
+        PtDebugPrint("xPodBattery.SimulateDrainDuringVacancy: SimulateDrainDuringVacancy: CostThisCycle: %.4f" % (CostThisCycle))
 
         CumulativeRecharge = (UnoccupiedDaylightSeconds / 3600.0) * kSunRechargeRate
         CumulativeDrain = (TimeSinceUpdate / 10.0) * CostThisCycle
 
-        print("\tCumulativeRecharge: %.2f" % (CumulativeRecharge)) # units of rechange
-        print("\tCumulativeDrain: %.2f" % (CumulativeDrain)) # units of discharge
+        PtDebugPrint("\tCumulativeRecharge: %.2f" % (CumulativeRecharge)) # units of rechange
+        PtDebugPrint("\tCumulativeDrain: %.2f" % (CumulativeDrain)) # units of discharge
 
         BatteryCharge += (CumulativeRecharge - CumulativeDrain)
         self.UpdateBatteryChargeSDL(BatteryCharge)
@@ -291,39 +291,39 @@ class xPodBattery(ptResponder):
         boolSpotlight03 = ageSDL[SDLSpotlight03.value][0]
 
         if boolPodLights and not boolEmergencyPower.value:
-            print("\tPodLights")
+            PtDebugPrint("\tPodLights")
             CostThisCycle += (kPowerOnDrain * (kTimeIncrement / 3600.0))
 
         if boolSpeaker01 and not boolEmergencyPower.value:
-            print("\tSpeaker01")
+            PtDebugPrint("\tSpeaker01")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
         if boolSpeaker02 and not boolEmergencyPower.value:
-            print("\tSpeaker02")
+            PtDebugPrint("\tSpeaker02")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
         if boolSpeaker03 and not boolEmergencyPower.value:
-            print("\tSpeaker03")
+            PtDebugPrint("\tSpeaker03")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
         if boolSpeaker04 and not boolEmergencyPower.value:
-            print("\tSpeaker04")
+            PtDebugPrint("\tSpeaker04")
             CostThisCycle += (kMicrophoneOnDrain * (kTimeIncrement / 3600.0))
 
         if boolSpotlight01 and not boolEmergencyPower.value:
-            print("\tSpotlight01")
+            PtDebugPrint("\tSpotlight01")
             CostThisCycle += (kSpotlightOnDrain * (kTimeIncrement / 3600.0))
         if boolSpotlight02 and not boolEmergencyPower.value:
-            print("\tSpotlight02")
+            PtDebugPrint("\tSpotlight02")
             CostThisCycle += (kSpotlightOnDrain * (kTimeIncrement / 3600.0))
         if boolSpotlight03 and not boolEmergencyPower.value:
-            print("\tSpotlight03")
+            PtDebugPrint("\tSpotlight03")
             CostThisCycle += (kSpotlightOnDrain * (kTimeIncrement / 3600.0))
 
     ###########################
     def CalculatePowerDrain(self):
         global CostThisCycle
 
-        print("xPodBattery.CalculatePowerDrain: The following gadgets are currently turned on:")
+        PtDebugPrint("xPodBattery.CalculatePowerDrain: The following gadgets are currently turned on:")
         self.CalculateCostPerCycle()
-        print("xPodBattery.CalculatePowerDrain: Over the last %s seconds, you drained the battery %.4f units." %(kTimeIncrement, CostThisCycle))
+        PtDebugPrint("xPodBattery.CalculatePowerDrain: Over the last %s seconds, you drained the battery %.4f units." %(kTimeIncrement, CostThisCycle))
 
         RechargeFromSun = 0
         ageSDL = PtGetAgeSDL()
@@ -334,12 +334,12 @@ class xPodBattery(ptResponder):
         # If it's currently day, include recharge effect of the Sun
         if AgeTimeOfDayPercent >= fSunrise.value and AgeTimeOfDayPercent <= fSunset.value:
             RechargeFromSun = kSunRechargeRate * (kTimeIncrement / 3600.0)
-            print("xPodBattery.CalculatePowerDrain: The time is %.1f%% through the daytime, adding %.4f units to the battery." % (((AgeTimeOfDayPercent * 2) * 100), RechargeFromSun))
+            PtDebugPrint("xPodBattery.CalculatePowerDrain: The time is %.1f%% through the daytime, adding %.4f units to the battery." % (((AgeTimeOfDayPercent * 2) * 100), RechargeFromSun))
             BatteryCharge += RechargeFromSun
 
         if (CostThisCycle - RechargeFromSun) > 0:
             EstimatedTimeLeft = BatteryCharge / (CostThisCycle * kTimeIncrement)
-            print("xPodBattery.CalculatePowerDrain: At this rate, you'll run out of power in %.2f minutes." % (EstimatedTimeLeft))
+            PtDebugPrint("xPodBattery.CalculatePowerDrain: At this rate, you'll run out of power in %.2f minutes." % (EstimatedTimeLeft))
 
         self.UpdateBatteryChargeSDL(BatteryCharge)
 
@@ -355,7 +355,7 @@ class xPodBattery(ptResponder):
                 BatteryCharge = BatteryCapacity
 
         ageSDL[SDLBatteryCharge.value] = (BatteryCharge,)
-        print("xPodBattery.UpdateBatteryChargeSDL: The Pod Battery now has %.4f units." % (BatteryCharge))
+        PtDebugPrint("xPodBattery.UpdateBatteryChargeSDL: The Pod Battery now has %.4f units." % (BatteryCharge))
 
         CurrentTime = PtGetDniTime()
         ageSDL[SDLBatteryLastUpdated.value] = (CurrentTime,)
@@ -372,7 +372,7 @@ class xPodBattery(ptResponder):
         global Avvie
         ageSDL = PtGetAgeSDL()
 
-        print("xPodBattery.OnNotify: state=%s id=%d events=" % (state, id), events)
+        PtDebugPrint("xPodBattery.OnNotify: state=%s id=%d events=" % (state, id), events)
         
         if id == actPodLights.id and state:
             Avvie = PtFindAvatar(events)
@@ -443,13 +443,13 @@ class xPodBattery(ptResponder):
     ###########################
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         ageSDL = PtGetAgeSDL()
-        print("xPodBattery.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
+        PtDebugPrint("xPodBattery.OnSDLNotify(): VARname:%s, SDLname:%s, tag:%s, value:%s, playerID:%d" % (VARname,SDLname,tag,ageSDL[VARname][0],playerID))
 
         if self.sceneobject.isLocallyOwned():
             if VARname == SDLPodLights.value:
                 respPodLights.run(self.key, state=str(ageSDL[SDLPodLights.value][0]))
                 if not ageSDL[SDLPodLights.value][0]:
-                    print("xPodBattery.OnSDLNotify(): Tripping all SDLs to negative")
+                    PtDebugPrint("xPodBattery.OnSDLNotify(): Tripping all SDLs to negative")
                     respPodLightsTripped.run(self.key)
                     ageSDL[SDLSpeaker01.value] = (0,)
                     ageSDL[SDLSpeaker02.value] = (0,)

--- a/Python/xPotsSymbol.py
+++ b/Python/xPotsSymbol.py
@@ -83,7 +83,7 @@ class xPotsSymbol(ptResponder):
         ptResponder.__init__(self)
         self.id = 230
         self.version = 1
-        print "xPotsSymbol.__init__: v.", self.version
+        print("xPotsSymbol.__init__: v.", self.version)
 
 
     def OnFirstUpdate(self):
@@ -98,7 +98,7 @@ class xPotsSymbol(ptResponder):
         if not all(listSDL):
             PtDebugPrint("ERROR: xPotsSymbol.OnFirstUpdate():\tERROR: missing a SDL var name")
 
-        print "xPotsSymbol.OnFirstUpdate(): listSDL = ", listSDL
+        print("xPotsSymbol.OnFirstUpdate(): listSDL = ", listSDL)
 
         if boolFirstUpdate.value:
             self.Initialize()
@@ -112,7 +112,7 @@ class xPotsSymbol(ptResponder):
             try:
                 ageSDL = PtGetAgeSDL()
                 for sc in listSDL:
-                    print "xPotsSymbol.OnServerInitComplete():\t sdl: %s = %d" % (sc,ageSDL[sc][0])
+                    print("xPotsSymbol.OnServerInitComplete():\t sdl: %s = %d" % (sc,ageSDL[sc][0]))
                     ageSDL.setFlags(sc,1,1)
                     ageSDL.sendToClients(sc)
                     ageSDL.setNotify(self.key,sc,0.0)
@@ -138,12 +138,12 @@ class xPotsSymbol(ptResponder):
         for sc in listSDL:
             if ageSDL[sc][0] == 1:
                 tallySC += 1
-        print "xPotsSymbol.IUpdateIcon(): total # of SaveCloths hit = ",tallySC
+        print("xPotsSymbol.IUpdateIcon(): total # of SaveCloths hit = ",tallySC)
         if tallySC > 0:
             respIconStages.run(self.key,state=iconStates[tallySC-1],fastforward=ff)
-            print "turning on POTS icon stage: ",iconStates[tallySC-1]
+            print("turning on POTS icon stage: ",iconStates[tallySC-1])
             if tallySC == len(listSDL):
-                print "POTS icon is completed, will enable link to POTS cave"
+                print("POTS icon is completed, will enable link to POTS cave")
                 rgnIconLinker.enable()
 
 

--- a/Python/xPotsSymbol.py
+++ b/Python/xPotsSymbol.py
@@ -83,7 +83,7 @@ class xPotsSymbol(ptResponder):
         ptResponder.__init__(self)
         self.id = 230
         self.version = 1
-        print("xPotsSymbol.__init__: v.", self.version)
+        PtDebugPrint("xPotsSymbol.__init__: v.", self.version)
 
 
     def OnFirstUpdate(self):
@@ -98,7 +98,7 @@ class xPotsSymbol(ptResponder):
         if not all(listSDL):
             PtDebugPrint("ERROR: xPotsSymbol.OnFirstUpdate():\tERROR: missing a SDL var name")
 
-        print("xPotsSymbol.OnFirstUpdate(): listSDL = ", listSDL)
+        PtDebugPrint("xPotsSymbol.OnFirstUpdate(): listSDL = ", listSDL)
 
         if boolFirstUpdate.value:
             self.Initialize()
@@ -112,7 +112,7 @@ class xPotsSymbol(ptResponder):
             try:
                 ageSDL = PtGetAgeSDL()
                 for sc in listSDL:
-                    print("xPotsSymbol.OnServerInitComplete():\t sdl: %s = %d" % (sc,ageSDL[sc][0]))
+                    PtDebugPrint("xPotsSymbol.OnServerInitComplete():\t sdl: %s = %d" % (sc,ageSDL[sc][0]))
                     ageSDL.setFlags(sc,1,1)
                     ageSDL.sendToClients(sc)
                     ageSDL.setNotify(self.key,sc,0.0)
@@ -138,12 +138,12 @@ class xPotsSymbol(ptResponder):
         for sc in listSDL:
             if ageSDL[sc][0] == 1:
                 tallySC += 1
-        print("xPotsSymbol.IUpdateIcon(): total # of SaveCloths hit = ",tallySC)
+        PtDebugPrint("xPotsSymbol.IUpdateIcon(): total # of SaveCloths hit = ",tallySC)
         if tallySC > 0:
             respIconStages.run(self.key,state=iconStates[tallySC-1],fastforward=ff)
-            print("turning on POTS icon stage: ",iconStates[tallySC-1])
+            PtDebugPrint("turning on POTS icon stage: ",iconStates[tallySC-1])
             if tallySC == len(listSDL):
-                print("POTS icon is completed, will enable link to POTS cave")
+                PtDebugPrint("POTS icon is completed, will enable link to POTS cave")
                 rgnIconLinker.enable()
 
 

--- a/Python/xPoweredLightSwitch.py
+++ b/Python/xPoweredLightSwitch.py
@@ -70,11 +70,11 @@ class xPoweredLightSwitch(ptResponder):
         
         version = 2
         self.version = version
-        print "__init__xPoweredLightSwitch v.", version
+        print("__init__xPoweredLightSwitch v.", version)
 
     def OnServerInitComplete(self):
         if self.SDL == None:
-            print "xPoweredLightSwitch.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value
+            print("xPoweredLightSwitch.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
             return
         self.SDL.setDefault("source",(0,))
         self.SDL.setDefault("switch",(0,))
@@ -90,9 +90,9 @@ class xPoweredLightSwitch(ptResponder):
                             elif event[3] == 0: #source has become deactivated
                                 self.SDL["source"] = (0,)
                             else: #unexpected value
-                                print "xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - source = %d" % (varstring.value,self.SDL["source"][0])
+                                print("xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - source = %d" % (varstring.value,self.SDL["source"][0]))
                  
-                        print "xPoweredLightSwitch.OnNotify:\t'%s' got msg - source = %d" % (varstring.value,self.SDL["source"][0])
+                        print("xPoweredLightSwitch.OnNotify:\t'%s' got msg - source = %d" % (varstring.value,self.SDL["source"][0]))
                     
                         if self.SDL["source"][0]==1 and self.SDL["switch"][0]==1: # if switch was already on and power now turns ON
                             respOn.run(self.key,events=events)
@@ -106,9 +106,9 @@ class xPoweredLightSwitch(ptResponder):
                 elif self.SDL["switch"][0] == 0: # switch has become deactivated
                     self. SDL["switch"] = (1,)
                 else: #unexpected value
-                    print "xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - switch = %d" % (varstring.value,self.SDL["switch"][0])
+                    print("xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - switch = %d" % (varstring.value,self.SDL["switch"][0]))
 
-                print "xPoweredLightSwitch.OnNotify:\t'%s' got msg - switch = %d" % (varstring.value,self.SDL["switch"][0])
+                print("xPoweredLightSwitch.OnNotify:\t'%s' got msg - switch = %d" % (varstring.value,self.SDL["switch"][0]))
 
                 if self.SDL["switch"][0]==1 and self.SDL["source"][0]==1: # if source was already on and switch now turns ON
                     respOn.run(self.key,events=events)
@@ -117,7 +117,7 @@ class xPoweredLightSwitch(ptResponder):
                     
             
         if id==respOn.id:
-            print "xPoweredLightSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % (varstring.value)
+            print("xPoweredLightSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % (varstring.value))
             note = ptNotify(self.key)
             note.setActivate(1.0)
             note.addVarNumber(varstring.value,1.0)

--- a/Python/xPoweredLightSwitch.py
+++ b/Python/xPoweredLightSwitch.py
@@ -70,11 +70,11 @@ class xPoweredLightSwitch(ptResponder):
         
         version = 2
         self.version = version
-        print("__init__xPoweredLightSwitch v.", version)
+        PtDebugPrint("__init__xPoweredLightSwitch v.", version)
 
     def OnServerInitComplete(self):
         if self.SDL == None:
-            print("xPoweredLightSwitch.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
+            PtDebugPrint("xPoweredLightSwitch.OnServerInitComplete():\tERROR---missing SDL (%s)" % varstring.value)
             return
         self.SDL.setDefault("source",(0,))
         self.SDL.setDefault("switch",(0,))
@@ -90,9 +90,9 @@ class xPoweredLightSwitch(ptResponder):
                             elif event[3] == 0: #source has become deactivated
                                 self.SDL["source"] = (0,)
                             else: #unexpected value
-                                print("xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - source = %d" % (varstring.value,self.SDL["source"][0]))
+                                PtDebugPrint("xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - source = %d" % (varstring.value,self.SDL["source"][0]))
                  
-                        print("xPoweredLightSwitch.OnNotify:\t'%s' got msg - source = %d" % (varstring.value,self.SDL["source"][0]))
+                        PtDebugPrint("xPoweredLightSwitch.OnNotify:\t'%s' got msg - source = %d" % (varstring.value,self.SDL["source"][0]))
                     
                         if self.SDL["source"][0]==1 and self.SDL["switch"][0]==1: # if switch was already on and power now turns ON
                             respOn.run(self.key,events=events)
@@ -106,9 +106,9 @@ class xPoweredLightSwitch(ptResponder):
                 elif self.SDL["switch"][0] == 0: # switch has become deactivated
                     self. SDL["switch"] = (1,)
                 else: #unexpected value
-                    print("xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - switch = %d" % (varstring.value,self.SDL["switch"][0]))
+                    PtDebugPrint("xPoweredLightSwitch.OnNotify:\t'%s' ERROR---got bogus msg - switch = %d" % (varstring.value,self.SDL["switch"][0]))
 
-                print("xPoweredLightSwitch.OnNotify:\t'%s' got msg - switch = %d" % (varstring.value,self.SDL["switch"][0]))
+                PtDebugPrint("xPoweredLightSwitch.OnNotify:\t'%s' got msg - switch = %d" % (varstring.value,self.SDL["switch"][0]))
 
                 if self.SDL["switch"][0]==1 and self.SDL["source"][0]==1: # if source was already on and switch now turns ON
                     respOn.run(self.key,events=events)
@@ -117,7 +117,7 @@ class xPoweredLightSwitch(ptResponder):
                     
             
         if id==respOn.id:
-            print("xPoweredLightSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % (varstring.value))
+            PtDebugPrint("xPoweredLightSwitch.OnNotify:\tsending msg '%s' clicked, pulled or otherwise activated." % (varstring.value))
             note = ptNotify(self.key)
             note.setActivate(1.0)
             note.addVarNumber(varstring.value,1.0)

--- a/Python/xPoweredStarTrekDoor.py
+++ b/Python/xPoweredStarTrekDoor.py
@@ -73,7 +73,7 @@ class xPoweredStarTrekDoor(ptModifier):
         
         version = 1
         self.version = version
-        print "__init__xPoweredStarTrekDoor v.", version
+        print("__init__xPoweredStarTrekDoor v.", version)
 
     def OnServerInitComplete(self):
         if self.SDL == None:
@@ -86,12 +86,12 @@ class xPoweredStarTrekDoor(ptModifier):
         global doorCued
         global doorMoving
         global doorState
-        print "DoorMoving = ", doorMoving
+        print("DoorMoving = ", doorMoving)
         
         if state and id==actPower.id:
-            print "message from GearActivated"
+            print("message from GearActivated")
             for event in events:
-                print event
+                print(event)
                 if event[0] == 4:
                     if event[3] == 1: # power on
                         self.SDL["haspower"] = (1,)
@@ -100,7 +100,7 @@ class xPoweredStarTrekDoor(ptModifier):
                     self.SDL["haspower"] = (0,)
                 
                 else: #unexpected value 
-                    print "xPoweredStarTrekDoor.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (Activate.value,self.SDL["enabled"][0])
+                    print("xPoweredStarTrekDoor.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (Activate.value,self.SDL["enabled"][0]))
                     return
                     
 #                print "xPoweredStarTrekDoor.OnNotify:\t'%s' got msg - power = %d" % (actPower.value,self.SDL["enabled"][0])
@@ -121,13 +121,13 @@ class xPoweredStarTrekDoor(ptModifier):
             
             if not doorMoving:
                 self.doorAction()
-                print "door played"
+                print("door played")
             else: # got a command, but door is busy so cue it
                 doorCued=1
-                print "door cued"
+                print("door cued")
         elif state and id == respDoor.id:
             # Callback from door finishing movement
-            print "callbackfromdoor"
+            print("callbackfromdoor")
             doorMoving=0
             if doorCued:
                 doorCued=0
@@ -140,7 +140,7 @@ class xPoweredStarTrekDoor(ptModifier):
             doorMoving=1
             doorHistory=doorState
             respDoor.run(self.key,state=doorState)
-            print "Door Begin %s" % doorState
+            print("Door Begin %s" % doorState)
 
 
 

--- a/Python/xPoweredStarTrekDoor.py
+++ b/Python/xPoweredStarTrekDoor.py
@@ -73,11 +73,11 @@ class xPoweredStarTrekDoor(ptModifier):
         
         version = 1
         self.version = version
-        print("__init__xPoweredStarTrekDoor v.", version)
+        PtDebugPrint("__init__xPoweredStarTrekDoor v.", version)
 
     def OnServerInitComplete(self):
         if self.SDL == None:
-#            print "xPoweredStarTrekDoor.OnFirstUpdate():\tERROR---missing SDL (%s)" % actPower.value
+#            PtDebugPrint("xPoweredStarTrekDoor.OnFirstUpdate():\tERROR---missing SDL (%s)" % actPower.value)
             return
         self.SDL.setDefault("haspower",(0,))
 
@@ -86,12 +86,12 @@ class xPoweredStarTrekDoor(ptModifier):
         global doorCued
         global doorMoving
         global doorState
-        print("DoorMoving = ", doorMoving)
+        PtDebugPrint("DoorMoving = ", doorMoving)
         
         if state and id==actPower.id:
-            print("message from GearActivated")
+            PtDebugPrint("message from GearActivated")
             for event in events:
-                print(event)
+                PtDebugPrint(event)
                 if event[0] == 4:
                     if event[3] == 1: # power on
                         self.SDL["haspower"] = (1,)
@@ -100,10 +100,10 @@ class xPoweredStarTrekDoor(ptModifier):
                     self.SDL["haspower"] = (0,)
                 
                 else: #unexpected value 
-                    print("xPoweredStarTrekDoor.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (Activate.value,self.SDL["enabled"][0]))
+                    PtDebugPrint("xPoweredStarTrekDoor.OnNotify:\t'%s' ERROR---got bogus msg - power = %d" % (Activate.value,self.SDL["enabled"][0]))
                     return
                     
-#                print "xPoweredStarTrekDoor.OnNotify:\t'%s' got msg - power = %d" % (actPower.value,self.SDL["enabled"][0])
+#                PtDebugPrint("xPoweredStarTrekDoor.OnNotify:\t'%s' got msg - power = %d" % (actPower.value,self.SDL["enabled"][0]))
 
 
 #Pete's original code
@@ -121,13 +121,13 @@ class xPoweredStarTrekDoor(ptModifier):
             
             if not doorMoving:
                 self.doorAction()
-                print("door played")
+                PtDebugPrint("door played")
             else: # got a command, but door is busy so cue it
                 doorCued=1
-                print("door cued")
+                PtDebugPrint("door cued")
         elif state and id == respDoor.id:
             # Callback from door finishing movement
-            print("callbackfromdoor")
+            PtDebugPrint("callbackfromdoor")
             doorMoving=0
             if doorCued:
                 doorCued=0
@@ -140,7 +140,7 @@ class xPoweredStarTrekDoor(ptModifier):
             doorMoving=1
             doorHistory=doorState
             respDoor.run(self.key,state=doorState)
-            print("Door Begin %s" % doorState)
+            PtDebugPrint("Door Begin %s" % doorState)
 
 
 

--- a/Python/xPsnlVaultSDL.py
+++ b/Python/xPsnlVaultSDL.py
@@ -73,7 +73,7 @@ class xPsnlVaultSDL:
             
             return (retval,)
         #except:
-        #    print "ERROR:xPsnlVaultSDL.__getitem__:\tError getting sdl & var"
+        #    PtDebugPrint("ERROR:xPsnlVaultSDL.__getitem__:\tError getting sdl & var")
         #    return None
 
     def __setitem__(self, sub, val):
@@ -98,7 +98,7 @@ class xPsnlVaultSDL:
                 self.vault.updatePsnlAgeSDL(sdl)
 
         #except:
-        #    print "ERROR:xPsnlVaultSDL.__setitem__:\tError getting sdl & var"
+        #    PtDebugPrint("ERROR:xPsnlVaultSDL.__setitem__:\tError getting sdl & var")
 
     def IGetVar(self, var):
         vartype = var.getType()
@@ -125,32 +125,32 @@ class xPsnlVaultSDL:
 
     def ISetVar(self, var, val):
         vartype = var.getType()
-        #print "Attempting to set item %s to %s" % (sub, str(val))
+        #PtDebugPrint("Attempting to set item %s to %s" % (sub, str(val)))
 
         if vartype == PtSDLVarType.kInt:
             if isintance(val, (int, long)):
-                #print "Set int"
+                #PtDebugPrint("Set int")
                 var.setInt(val)
 
         elif vartype == PtSDLVarType.kFloat:
             if isinstance(val, (int, long, float)):
-                #print "Set float"
+                #PtDebugPrint("Set float")
                 var.setFloat(val)
 
         elif vartype == PtSDLVarType.kDouble:
             if isinstance(val, (int, long, float)):
-                #print "Set double"
+                #PtDebugPrint("Set double")
                 var.setDouble(val)
 
         elif vartype == PtSDLVarType.kBool:
-            #print "Set bool"
+            #PtDebugPrint("Set bool")
             if val:
                 var.setBool(1)
             else:
                 var.setBool(0)
 
         elif vartype == PtSDLVarType.kString32:
-            #print "Set string"
+            #PtDebugPrint("Set string")
             if isinstance(val, str):
                 var.setString(val)
             else:
@@ -158,7 +158,7 @@ class xPsnlVaultSDL:
 
         else:
             if isinstance(val, (int, long)):
-                #print "Set int"
+                #PtDebugPrint("Set int")
                 var.setInt(val)
 
     def BatchGet(self, vars):
@@ -175,7 +175,7 @@ class xPsnlVaultSDL:
 
             return retval
         #except:
-        #    print "ERROR:xPsnlVaultSDL.BatchGet:  problem doing a batch get"
+        #    PtDebugPrint("ERROR:xPsnlVaultSDL.BatchGet:  problem doing a batch get")
 
     def BatchSet(self, vars):
         if 1:#try:
@@ -195,4 +195,4 @@ class xPsnlVaultSDL:
                 self.vault.updatePsnlAgeSDL(sdl)
 
         #except:
-        #    print "ERROR:xPsnlVaultSDL.BatchSet:  problem doing a batch set"
+        #    PtDebugPrint("ERROR:xPsnlVaultSDL.BatchSet:  problem doing a batch set")

--- a/Python/xRandom.py
+++ b/Python/xRandom.py
@@ -153,7 +153,7 @@ class xRandom:
 
             if (self._range[1] - self._range[0] + 1) <= len(self._currentSequence):
                 self._currentSequence = [newInt]
-                print "numTries:", numTries
+                print("numTries:", numTries)
                 return newInt
             else:
                 while newInt in self._currentSequence:
@@ -161,9 +161,9 @@ class xRandom:
                     numTries += 1
 
                 self._currentSequence.append(newInt)
-                print "numTries:", numTries
+                print("numTries:", numTries)
                 return newInt
         else:
-            print "numTries:", numTries
+            print("numTries:", numTries)
             return None
             

--- a/Python/xRandom.py
+++ b/Python/xRandom.py
@@ -153,7 +153,7 @@ class xRandom:
 
             if (self._range[1] - self._range[0] + 1) <= len(self._currentSequence):
                 self._currentSequence = [newInt]
-                print("numTries:", numTries)
+                PtDebugPrint("numTries:", numTries)
                 return newInt
             else:
                 while newInt in self._currentSequence:
@@ -161,9 +161,9 @@ class xRandom:
                     numTries += 1
 
                 self._currentSequence.append(newInt)
-                print("numTries:", numTries)
+                PtDebugPrint("numTries:", numTries)
                 return newInt
         else:
-            print("numTries:", numTries)
+            PtDebugPrint("numTries:", numTries)
             return None
             

--- a/Python/xRandomBoolChange.py
+++ b/Python/xRandomBoolChange.py
@@ -118,28 +118,28 @@ class xRandomBoolChange(ptModifier):
             PtDebugPrint("ERROR: xRandomBoolChange.OnServerInitComplete():\tERROR accessing nearby ageSDL on %s. Using default." % self.sceneobject.getName())
             nearby = 0
 
-        print "RandomBoolChange script on object " + self.sceneobject.getName()
-        print "Visible:" + str(visible)
-        print "Enabled:" + str(enabled)
-        print "Chance :" + str(chance)
-        print "Nearby :" + str(nearby)
+        print("RandomBoolChange script on object " + self.sceneobject.getName())
+        print("Visible:" + str(visible))
+        print("Enabled:" + str(enabled))
+        print("Chance :" + str(chance))
+        print("Nearby :" + str(nearby))
 
         # check if the object is enabled
         if enabled:
             if not nearby:
                 rint = xRandom.randint(0, 100)
-                print "Random int:" + str(rint)
+                print("Random int:" + str(rint))
                 if rint <= chance:
                     # we passed so take appropriate action
                     if visible:
-                        print "Passed!  Setting variable to 0"
+                        print("Passed!  Setting variable to 0")
                         ageSDL[strVarName.value] = (0,)
                     else:
-                        print "Passed!  Setting variable to 1"
+                        print("Passed!  Setting variable to 1")
                         ageSDL[strVarName.value] = (1,)
         else:
             if visible:
-                print "Object not enabled, turning off"
+                print("Object not enabled, turning off")
                 ageSDL[strVarName.value] = (0,)
 
     def OnNotify(self,state,id,events):
@@ -150,14 +150,14 @@ class xRandomBoolChange(ptModifier):
                     currentlyOccupied = sdl[strProximityVar.value][0]
 
                     if event[1]:  # someone entered
-                        print "Someone entered the bahro stone region"
+                        print("Someone entered the bahro stone region")
                         if not currentlyOccupied:
-                            print "Region var is set to unoccupied so setting to occupied"
+                            print("Region var is set to unoccupied so setting to occupied")
                             sdl[strProximityVar.value] = (1,)
                     else:         # everyone exited
-                        print "No one is in the bahro stone region"
+                        print("No one is in the bahro stone region")
                         if currentlyOccupied:
-                            print "Region var is set to occupied so setting to unoccupied"
+                            print("Region var is set to occupied so setting to unoccupied")
                             sdl[strProximityVar.value] = (0,)
                     break
 
@@ -165,14 +165,14 @@ class xRandomBoolChange(ptModifier):
         if VARname == strEnabledVar.value:
             if soOwned.sceneobject.isLocallyOwned():
                 sdl = PtGetAgeSDL()
-                print "Enabled var changed to: " + str(sdl[strEnabledVar.value][0])
+                print("Enabled var changed to: " + str(sdl[strEnabledVar.value][0]))
                 if not sdl[strEnabledVar.value][0]:
-                    print "Enabled var is no longer enabled"
+                    print("Enabled var is no longer enabled")
                     if boolEnable.value:
                         if sdl[strVarName.value][0]:
-                            print "Setting var to disabled"
+                            print("Setting var to disabled")
                             sdl[strVarName.value] = (0,)
                     else:
                         if not sdl[strVarName.value][0]:
-                            print "Setting var to enabled"
+                            print("Setting var to enabled")
                             sdl[strVarName.value] = (1,)

--- a/Python/xRandomBoolChange.py
+++ b/Python/xRandomBoolChange.py
@@ -118,28 +118,28 @@ class xRandomBoolChange(ptModifier):
             PtDebugPrint("ERROR: xRandomBoolChange.OnServerInitComplete():\tERROR accessing nearby ageSDL on %s. Using default." % self.sceneobject.getName())
             nearby = 0
 
-        print("RandomBoolChange script on object " + self.sceneobject.getName())
-        print("Visible:" + str(visible))
-        print("Enabled:" + str(enabled))
-        print("Chance :" + str(chance))
-        print("Nearby :" + str(nearby))
+        PtDebugPrint("RandomBoolChange script on object " + self.sceneobject.getName())
+        PtDebugPrint("Visible:" + str(visible))
+        PtDebugPrint("Enabled:" + str(enabled))
+        PtDebugPrint("Chance :" + str(chance))
+        PtDebugPrint("Nearby :" + str(nearby))
 
         # check if the object is enabled
         if enabled:
             if not nearby:
                 rint = xRandom.randint(0, 100)
-                print("Random int:" + str(rint))
+                PtDebugPrint("Random int:" + str(rint))
                 if rint <= chance:
                     # we passed so take appropriate action
                     if visible:
-                        print("Passed!  Setting variable to 0")
+                        PtDebugPrint("Passed!  Setting variable to 0")
                         ageSDL[strVarName.value] = (0,)
                     else:
-                        print("Passed!  Setting variable to 1")
+                        PtDebugPrint("Passed!  Setting variable to 1")
                         ageSDL[strVarName.value] = (1,)
         else:
             if visible:
-                print("Object not enabled, turning off")
+                PtDebugPrint("Object not enabled, turning off")
                 ageSDL[strVarName.value] = (0,)
 
     def OnNotify(self,state,id,events):
@@ -150,14 +150,14 @@ class xRandomBoolChange(ptModifier):
                     currentlyOccupied = sdl[strProximityVar.value][0]
 
                     if event[1]:  # someone entered
-                        print("Someone entered the bahro stone region")
+                        PtDebugPrint("Someone entered the bahro stone region")
                         if not currentlyOccupied:
-                            print("Region var is set to unoccupied so setting to occupied")
+                            PtDebugPrint("Region var is set to unoccupied so setting to occupied")
                             sdl[strProximityVar.value] = (1,)
                     else:         # everyone exited
-                        print("No one is in the bahro stone region")
+                        PtDebugPrint("No one is in the bahro stone region")
                         if currentlyOccupied:
-                            print("Region var is set to occupied so setting to unoccupied")
+                            PtDebugPrint("Region var is set to occupied so setting to unoccupied")
                             sdl[strProximityVar.value] = (0,)
                     break
 
@@ -165,14 +165,14 @@ class xRandomBoolChange(ptModifier):
         if VARname == strEnabledVar.value:
             if soOwned.sceneobject.isLocallyOwned():
                 sdl = PtGetAgeSDL()
-                print("Enabled var changed to: " + str(sdl[strEnabledVar.value][0]))
+                PtDebugPrint("Enabled var changed to: " + str(sdl[strEnabledVar.value][0]))
                 if not sdl[strEnabledVar.value][0]:
-                    print("Enabled var is no longer enabled")
+                    PtDebugPrint("Enabled var is no longer enabled")
                     if boolEnable.value:
                         if sdl[strVarName.value][0]:
-                            print("Setting var to disabled")
+                            PtDebugPrint("Setting var to disabled")
                             sdl[strVarName.value] = (0,)
                     else:
                         if not sdl[strVarName.value][0]:
-                            print("Setting var to enabled")
+                            PtDebugPrint("Setting var to enabled")
                             sdl[strVarName.value] = (1,)

--- a/Python/xRunResponder.py
+++ b/Python/xRunResponder.py
@@ -67,10 +67,10 @@ class xRunResponder(ptResponder):
          
         version = 1
         self.version = version
-        print "__init__xRunResponder v.", version
+        print("__init__xRunResponder v.", version)
        
     def OnNotify(self,state,id,events):
 
         if state and id==message.id:
             resp.run(self.key)
-            print "I just ran a responder. I'm cool."
+            print("I just ran a responder. I'm cool.")

--- a/Python/xRunResponder.py
+++ b/Python/xRunResponder.py
@@ -67,10 +67,10 @@ class xRunResponder(ptResponder):
          
         version = 1
         self.version = version
-        print("__init__xRunResponder v.", version)
+        PtDebugPrint("__init__xRunResponder v.", version)
        
     def OnNotify(self,state,id,events):
 
         if state and id==message.id:
             resp.run(self.key)
-            print("I just ran a responder. I'm cool.")
+            PtDebugPrint("I just ran a responder. I'm cool.")

--- a/Python/xSaveCloth.py
+++ b/Python/xSaveCloth.py
@@ -77,7 +77,7 @@ class xSaveCloth(ptModifier):
         ptModifier.__init__(self)
         self.id = 5324
         self.version = 2
-        print "DEBUG: xSaveCloth.__init__: v.", self.version
+        print("DEBUG: xSaveCloth.__init__: v.", self.version)
 
 
     def OnFirstUpdate(self):
@@ -95,20 +95,20 @@ class xSaveCloth(ptModifier):
         spTitle = spawnPoint.getTitle()
         spName = spawnPoint.getName()
 
-        print "spawned into", spName, ", this save cloth handles", soSpawnpoint.value.getName()
+        print("spawned into", spName, ", this save cloth handles", soSpawnpoint.value.getName())
         if spTitle.endswith("SavePoint") and spName == soSpawnpoint.value.getName():
-            print "restoring camera stack for save point", spTitle, spName
+            print("restoring camera stack for save point", spTitle, spName)
 
             # Restore camera stack
             camstack = spawnPoint.getCameraStack()
-            print "camera stack:", camstack
+            print("camera stack:", camstack)
             if camstack != "":
                 PtClearCameraStack()
                 camlist = camstack.split(CAM_DIVIDER)
 
                 age = PtGetAgeName()
                 for x in camlist:
-                    print "adding camera: |" + str(x) + "|"
+                    print("adding camera: |" + str(x) + "|")
                     try:
                         PtRebuildCameraStack(x, age)
                     except:
@@ -118,7 +118,7 @@ class xSaveCloth(ptModifier):
         
         # SaveCloth SDL stuff, for use with POTS symbols
         if not (numSC.value > 0 and numSC.value <= kMaxSC):
-            print "xSaveCloth.OnServerInitComplete(): ERROR! invalid save cloth # of ",numSC.value,", specified in MAX component.  Please revise..."
+            print("xSaveCloth.OnServerInitComplete(): ERROR! invalid save cloth # of ",numSC.value,", specified in MAX component.  Please revise...")
             return
         ageName = PtGetAgeName()
         if ageName == "Ercana":
@@ -127,7 +127,7 @@ class xSaveCloth(ptModifier):
 #        elif ageName == "Ahnonay":
 #            sdlPre = "ahny"
         else:
-            print "xSaveCloth.py not updated for this age's SDL.  Ignoring SaveCloth SDL stuff..."
+            print("xSaveCloth.py not updated for this age's SDL.  Ignoring SaveCloth SDL stuff...")
             return
         sdlSC = sdlPre + sdlBase + str(numSC.value)
         try:
@@ -138,7 +138,7 @@ class xSaveCloth(ptModifier):
             gotSC = ageSDL[sdlSC][0]
             #print "xSaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC
         except:
-            print "ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0"
+            print("ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0")
 
 
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -176,7 +176,7 @@ class xSaveCloth(ptModifier):
                         camstack += (PtGetCameraNumber(x+1) + CAM_DIVIDER)
                     camstack = camstack[:-1]
 
-                    print "camera stack:", camstack
+                    print("camera stack:", camstack)
 
                     # camera stack is now being saved as a spawn point on the owned age link
                     vault = ptVault()

--- a/Python/xSaveCloth.py
+++ b/Python/xSaveCloth.py
@@ -77,7 +77,7 @@ class xSaveCloth(ptModifier):
         ptModifier.__init__(self)
         self.id = 5324
         self.version = 2
-        print("DEBUG: xSaveCloth.__init__: v.", self.version)
+        PtDebugPrint("DEBUG: xSaveCloth.__init__: v.", self.version)
 
 
     def OnFirstUpdate(self):
@@ -95,20 +95,20 @@ class xSaveCloth(ptModifier):
         spTitle = spawnPoint.getTitle()
         spName = spawnPoint.getName()
 
-        print("spawned into", spName, ", this save cloth handles", soSpawnpoint.value.getName())
+        PtDebugPrint("spawned into", spName, ", this save cloth handles", soSpawnpoint.value.getName())
         if spTitle.endswith("SavePoint") and spName == soSpawnpoint.value.getName():
-            print("restoring camera stack for save point", spTitle, spName)
+            PtDebugPrint("restoring camera stack for save point", spTitle, spName)
 
             # Restore camera stack
             camstack = spawnPoint.getCameraStack()
-            print("camera stack:", camstack)
+            PtDebugPrint("camera stack:", camstack)
             if camstack != "":
                 PtClearCameraStack()
                 camlist = camstack.split(CAM_DIVIDER)
 
                 age = PtGetAgeName()
                 for x in camlist:
-                    print("adding camera: |" + str(x) + "|")
+                    PtDebugPrint("adding camera: |" + str(x) + "|")
                     try:
                         PtRebuildCameraStack(x, age)
                     except:
@@ -118,7 +118,7 @@ class xSaveCloth(ptModifier):
         
         # SaveCloth SDL stuff, for use with POTS symbols
         if not (numSC.value > 0 and numSC.value <= kMaxSC):
-            print("xSaveCloth.OnServerInitComplete(): ERROR! invalid save cloth # of ",numSC.value,", specified in MAX component.  Please revise...")
+            PtDebugPrint("xSaveCloth.OnServerInitComplete(): ERROR! invalid save cloth # of ",numSC.value,", specified in MAX component.  Please revise...")
             return
         ageName = PtGetAgeName()
         if ageName == "Ercana":
@@ -127,7 +127,7 @@ class xSaveCloth(ptModifier):
 #        elif ageName == "Ahnonay":
 #            sdlPre = "ahny"
         else:
-            print("xSaveCloth.py not updated for this age's SDL.  Ignoring SaveCloth SDL stuff...")
+            PtDebugPrint("xSaveCloth.py not updated for this age's SDL.  Ignoring SaveCloth SDL stuff...")
             return
         sdlSC = sdlPre + sdlBase + str(numSC.value)
         try:
@@ -136,9 +136,9 @@ class xSaveCloth(ptModifier):
             ageSDL.sendToClients(sdlSC)
             ageSDL.setNotify(self.key,sdlSC,0.0)
             gotSC = ageSDL[sdlSC][0]
-            #print "xSaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC
+            #PtDebugPrint("xSaveCloth.OnServerInitComplete():\t found sdl: ",sdlSC,", which = ",gotSC)
         except:
-            print("ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0")
+            PtDebugPrint("ERROR.  Couldn't find sdl: ",sdlSC,", defaulting to 0")
 
 
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
@@ -176,7 +176,7 @@ class xSaveCloth(ptModifier):
                         camstack += (PtGetCameraNumber(x+1) + CAM_DIVIDER)
                     camstack = camstack[:-1]
 
-                    print("camera stack:", camstack)
+                    PtDebugPrint("camera stack:", camstack)
 
                     # camera stack is now being saved as a spawn point on the owned age link
                     vault = ptVault()

--- a/Python/xSaveScreenCapture.py
+++ b/Python/xSaveScreenCapture.py
@@ -59,7 +59,7 @@ class xSaveScreenCapture(ptModifier):
         ptModifier.__init__(self)
         self.id = 5319
         self.version = 1
-        print("__init__xSaveScreenCapture v.", self.version)
+        PtDebugPrint("__init__xSaveScreenCapture v.", self.version)
 
     def OnScreenCaptureDone(self,image):
         if strFileName.value:

--- a/Python/xSaveScreenCapture.py
+++ b/Python/xSaveScreenCapture.py
@@ -59,7 +59,7 @@ class xSaveScreenCapture(ptModifier):
         ptModifier.__init__(self)
         self.id = 5319
         self.version = 1
-        print "__init__xSaveScreenCapture v.", self.version
+        print("__init__xSaveScreenCapture v.", self.version)
 
     def OnScreenCaptureDone(self,image):
         if strFileName.value:

--- a/Python/xSimpleImager.py
+++ b/Python/xSimpleImager.py
@@ -264,7 +264,7 @@ class xSimpleImager(ptModifier):
             self.IRefreshImagerFolder()
             self.IRefreshImagerContent(tupdata[0])
         elif event == PtVaultCallbackTypes.kVaultRemovingNodeRef:
-            #~ print "xSimpleImager: kVaultRemovingNodeRef event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID())
+            #~ PtDebugPrint("xSimpleImager: kVaultRemovingNodeRef event (childID=%d,parentID=%d)" % (tupdata[0].getChildID(),tupdata[0].getParentID()))
             # tupdata is ( ptVaultNodeRef )
             self.IRefreshImagerFolder()
 
@@ -354,7 +354,7 @@ class xSimpleImager(ptModifier):
                 self.IChangeCurrentContent()
         else:
             # there is no folders
-            #~ print "simpleImager: folder(%s) had nothing in it!" % (ImagerName.value)
+            #~ PtDebugPrint("simpleImager: folder(%s) had nothing in it!" % (ImagerName.value))
             ImagerContents = []
 
     def IRefreshImagerContent(self,updated_content):
@@ -414,7 +414,7 @@ class xSimpleImager(ptModifier):
             selfnotify.addVarNumber(sname,1.0)
             selfnotify.send()
         else:
-            #~ print "Not owner of Imager"
+            #~ PtDebugPrint("Not owner of Imager")
             pass
 
     def IShowCurrentContent(self):

--- a/Python/xSitAugment.py
+++ b/Python/xSitAugment.py
@@ -80,7 +80,7 @@ class xSitAugment(ptModifier):
         
         version = 1
         self.version = version
-        print "__init__xSitAugment v.", version
+        print("__init__xSitAugment v.", version)
 
     def OnFirstUpdate(self):
         pass
@@ -110,7 +110,7 @@ class xSitAugment(ptModifier):
 ### below is scrap 
     def OnGUINotify(self,id,control,event):
         "Notifications from the vignette"
-        print "GUI Notify id=%d, event=%d control=" % (id,event),control
+        print("GUI Notify id=%d, event=%d control=" % (id,event),control)
         if control.getTagID() == kExit: #off
             self.IQuitDialog()
         #elif event == kDialogLoaded:
@@ -120,7 +120,7 @@ class xSitAugment(ptModifier):
 
     def OnControlKeyEvent(self,controlKey,activeFlag):
         "Control key events... anything we're interested in?"
-        print "Got controlKey event %d and its activeFlage is %d" % (controlKey,activeFlag)
+        print("Got controlKey event %d and its activeFlage is %d" % (controlKey,activeFlag))
         if controlKey == PlasmaControlKeys.kKeyExitMode:
             self.IQuitDialog()
 
@@ -131,7 +131,7 @@ class xSitAugment(ptModifier):
         PtLoadDialog(Vignette.value,self.key)
         if ( PtIsDialogLoaded(Vignette.value) ):
             PtShowDialog(Vignette.value)
-            print "dialog: %s goes up" % Vignette.value
+            print("dialog: %s goes up" % Vignette.value)
         # get control key events
         PtEnableControlKeyEvents(self.key)
 
@@ -141,9 +141,9 @@ class xSitAugment(ptModifier):
         # exit every thing
         if Vignette.value:
             PtHideDialog(Vignette.value)
-            print "Dialog: %s goes down" % Vignette.value
+            print("Dialog: %s goes down" % Vignette.value)
         else:
-            print "WTH!!!"
+            print("WTH!!!")
         #disable the Control key events
         PtDisableControlKeyEvents(self.key)
         # re-enable the dialog for someone else to use

--- a/Python/xSitAugment.py
+++ b/Python/xSitAugment.py
@@ -80,7 +80,7 @@ class xSitAugment(ptModifier):
         
         version = 1
         self.version = version
-        print("__init__xSitAugment v.", version)
+        PtDebugPrint("__init__xSitAugment v.", version)
 
     def OnFirstUpdate(self):
         pass
@@ -110,7 +110,7 @@ class xSitAugment(ptModifier):
 ### below is scrap 
     def OnGUINotify(self,id,control,event):
         "Notifications from the vignette"
-        print("GUI Notify id=%d, event=%d control=" % (id,event),control)
+        PtDebugPrint("GUI Notify id=%d, event=%d control=" % (id,event),control)
         if control.getTagID() == kExit: #off
             self.IQuitDialog()
         #elif event == kDialogLoaded:
@@ -120,7 +120,7 @@ class xSitAugment(ptModifier):
 
     def OnControlKeyEvent(self,controlKey,activeFlag):
         "Control key events... anything we're interested in?"
-        print("Got controlKey event %d and its activeFlage is %d" % (controlKey,activeFlag))
+        PtDebugPrint("Got controlKey event %d and its activeFlage is %d" % (controlKey,activeFlag))
         if controlKey == PlasmaControlKeys.kKeyExitMode:
             self.IQuitDialog()
 
@@ -131,7 +131,7 @@ class xSitAugment(ptModifier):
         PtLoadDialog(Vignette.value,self.key)
         if ( PtIsDialogLoaded(Vignette.value) ):
             PtShowDialog(Vignette.value)
-            print("dialog: %s goes up" % Vignette.value)
+            PtDebugPrint("dialog: %s goes up" % Vignette.value)
         # get control key events
         PtEnableControlKeyEvents(self.key)
 
@@ -141,9 +141,9 @@ class xSitAugment(ptModifier):
         # exit every thing
         if Vignette.value:
             PtHideDialog(Vignette.value)
-            print("Dialog: %s goes down" % Vignette.value)
+            PtDebugPrint("Dialog: %s goes down" % Vignette.value)
         else:
-            print("WTH!!!")
+            PtDebugPrint("WTH!!!")
         #disable the Control key events
         PtDisableControlKeyEvents(self.key)
         # re-enable the dialog for someone else to use

--- a/Python/xSndLogTracks.py
+++ b/Python/xSndLogTracks.py
@@ -71,12 +71,12 @@ def LogTrack(currentState,nextState):
                 entry.chronicleSetValue(nextState)
                 entry.save()
                 updated = 1
-                print "updated to %s" % (nextState)
+                print("updated to %s" % (nextState))
             else:
-                print "no track"
+                print("no track")
         if not updated:
             # ha, ha ...start over
-            print "not updated"
+            print("not updated")
 #            entry.chronicleSetValue("15")
 #            entry.save()
     return updated
@@ -118,9 +118,9 @@ def WhatIsLog():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
     if entry is not None:
-        print entry.chronicleGetValue()
+        print(entry.chronicleGetValue())
     else:
-        print "not initialized"
+        print("not initialized")
 
 def GetTrack():
     avatar = PtGetLocalAvatar()

--- a/Python/xSndLogTracks.py
+++ b/Python/xSndLogTracks.py
@@ -71,12 +71,12 @@ def LogTrack(currentState,nextState):
                 entry.chronicleSetValue(nextState)
                 entry.save()
                 updated = 1
-                print("updated to %s" % (nextState))
+                PtDebugPrint("updated to %s" % (nextState))
             else:
-                print("no track")
+                PtDebugPrint("no track")
         if not updated:
             # ha, ha ...start over
-            print("not updated")
+            PtDebugPrint("not updated")
 #            entry.chronicleSetValue("15")
 #            entry.save()
     return updated
@@ -118,9 +118,9 @@ def WhatIsLog():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
     if entry is not None:
-        print(entry.chronicleGetValue())
+        PtDebugPrint(entry.chronicleGetValue())
     else:
-        print("not initialized")
+        PtDebugPrint("not initialized")
 
 def GetTrack():
     avatar = PtGetLocalAvatar()

--- a/Python/xStandardDoor.py
+++ b/Python/xStandardDoor.py
@@ -104,11 +104,11 @@ class xStandardDoor(ptResponder):
         
         version = 6
         self.version = version
-        print "__init__xStandardDoor v.", version
+        print("__init__xStandardDoor v.", version)
         self.DoorStack = []
 
     def OnFirstUpdate(self):
-        print "xStandardDoor: Located in age %s, Max Object %s" % (str(PtGetAgeName()),str(self.sceneobject.getName()))
+        print("xStandardDoor: Located in age %s, Max Object %s" % (str(PtGetAgeName()),str(self.sceneobject.getName())))
         # get the age we started in
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
@@ -266,7 +266,7 @@ class xStandardDoor(ptResponder):
                         OkTags = ["fromOutside", "fromInside", "fromAuto", "fastforward"]
                         if tag in OkTags:
                             self.SendNote('%s;%d;%d;true' % (tag, playerID, fastforward), playerID)
-                            print 'xStandardDoor.OnSDLNotify():\tClosing ', tag 
+                            print('xStandardDoor.OnSDLNotify():\tClosing ', tag) 
                         else:
                             PtDebugPrint("xStandardDoor.OnSDLNotify():\tWARNING missing or invalid hint string:%s" % (tag)) # ok if from vaultmanager
                             fastforward = 1
@@ -277,7 +277,7 @@ class xStandardDoor(ptResponder):
                             else:
                                 PtDebugPrint("xStandardDoor.OnSDLNotify():\tWARNING: door set to neither manual close nor auto close, can't close")
                     except:
-                        print "xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag)
+                        print("xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag))
                     if fastforward: # reenable clickables and xregion state via responder won't happen so do it manually
                         if boolEnableOK:
                             actExterior.enable()
@@ -289,13 +289,13 @@ class xStandardDoor(ptResponder):
                         OkTags = ["fromOutside", "fromInside"]
                         if tag in OkTags:
                             self.SendNote('%s;%d;%d;false' % (tag, playerID, fastforward), playerID)
-                            print 'xStandardDoor.OnSDLNotify():\tOpening ', tag
+                            print('xStandardDoor.OnSDLNotify():\tOpening ', tag)
                         else:
                             PtDebugPrint("xStandardDoor.OnSDLNotify():\tWARNING missing or invalid hint string:%s" % (tag))
                             fastforward = 1
                             respOpenExt.run(self.key,fastforward=fastforward)
                     except:
-                        print "xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag)
+                        print("xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag))
                         fastforward = 1
                         respOpenExt.run(self.key,fastforward=fastforward)
                     if fastforward: # reenable clickables and xregion state via responder won't happen so do it manually
@@ -305,16 +305,16 @@ class xStandardDoor(ptResponder):
                         xrgnDoorBlocker.releaseNow(self.key)                    
 
     def OnNotify(self,state,id,events):
-        print "xStandardDoor: ID notified:", id
+        print("xStandardDoor: ID notified:", id)
         
         if id == -1:
             self.DoorStack.append(events[0][1])
-            print "xStandardDoor: New list is: %s" % (str(self.DoorStack))
+            print("xStandardDoor: New list is: %s" % (str(self.DoorStack)))
 
             if len(self.DoorStack) == 1:
-                print "xStandardDoor: List is only one command long, so I'm playing it"
+                print("xStandardDoor: List is only one command long, so I'm playing it")
                 code = self.DoorStack[0]
-                print "xStandardDoor: Playing command: %s" % (code)
+                print("xStandardDoor: Playing command: %s" % (code))
                 self.ExecCode(code)
                 return
 
@@ -331,7 +331,7 @@ class xStandardDoor(ptResponder):
                 actInterior.enable()
 
     def SendNote(self, ExtraInfo, avatar):
-        print "xStandardDoor: Avatar who did this:", avatar
+        print("xStandardDoor: Avatar who did this:", avatar)
         if avatar == 0:
             notify = ptNotify(self.key)
             notify.clearReceivers()
@@ -355,11 +355,11 @@ class xStandardDoor(ptResponder):
     def UpdateRespStack (self):
         #Updates the Responder List
         old = self.DoorStack.pop(0)
-        print "xStandardDoor: Getting rid of Resp: %s" % (old)
+        print("xStandardDoor: Getting rid of Resp: %s" % (old))
         if len(self.DoorStack):            
-            print "xStandardDoor: There's at lest one more Resp to play."
+            print("xStandardDoor: There's at lest one more Resp to play.")
             code = self.DoorStack[0]            
-            print "Playing command: %s" % (code)
+            print("Playing command: %s" % (code))
             self.ExecCode(code)
 
     def ExecCode (self, code):
@@ -379,7 +379,7 @@ class xStandardDoor(ptResponder):
                 elif tag == "fastforward":
                     respCloseExt.run(self.key,avatar=ptSceneobject(PtGetAvatarKeyFromClientID(playerId),self.key),fastforward=1,netPropagate=0)
                 else:
-                    print "xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag)
+                    print("xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
                     self.DoorStack.pop(0)
             else:
                 if tag == "fromOutside":
@@ -387,8 +387,8 @@ class xStandardDoor(ptResponder):
                 elif tag == "fromInside" or playerId == 0:
                     respOpenInt.run(self.key,avatar=ptSceneobject(PtGetAvatarKeyFromClientID(playerId),self.key),fastforward=fastForward,netPropagate=0)
                 else:
-                    print "xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag)
+                    print("xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
                     self.DoorStack.pop(0)
         except:
-            print "xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code)
+            print("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.DoorStack.pop(0)

--- a/Python/xStandardDoor.py
+++ b/Python/xStandardDoor.py
@@ -104,11 +104,11 @@ class xStandardDoor(ptResponder):
         
         version = 6
         self.version = version
-        print("__init__xStandardDoor v.", version)
+        PtDebugPrint("__init__xStandardDoor v.", version)
         self.DoorStack = []
 
     def OnFirstUpdate(self):
-        print("xStandardDoor: Located in age %s, Max Object %s" % (str(PtGetAgeName()),str(self.sceneobject.getName())))
+        PtDebugPrint("xStandardDoor: Located in age %s, Max Object %s" % (str(PtGetAgeName()),str(self.sceneobject.getName())))
         # get the age we started in
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
@@ -266,7 +266,7 @@ class xStandardDoor(ptResponder):
                         OkTags = ["fromOutside", "fromInside", "fromAuto", "fastforward"]
                         if tag in OkTags:
                             self.SendNote('%s;%d;%d;true' % (tag, playerID, fastforward), playerID)
-                            print('xStandardDoor.OnSDLNotify():\tClosing ', tag) 
+                            PtDebugPrint('xStandardDoor.OnSDLNotify():\tClosing ', tag) 
                         else:
                             PtDebugPrint("xStandardDoor.OnSDLNotify():\tWARNING missing or invalid hint string:%s" % (tag)) # ok if from vaultmanager
                             fastforward = 1
@@ -277,7 +277,7 @@ class xStandardDoor(ptResponder):
                             else:
                                 PtDebugPrint("xStandardDoor.OnSDLNotify():\tWARNING: door set to neither manual close nor auto close, can't close")
                     except:
-                        print("xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag))
+                        PtDebugPrint("xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag))
                     if fastforward: # reenable clickables and xregion state via responder won't happen so do it manually
                         if boolEnableOK:
                             actExterior.enable()
@@ -289,13 +289,13 @@ class xStandardDoor(ptResponder):
                         OkTags = ["fromOutside", "fromInside"]
                         if tag in OkTags:
                             self.SendNote('%s;%d;%d;false' % (tag, playerID, fastforward), playerID)
-                            print('xStandardDoor.OnSDLNotify():\tOpening ', tag)
+                            PtDebugPrint('xStandardDoor.OnSDLNotify():\tOpening ', tag)
                         else:
                             PtDebugPrint("xStandardDoor.OnSDLNotify():\tWARNING missing or invalid hint string:%s" % (tag))
                             fastforward = 1
                             respOpenExt.run(self.key,fastforward=fastforward)
                     except:
-                        print("xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag))
+                        PtDebugPrint("xStandardDoor.OnSDLNotify():\tERROR processing sdl var %s hint string: %s" % (VARname,tag))
                         fastforward = 1
                         respOpenExt.run(self.key,fastforward=fastforward)
                     if fastforward: # reenable clickables and xregion state via responder won't happen so do it manually
@@ -305,16 +305,16 @@ class xStandardDoor(ptResponder):
                         xrgnDoorBlocker.releaseNow(self.key)                    
 
     def OnNotify(self,state,id,events):
-        print("xStandardDoor: ID notified:", id)
+        PtDebugPrint("xStandardDoor: ID notified:", id)
         
         if id == -1:
             self.DoorStack.append(events[0][1])
-            print("xStandardDoor: New list is: %s" % (str(self.DoorStack)))
+            PtDebugPrint("xStandardDoor: New list is: %s" % (str(self.DoorStack)))
 
             if len(self.DoorStack) == 1:
-                print("xStandardDoor: List is only one command long, so I'm playing it")
+                PtDebugPrint("xStandardDoor: List is only one command long, so I'm playing it")
                 code = self.DoorStack[0]
-                print("xStandardDoor: Playing command: %s" % (code))
+                PtDebugPrint("xStandardDoor: Playing command: %s" % (code))
                 self.ExecCode(code)
                 return
 
@@ -331,7 +331,7 @@ class xStandardDoor(ptResponder):
                 actInterior.enable()
 
     def SendNote(self, ExtraInfo, avatar):
-        print("xStandardDoor: Avatar who did this:", avatar)
+        PtDebugPrint("xStandardDoor: Avatar who did this:", avatar)
         if avatar == 0:
             notify = ptNotify(self.key)
             notify.clearReceivers()
@@ -355,11 +355,11 @@ class xStandardDoor(ptResponder):
     def UpdateRespStack (self):
         #Updates the Responder List
         old = self.DoorStack.pop(0)
-        print("xStandardDoor: Getting rid of Resp: %s" % (old))
+        PtDebugPrint("xStandardDoor: Getting rid of Resp: %s" % (old))
         if len(self.DoorStack):            
-            print("xStandardDoor: There's at lest one more Resp to play.")
+            PtDebugPrint("xStandardDoor: There's at lest one more Resp to play.")
             code = self.DoorStack[0]            
-            print("Playing command: %s" % (code))
+            PtDebugPrint("Playing command: %s" % (code))
             self.ExecCode(code)
 
     def ExecCode (self, code):
@@ -379,7 +379,7 @@ class xStandardDoor(ptResponder):
                 elif tag == "fastforward":
                     respCloseExt.run(self.key,avatar=ptSceneobject(PtGetAvatarKeyFromClientID(playerId),self.key),fastforward=1,netPropagate=0)
                 else:
-                    print("xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
+                    PtDebugPrint("xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
                     self.DoorStack.pop(0)
             else:
                 if tag == "fromOutside":
@@ -387,8 +387,8 @@ class xStandardDoor(ptResponder):
                 elif tag == "fromInside" or playerId == 0:
                     respOpenInt.run(self.key,avatar=ptSceneobject(PtGetAvatarKeyFromClientID(playerId),self.key),fastforward=fastForward,netPropagate=0)
                 else:
-                    print("xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
+                    PtDebugPrint("xStandardDoor.ExecCode(): ERROR! Invalid tag '%s'." % (tag))
                     self.DoorStack.pop(0)
         except:
-            print("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
+            PtDebugPrint("xStandardDoor.ExecCode(): ERROR! Invalid code '%s'." % (code))
             self.DoorStack.pop(0)

--- a/Python/xStarTrekDoor.py
+++ b/Python/xStarTrekDoor.py
@@ -72,7 +72,7 @@ class xStarTrekDoor(ptModifier):
         
         version = 2
         self.version = version
-        print "__init__xStarTrekDoor v.", version
+        print("__init__xStarTrekDoor v.", version)
 
     def OnFirstUpdate(self):
         pass
@@ -82,7 +82,7 @@ class xStarTrekDoor(ptModifier):
         global doorCued
         global doorMoving
         global doorState
-        print doorMoving
+        print(doorMoving)
         if state and id == Activate.id: # and PtWasLocallyNotified(self.key): # region is activated.
 
             for event in events:
@@ -94,13 +94,13 @@ class xStarTrekDoor(ptModifier):
             
             if not doorMoving:
                 self.doorAction()
-                print "door played"
+                print("door played")
             else: # got a command, but door is busy so cue it
                 doorCued=1
-                print "door cued"
+                print("door cued")
         elif state and id == respDoor.id:
             # Callback from door finishing movement
-            print "callbackfromdoor"
+            print("callbackfromdoor")
             doorMoving=0
             if doorCued:
                 doorCued=0
@@ -113,7 +113,7 @@ class xStarTrekDoor(ptModifier):
             doorMoving=1
             doorHistory=doorState
             respDoor.run(self.key,state=doorState)
-            print "Door Begin %s" % doorState
+            print("Door Begin %s" % doorState)
 
 
 

--- a/Python/xStarTrekDoor.py
+++ b/Python/xStarTrekDoor.py
@@ -72,7 +72,7 @@ class xStarTrekDoor(ptModifier):
         
         version = 2
         self.version = version
-        print("__init__xStarTrekDoor v.", version)
+        PtDebugPrint("__init__xStarTrekDoor v.", version)
 
     def OnFirstUpdate(self):
         pass
@@ -82,7 +82,7 @@ class xStarTrekDoor(ptModifier):
         global doorCued
         global doorMoving
         global doorState
-        print(doorMoving)
+        PtDebugPrint(doorMoving)
         if state and id == Activate.id: # and PtWasLocallyNotified(self.key): # region is activated.
 
             for event in events:
@@ -94,13 +94,13 @@ class xStarTrekDoor(ptModifier):
             
             if not doorMoving:
                 self.doorAction()
-                print("door played")
+                PtDebugPrint("door played")
             else: # got a command, but door is busy so cue it
                 doorCued=1
-                print("door cued")
+                PtDebugPrint("door cued")
         elif state and id == respDoor.id:
             # Callback from door finishing movement
-            print("callbackfromdoor")
+            PtDebugPrint("callbackfromdoor")
             doorMoving=0
             if doorCued:
                 doorCued=0
@@ -113,7 +113,7 @@ class xStarTrekDoor(ptModifier):
             doorMoving=1
             doorHistory=doorState
             respDoor.run(self.key,state=doorState)
-            print("Door Begin %s" % doorState)
+            PtDebugPrint("Door Begin %s" % doorState)
 
 
 

--- a/Python/xStateToggler.py
+++ b/Python/xStateToggler.py
@@ -75,11 +75,11 @@ class xStateToggler(ptResponder):
     # hack - remove when clickable state manipulation via responder is persistentified
     def Load(self):
         if self.SDL["enabled"][0]:
-            print "LOAD: enabling clickables"
+            print("LOAD: enabling clickables")
             actClick1.enable()
             actClick2.enable()
         else:
-            print "LOAD: disabling clickables"
+            print("LOAD: disabling clickables")
             actClick1.disable()
             actClick2.disable()
 
@@ -109,14 +109,14 @@ class xStateToggler(ptResponder):
             return
             
         if varState:
-            print "xStateToggler:%s running state true responder" % stringName.value
+            print("xStateToggler:%s running state true responder" % stringName.value)
             respTrue.run(self.key)
             # hack - remove when clickable state manipulation via responder is persistentified
             actClick1.enable()
             actClick2.enable()
             self.SDL["enabled"]=(1,)
         else:
-            print "xStateToggler:%s running state false responder" % stringName.value
+            print("xStateToggler:%s running state false responder" % stringName.value)
             respFalse.run(self.key)
             # hack - remove when clickable state manipulation via responder is persistentified
             actClick1.disable()

--- a/Python/xStateToggler.py
+++ b/Python/xStateToggler.py
@@ -75,19 +75,19 @@ class xStateToggler(ptResponder):
     # hack - remove when clickable state manipulation via responder is persistentified
     def Load(self):
         if self.SDL["enabled"][0]:
-            print("LOAD: enabling clickables")
+            PtDebugPrint("LOAD: enabling clickables")
             actClick1.enable()
             actClick2.enable()
         else:
-            print("LOAD: disabling clickables")
+            PtDebugPrint("LOAD: disabling clickables")
             actClick1.disable()
             actClick2.disable()
 
     def OnNotify(self,state,id,events):
         if not state:
             return
-        #print "xStateToggler:%s got a message!" % stringName.value
-        #print "ID:",id,"EVENTS:",events
+        #PtDebugPrint("xStateToggler:%s got a message!" % stringName.value)
+        #PtDebugPrint("ID:",id,"EVENTS:",events)
         
         if id==actStateChange.id:
             boolVariableEvent = False
@@ -95,7 +95,7 @@ class xStateToggler(ptResponder):
                 if event[0] == kVariableEvent:
                     varName = event[1]
                     varState = event[3]
-                    #print "xStateToggler got message name:", varName, " state:", varState
+                    #PtDebugPrint("xStateToggler got message name:", varName, " state:", varState)
                     boolVariableEvent = True
                     break
             if not boolVariableEvent:
@@ -109,14 +109,14 @@ class xStateToggler(ptResponder):
             return
             
         if varState:
-            print("xStateToggler:%s running state true responder" % stringName.value)
+            PtDebugPrint("xStateToggler:%s running state true responder" % stringName.value)
             respTrue.run(self.key)
             # hack - remove when clickable state manipulation via responder is persistentified
             actClick1.enable()
             actClick2.enable()
             self.SDL["enabled"]=(1,)
         else:
-            print("xStateToggler:%s running state false responder" % stringName.value)
+            PtDebugPrint("xStateToggler:%s running state false responder" % stringName.value)
             respFalse.run(self.key)
             # hack - remove when clickable state manipulation via responder is persistentified
             actClick1.disable()

--- a/Python/xTakableClothing.py
+++ b/Python/xTakableClothing.py
@@ -280,19 +280,19 @@ class xTakableClothing(ptModifier):
     
     def IRemoveOtherGuildShirt (self):
         playerCNode = ptVault().getAvatarClosetFolder()
-        print "xTakableClothing: getAvatarClosetFolder Type = " + str(playerCNode.getType())
-        print "xTakableClothing: getAvatarClosetFolder Child Node Count = " + str(playerCNode.getChildNodeCount())
+        print("xTakableClothing: getAvatarClosetFolder Type = " + str(playerCNode.getType()))
+        print("xTakableClothing: getAvatarClosetFolder Child Node Count = " + str(playerCNode.getChildNodeCount()))
         if playerCNode.getChildNodeCount() > 0:
             playerCNodeList = playerCNode.getChildNodeRefList()
             for folderChild in playerCNodeList:
                 PtDebugPrint("xTakableClothing: looking at child node " + str(folderChild),level=kDebugDumpLevel)
                 childNode = folderChild.getChild()
                 if childNode != type(None):
-                    print "xTakableClothing: Child Node Node ID"
+                    print("xTakableClothing: Child Node Node ID")
                     SDLNode = childNode.upcastToSDLNode()
                     if SDLNode is not None:
                         rec = SDLNode.getStateDataRecord()
-                        print "xTakableClothing: getStateDataRecord().getName(): " + str(rec.getName())
+                        print("xTakableClothing: getStateDataRecord().getName(): " + str(rec.getName()))
                         SDLVarList = rec.getVarList()
                         for var in SDLVarList:
                             varnode = rec.findVar(var)
@@ -300,13 +300,13 @@ class xTakableClothing(ptModifier):
                                 if varnode.getType() == 4:
                                     varKey = varnode.getKey()
                                     varName = varKey.getName()
-                                    print "xTakableClothing: VarNode.getName(): ", varName
+                                    print("xTakableClothing: VarNode.getName(): ", varName)
                                     if varName.find('Torso_GuildBlue') != -1 or varName.find('Torso_GuildGreen') != -1 or varName.find('Torso_GuildRed') != -1 or varName.find('Torso_GuildYellow') != -1 or varName.find('Torso_GuildWhite') !=  -1:
-                                        print "xTakableClothing: Found Other Guild Shirt. Deleting Old Guild Shirt."
+                                        print("xTakableClothing: Found Other Guild Shirt. Deleting Old Guild Shirt.")
                                         if playerCNode.removeNode(childNode):
-                                            print "xTakableClothing: Delete was a success."
+                                            print("xTakableClothing: Delete was a success.")
                                         else:
-                                            print "xTakableClothing: Delete failed."
+                                            print("xTakableClothing: Delete failed.")
                                         return
 
     def IRemoveWornSet(self,setName):
@@ -366,7 +366,7 @@ class xTakableClothing(ptModifier):
                     self.IRemoveOtherGuildShirt()
                     psnlSDL = xPsnlVaultSDL()
                     psnlSDL["guildAlliance"] = (guildSDLValues[base],)
-                    print "xTakableClothing: Guild set to:", guildSDLValues[base]
+                    print("xTakableClothing: Guild set to:", guildSDLValues[base])
                 avatar.avatar.addWardrobeClothingItem(base,ptColor().white(),ptColor().white())
                 acclist = avatar.avatar.getClosetClothingList(kAccessoryClothingItem)
                 accnamelist = []

--- a/Python/xTakableClothing.py
+++ b/Python/xTakableClothing.py
@@ -280,19 +280,19 @@ class xTakableClothing(ptModifier):
     
     def IRemoveOtherGuildShirt (self):
         playerCNode = ptVault().getAvatarClosetFolder()
-        print("xTakableClothing: getAvatarClosetFolder Type = " + str(playerCNode.getType()))
-        print("xTakableClothing: getAvatarClosetFolder Child Node Count = " + str(playerCNode.getChildNodeCount()))
+        PtDebugPrint("xTakableClothing: getAvatarClosetFolder Type = " + str(playerCNode.getType()))
+        PtDebugPrint("xTakableClothing: getAvatarClosetFolder Child Node Count = " + str(playerCNode.getChildNodeCount()))
         if playerCNode.getChildNodeCount() > 0:
             playerCNodeList = playerCNode.getChildNodeRefList()
             for folderChild in playerCNodeList:
                 PtDebugPrint("xTakableClothing: looking at child node " + str(folderChild),level=kDebugDumpLevel)
                 childNode = folderChild.getChild()
                 if childNode != type(None):
-                    print("xTakableClothing: Child Node Node ID")
+                    PtDebugPrint("xTakableClothing: Child Node Node ID")
                     SDLNode = childNode.upcastToSDLNode()
                     if SDLNode is not None:
                         rec = SDLNode.getStateDataRecord()
-                        print("xTakableClothing: getStateDataRecord().getName(): " + str(rec.getName()))
+                        PtDebugPrint("xTakableClothing: getStateDataRecord().getName(): " + str(rec.getName()))
                         SDLVarList = rec.getVarList()
                         for var in SDLVarList:
                             varnode = rec.findVar(var)
@@ -300,13 +300,13 @@ class xTakableClothing(ptModifier):
                                 if varnode.getType() == 4:
                                     varKey = varnode.getKey()
                                     varName = varKey.getName()
-                                    print("xTakableClothing: VarNode.getName(): ", varName)
+                                    PtDebugPrint("xTakableClothing: VarNode.getName(): ", varName)
                                     if varName.find('Torso_GuildBlue') != -1 or varName.find('Torso_GuildGreen') != -1 or varName.find('Torso_GuildRed') != -1 or varName.find('Torso_GuildYellow') != -1 or varName.find('Torso_GuildWhite') !=  -1:
-                                        print("xTakableClothing: Found Other Guild Shirt. Deleting Old Guild Shirt.")
+                                        PtDebugPrint("xTakableClothing: Found Other Guild Shirt. Deleting Old Guild Shirt.")
                                         if playerCNode.removeNode(childNode):
-                                            print("xTakableClothing: Delete was a success.")
+                                            PtDebugPrint("xTakableClothing: Delete was a success.")
                                         else:
-                                            print("xTakableClothing: Delete failed.")
+                                            PtDebugPrint("xTakableClothing: Delete failed.")
                                         return
 
     def IRemoveWornSet(self,setName):
@@ -366,7 +366,7 @@ class xTakableClothing(ptModifier):
                     self.IRemoveOtherGuildShirt()
                     psnlSDL = xPsnlVaultSDL()
                     psnlSDL["guildAlliance"] = (guildSDLValues[base],)
-                    print("xTakableClothing: Guild set to:", guildSDLValues[base])
+                    PtDebugPrint("xTakableClothing: Guild set to:", guildSDLValues[base])
                 avatar.avatar.addWardrobeClothingItem(base,ptColor().white(),ptColor().white())
                 acclist = avatar.avatar.getClosetClothingList(kAccessoryClothingItem)
                 accnamelist = []

--- a/Python/xYeeshaPages.py
+++ b/Python/xYeeshaPages.py
@@ -111,7 +111,7 @@ class xYeeshaPages(ptModifier):
         self.id = 5225
         version = 6
         self.version = version
-        print("__init__xYeeshaPages v.", version)
+        PtDebugPrint("__init__xYeeshaPages v.", version)
 
 
     def OnFirstUpdate(self):
@@ -153,7 +153,7 @@ class xYeeshaPages(ptModifier):
             btnID = control.getTagID()
 
         if event == 2 and btnID in YeeshaPageIDList:
-            print("xYeeshaPages.OnGUINotify():\tPicked up page number: ", PageNumber.value)
+            PtDebugPrint("xYeeshaPages.OnGUINotify():\tPicked up page number: ", PageNumber.value)
 #            PtUnloadDialog(DialogName)
             PtHideDialog(DialogName)
             
@@ -202,7 +202,7 @@ class xYeeshaPages(ptModifier):
         mydialog = PtGetDialogFromString(DialogName)
 
         #first hide them all
-#        print "PageNumber = ", PageNumber.value
+#        PtDebugPrint("PageNumber = ", PageNumber.value)
         ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage01)).hide()
         ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage02)).hide()
         ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage03)).hide() 
@@ -280,14 +280,14 @@ class xYeeshaPages(ptModifier):
 
 
         else:
-            print("xYeeshaPages.IDrawLinkPanel():\tERROR: couldn't find page named ",PageNumber.value)
+            PtDebugPrint("xYeeshaPages.IDrawLinkPanel():\tERROR: couldn't find page named ",PageNumber.value)
         return
 
 #
 #    def OnTimer(self,id):
 #        if id == kStartFadeoutID:
 #            PtFadeOut(kFadeOutSecs,1)
-#            print "\txYeeshaPages.OnTimer(): Linking the player from Cleft to Relto.  FadeOut over", kFadeOutSecs," seconds."
+#            PtDebugPrint("\txYeeshaPages.OnTimer(): Linking the player from Cleft to Relto.  FadeOut over", kFadeOutSecs," seconds.")
 #            PtAtTimeCallback(self.key,kReltoLinkSecs,kReltoLinkID)
 #        elif id == kReltoLinkID:  
 #            #link back to Relto now

--- a/Python/xYeeshaPages.py
+++ b/Python/xYeeshaPages.py
@@ -111,7 +111,7 @@ class xYeeshaPages(ptModifier):
         self.id = 5225
         version = 6
         self.version = version
-        print "__init__xYeeshaPages v.", version
+        print("__init__xYeeshaPages v.", version)
 
 
     def OnFirstUpdate(self):
@@ -153,7 +153,7 @@ class xYeeshaPages(ptModifier):
             btnID = control.getTagID()
 
         if event == 2 and btnID in YeeshaPageIDList:
-            print "xYeeshaPages.OnGUINotify():\tPicked up page number: ", PageNumber.value
+            print("xYeeshaPages.OnGUINotify():\tPicked up page number: ", PageNumber.value)
 #            PtUnloadDialog(DialogName)
             PtHideDialog(DialogName)
             
@@ -280,7 +280,7 @@ class xYeeshaPages(ptModifier):
 
 
         else:
-            print "xYeeshaPages.IDrawLinkPanel():\tERROR: couldn't find page named ",PageNumber.value
+            print("xYeeshaPages.IDrawLinkPanel():\tERROR: couldn't find page named ",PageNumber.value)
         return
 
 #


### PR DESCRIPTION
Run those 2to3 fixers which should be safe. Additionally, change `print` calls to `PtDebugPrint`.

Included fixers: `print`, `exec`, `import`, `has_key`, `repr`, `funcattrs`, `raise`, `except`.

Excluded fixers and reasons. Links to commits which apply the fix.
- [unicode](https://github.com/aqua-uru/moul-scripts/commit/e319e6339d94a555a67150fe12b9582efdcc29e1): scary string handling changes
- [dict](https://github.com/aqua-uru/moul-scripts/commit/3a46884ef0ebc5cf5f497ccfad4b85516fe05b87), [xrange](https://github.com/aqua-uru/moul-scripts/commit/352ae9910e7e417d50683aae3725b00f6792849c): changes behaviour (list vs generators) so should only happen when switching to py3. Also generators should be introduced in the py2 code.
- [imports](https://github.com/aqua-uru/moul-scripts/commit/6f87c0d83e66206a83a42eda35e2425f4a7c59df): changes `cPickle` to `pickle` which in py2 is a speed difference.
- [long](https://github.com/aqua-uru/moul-scripts/commit/bcdcf174b1329fed43417d73ff2420d59df50f70): scary type handling changes
- [metaclass](https://github.com/aqua-uru/moul-scripts/commit/ac745bd82c22f6a8e208d2fb57813e63d5efb097): creates non-py2 code.

The system/ directory is excluded from changes.