### PR TITLE
replace `type(x) == y` checks by `isinstance(x, y)` and clean up resulting code

### DIFF
--- a/Python/BaronCityOffice.py
+++ b/Python/BaronCityOffice.py
@@ -63,9 +63,9 @@ class BaronCityOffice(ptResponder):
         #~ kChronicleVarName = "LinksIntoGarden"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/Cleft.py
+++ b/Python/Cleft.py
@@ -86,18 +86,18 @@ class Cleft(ptResponder):
 
         vault = ptVault()
         entryCleft = vault.findChronicleEntry("CleftSolved")
-        if type(entryCleft) != type(None):
+        if entryCleft is not None:
             entryCleftValue = entryCleft.chronicleGetValue()
             if entryCleftValue != "yes":
                 loadZandi = 1
                 loadBook = 1
-        elif type(entryCleft) == type(None):
+        elif entryCleft is None:
             loadZandi = 1
             loadBook = 1
 
         vault = ptVault()
         entryTomahna = vault.findChronicleEntry("TomahnaLoad")
-        if type(entryTomahna) != type(None):
+        if entryTomahna is not None:
             entryTomahnaValue = entryTomahna.chronicleGetValue()
             if entryTomahnaValue == "yes":
                 loadTomahna = 1
@@ -151,7 +151,7 @@ class Cleft(ptResponder):
         #~ # test for first time to play the intro movie
         #~ vault = ptVault()
         #~ entry = vault.findChronicleEntry(kIntroPlayedChronicle)
-        #~ if type(entry) != type(None):
+        #~ if entry is not None:
             #~ # already played intro sometime in the past... just let 'em play
             #~ PtSendKIMessage(kEnableKIandBB,0)
         #~ else:

--- a/Python/ErcanaCitySilo.py
+++ b/Python/ErcanaCitySilo.py
@@ -100,7 +100,7 @@ class ErcanaCitySilo(ptResponder):
         
         vault = ptVault()
         entry = vault.findChronicleEntry("GotPellet")
-        if type(entry) != type(None):
+        if entry is not None:
             entryValue = entry.chronicleGetValue()
             gotPellet = string.atoi(entryValue)
             if gotPellet != 0:

--- a/Python/Garden.py
+++ b/Python/Garden.py
@@ -63,9 +63,9 @@ class Garden(ptResponder):
         #~ kChronicleVarName = "LinksIntoGarden"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/GardenBugs.py
+++ b/Python/GardenBugs.py
@@ -82,9 +82,9 @@ class GardenBugs(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add chronicle
                 vault.addChronicleEntry(chronicleEntryName,0,str(count))
             else:
@@ -93,9 +93,9 @@ class GardenBugs(ptResponder):
     
     def IGetBugCount(self):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) != type(None):
+            if entry is not None:
                 return int(entry.chronicleGetValue())
         return 0 # no vault or no chronicle var
 

--- a/Python/GardenBugs.py
+++ b/Python/GardenBugs.py
@@ -82,22 +82,20 @@ class GardenBugs(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is None:
-                # not found... add chronicle
-                vault.addChronicleEntry(chronicleEntryName,0,str(count))
-            else:
-                entry.chronicleSetValue(str(count))
-                entry.save()
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is None:
+            # not found... add chronicle
+            vault.addChronicleEntry(chronicleEntryName,0,str(count))
+        else:
+            entry.chronicleSetValue(str(count))
+            entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is not None:
-                return int(entry.chronicleGetValue())
-        return 0 # no vault or no chronicle var
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is not None:
+            return int(entry.chronicleGetValue())
+        return 0 # no chronicle var
 
     def OnServerInitComplete(self):
         self.ageSDL = PtGetAgeSDL()

--- a/Python/Gira.py
+++ b/Python/Gira.py
@@ -62,9 +62,9 @@ class Gira(ptResponder):
         #~ kChronicleVarName = "LinksIntoGarden"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/GiraBugs.py
+++ b/Python/GiraBugs.py
@@ -88,9 +88,9 @@ class GiraBugs(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add chronicle
                 vault.addChronicleEntry(chronicleEntryName,0,str(count))
             else:
@@ -99,9 +99,9 @@ class GiraBugs(ptResponder):
     
     def IGetBugCount(self):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) != type(None):
+            if entry is not None:
                 return int(entry.chronicleGetValue())
         return 0 # no vault or no chronicle var
 

--- a/Python/GiraBugs.py
+++ b/Python/GiraBugs.py
@@ -88,22 +88,20 @@ class GiraBugs(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is None:
-                # not found... add chronicle
-                vault.addChronicleEntry(chronicleEntryName,0,str(count))
-            else:
-                entry.chronicleSetValue(str(count))
-                entry.save()
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is None:
+            # not found... add chronicle
+            vault.addChronicleEntry(chronicleEntryName,0,str(count))
+        else:
+            entry.chronicleSetValue(str(count))
+            entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is not None:
-                return int(entry.chronicleGetValue())
-        return 0 # no vault or no chronicle var
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is not None:
+            return int(entry.chronicleGetValue())
+        return 0 # no chronicle var
 
     def OnServerInitComplete(self):
         avatar = 0

--- a/Python/GiraCave1.py
+++ b/Python/GiraCave1.py
@@ -65,7 +65,7 @@ class GiraCave1(ptResponder):
         self.version = 1
 
     def OnServerInitComplete(self):
-        if isinstance(sdlSolved.value, str) and sdlSolved.value != "":
+        if sdlSolved.value:
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(sdlSolved.value,1,1)
             self.ageSDL.sendToClients(sdlSolved.value)

--- a/Python/GiraCave1.py
+++ b/Python/GiraCave1.py
@@ -65,7 +65,7 @@ class GiraCave1(ptResponder):
         self.version = 1
 
     def OnServerInitComplete(self):
-        if type(sdlSolved.value) == type("") and sdlSolved.value != "":
+        if isinstance(sdlSolved.value, str) and sdlSolved.value != "":
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(sdlSolved.value,1,1)
             self.ageSDL.sendToClients(sdlSolved.value)

--- a/Python/Kadish.py
+++ b/Python/Kadish.py
@@ -63,9 +63,9 @@ class Kadish(ptResponder):
         #~ kChronicleVarName = "LinksIntoGarden"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/Neighborhood.py
+++ b/Python/Neighborhood.py
@@ -63,9 +63,9 @@ class Neighborhood(ptResponder):
         #~ kChronicleVarName = "LinksIntoNeighborhood"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/PelletBahroCave.py
+++ b/Python/PelletBahroCave.py
@@ -156,7 +156,7 @@ class PelletBahroCave(ptResponder):
             lowerCave = 0
             vault = ptVault()
             entry = vault.findChronicleEntry("GotPellet")
-            if type(entry) != type(None):
+            if entry is not None:
                 entryValue = entry.chronicleGetValue()
                 gotPellet = string.atoi(entryValue)
                 if gotPellet != 0:

--- a/Python/Personal.py
+++ b/Python/Personal.py
@@ -91,7 +91,7 @@ class Personal(ptResponder):
         # test for first time to play the intro movie
         vault = ptVault()
         entry = vault.findChronicleEntry(kIntroPlayedChronicle)
-        if type(entry) != type(None):
+        if entry is not None:
             # already played intro sometime in the past... just let 'em play
             # enable twice because if we came from the ACA (closet->ACA->personal) it was disabled twice
             PtSendKIMessage(kEnableKIandBB,0)
@@ -132,9 +132,9 @@ class Personal(ptResponder):
         #~ kChronicleVarName = "LinksIntoPersonalAge"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/Teledahn.py
+++ b/Python/Teledahn.py
@@ -63,9 +63,9 @@ class Teledahn(ptResponder):
         #~ kChronicleVarName = "LinksIntoTeledahn"
         #~ kChronicleVarType = 0
         #~ vault = ptVault()
-        #~ if type(vault) != type(None):
+        #~ if vault is not None:
             #~ entry = vault.findChronicleEntry(kChronicleVarName)
-            #~ if type(entry) == type(None):
+            #~ if entry is None:
                 #~ # not found... add current level chronicle
                 #~ vault.addChronicleEntry(kChronicleVarName,kChronicleVarType,"%d" %(1))
                 #~ PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,kChronicleVarName))

--- a/Python/ahnyVogondolaRideV2.py
+++ b/Python/ahnyVogondolaRideV2.py
@@ -169,7 +169,7 @@ actStopVogSoundBackward.setVisInfo(1, ["Vogondola"])
 def DisableVogControls( enabledControlList ):
     disableControlList = [actVogEjectFront, actVogEjectRear, actVogThrottleF, actVogThrottleB, actVogThrottleRevF, actVogThrottleRevB, actVogDirection, actVogDirectionRev]
 
-    if type(enabledControlList) == type( [] ):
+    if isinstance(enabledControlList, list):
         for control in enabledControlList:
             disableControlList.remove(control)
             control.enable()

--- a/Python/bhroBahroYeeshaCave.py
+++ b/Python/bhroBahroYeeshaCave.py
@@ -161,7 +161,7 @@ class bhroBahroYeeshaCave(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry("BahroCave")
 
-        if type(entry) == type(None):
+        if entry is None:
             PtDebugPrint("DEBUG: bhroBahroYeeshaCave.OnFirstUpdate: Did not find BahroCave chronicle...creating")
             vault.addChronicleEntry("BahroCave",0,"0")
 
@@ -432,7 +432,7 @@ class bhroBahroYeeshaCave(ptModifier):
 
 
     def SetState(self, age, state):
-        if type(state) == type(0):
+        if isinstance(state, int):
             #PtDebugPrint("Setting %s state to %d" % (age, state))
             psnlSDL = xPsnlVaultSDL()
 
@@ -542,7 +542,7 @@ class bhroBahroYeeshaCave(ptModifier):
         self.ageDict[age]['PoleCollider'].value.physics.suppress(1)
         if not fforward:
             vault = ptVault()
-            if type(vault) != type(None): #is the Vault online?
+            if vault is not None: #is the Vault online?
                 psnlSDL = vault.getPsnlAgeSDL()
                 if psnlSDL:
                     ypageSDL = psnlSDL.findVar("YeeshaPage25")
@@ -580,7 +580,7 @@ class bhroBahroYeeshaCave(ptModifier):
 
     def PostJCOneShot(self, age):
         vault = ptVault()
-        if type(vault) != type(None): #is the Vault online?
+        if vault is not None: #is the Vault online?
             psnlSDL = vault.getPsnlAgeSDL()
             if psnlSDL:
                 ypageSDL = psnlSDL.findVar("YeeshaPage25")
@@ -784,7 +784,7 @@ class bhroBahroYeeshaCave(ptModifier):
         print "bhroBahroYeeshaCave.GetAutoStartLevel()"
         vault = ptVault()
         bc = vault.findChronicleEntry("BahroCave")
-        if type(bc) != type(None):
+        if bc is not None:
             val = bc.chronicleGetValue()
             if val == "":
                 return 0
@@ -797,7 +797,7 @@ class bhroBahroYeeshaCave(ptModifier):
     def IncrementAutoStartLevel(self):
         vault = ptVault()
         bc = vault.findChronicleEntry("BahroCave")
-        if type(bc) != type(None):
+        if bc is not None:
             val = bc.chronicleGetValue()
             if val == "":
                 val = 0

--- a/Python/bhroBahroYeeshaCave.py
+++ b/Python/bhroBahroYeeshaCave.py
@@ -542,16 +542,15 @@ class bhroBahroYeeshaCave(ptModifier):
         self.ageDict[age]['PoleCollider'].value.physics.suppress(1)
         if not fforward:
             vault = ptVault()
-            if vault is not None: #is the Vault online?
-                psnlSDL = vault.getPsnlAgeSDL()
-                if psnlSDL:
-                    ypageSDL = psnlSDL.findVar("YeeshaPage25")
-                    if ypageSDL:
-                        size, state = divmod(ypageSDL.getInt(), 10)
-                        print "YeeshaPage25 = ",state
-                        if state == 1:
-                            print "bhroBahroYeeshaCave.DisablePole():  sending the pole and YeeshaPage25 is on!  will do the age's wedge..."
-                            self.DoWedge()
+            psnlSDL = vault.getPsnlAgeSDL()
+            if psnlSDL:
+                ypageSDL = psnlSDL.findVar("YeeshaPage25")
+                if ypageSDL:
+                    size, state = divmod(ypageSDL.getInt(), 10)
+                    print "YeeshaPage25 = ",state
+                    if state == 1:
+                        print "bhroBahroYeeshaCave.DisablePole():  sending the pole and YeeshaPage25 is on!  will do the age's wedge..."
+                        self.DoWedge()
 
 
     def EnablePole(self, age, fforward = 0):
@@ -580,18 +579,17 @@ class bhroBahroYeeshaCave(ptModifier):
 
     def PostJCOneShot(self, age):
         vault = ptVault()
-        if vault is not None: #is the Vault online?
-            psnlSDL = vault.getPsnlAgeSDL()
-            if psnlSDL:
-                ypageSDL = psnlSDL.findVar("YeeshaPage25")
-                if ypageSDL:
-                    size, state = divmod(ypageSDL.getInt(), 10)
-                    print "YeeshaPage25 = ",state
-                    if state != 1:
-                        print "bhroBahroYeeshaCave.PostJCOneShot():  can't send pole to Relto, YeeshaPage25 is off!  Returning the pole..."
-                        self.ageDict[age]['JCClickable'].disable()
-                        self.ageDict[age]['PoleRemove'].run(self.key, state="Reject")
-                        return
+        psnlSDL = vault.getPsnlAgeSDL()
+        if psnlSDL:
+            ypageSDL = psnlSDL.findVar("YeeshaPage25")
+            if ypageSDL:
+                size, state = divmod(ypageSDL.getInt(), 10)
+                print "YeeshaPage25 = ",state
+                if state != 1:
+                    print "bhroBahroYeeshaCave.PostJCOneShot():  can't send pole to Relto, YeeshaPage25 is off!  Returning the pole..."
+                    self.ageDict[age]['JCClickable'].disable()
+                    self.ageDict[age]['PoleRemove'].run(self.key, state="Reject")
+                    return
                     
         self.UpdatePoleStates()
 

--- a/Python/clftGetPersonalBook.py
+++ b/Python/clftGetPersonalBook.py
@@ -94,7 +94,7 @@ class clftGetPersonalBook(ptResponder):
         pass
         #~ vault = ptVault()
         #~ entry = vault.findChronicleEntry("JourneyClothProgress")
-        #~ if type(entry) != type(None):
+        #~ if entry is not None:
             #~ FoundJCs = entry.chronicleGetValue()
             #~ if "Z" in FoundJCs:
                 #~ PtPageOutNode("clftYeeshaBookVis")
@@ -245,7 +245,7 @@ class clftGetPersonalBook(ptResponder):
             gDemoMovie.playPaused()
         elif id == kTrailerFadeInID:
             PtDebugPrint("xLiveTrailer - roll the movie",level=kDebugDumpLevel)
-            if type(gDemoMovie) != type(None):
+            if gDemoMovie is not None:
                 gDemoMovie.resume()
         elif id == kTrailerDoneID:
             print "Quitting demo now..."

--- a/Python/clftImager.py
+++ b/Python/clftImager.py
@@ -592,10 +592,10 @@ class clftImager(ptResponder):
         vault = ptVault()
         
         chron = vault.findChronicleEntry("BahroCave")
-        if type(chron) != type(None):
+        if chron is not None:
             ageChronRefList = chron.getChildNodeRefList()
 
-            if type(ageChronRefList) != type(None):
+            if ageChronRefList is not None:
                 for ageChron in ageChronRefList:
                     ageChild = ageChron.getChild()
 
@@ -637,7 +637,7 @@ class clftImager(ptResponder):
         boolCleftSolved = 0
         vault = ptVault()
         entry = vault.findChronicleEntry("CleftSolved")
-        if type(entry) != type(None):
+        if entry is not None:
             if entry.chronicleGetValue() == "yes":
                 boolCleftSolved = 1
 
@@ -649,7 +649,7 @@ class clftImager(ptResponder):
         
         for age in ["Teledahn", "Garden", "Garrison", "Kadish"]:
             symbol = self.GetAgeSolutionSymbol(age)
-            if type(symbol) == type(""):
+            if isinstance(symbol, str):
                 symbol = int(symbol)
             solutionList.append(symbol)
 
@@ -803,7 +803,7 @@ class clftImager(ptResponder):
         elif PlayFinal == 0 and PlayFull == 1:
             vault = ptVault()
             entry = vault.findChronicleEntry("YeeshaVisionViewed")
-            if type(entry) == type(None):
+            if entry is None:
                 vault.addChronicleEntry("YeeshaVisionViewed", 0, "1")
             else:
                 entry.chronicleSetValue("1")
@@ -894,7 +894,7 @@ class clftImager(ptResponder):
         CityLinks = []
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
-        if type(entryCityLinks) != type(None):
+        if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
             print "valCityLinks = ",valCityLinks
             CityLinks = valCityLinks.split(",")

--- a/Python/clftNpcZandi.py
+++ b/Python/clftNpcZandi.py
@@ -115,14 +115,14 @@ class clftNpcZandi(ptModifier):
 
         vault = ptVault()
         #~ entry = vault.findChronicleEntry("JourneyClothProgress")
-        #~ if type(entry) != type(None):
+        #~ if entry is not None:
             #~ FoundJCs = entry.chronicleGetValue()
             #~ if "Z" in FoundJCs:
                 #~ PtPageOutNode("clftZandiVis")
                 #~ print "Zandi seems to have stepped away from the Airstream. Hmmm..."
 
         entry = vault.findChronicleEntry("YeeshaVisionViewed")
-        if type(entry) == type(None):
+        if entry is None:
             vault.addChronicleEntry("YeeshaVisionViewed", 0, "0")
 
         PtAtTimeCallback(self.key, PageTurnInterval, TimerID.TurnPage)
@@ -184,7 +184,7 @@ class clftNpcZandi(ptModifier):
                 print "doing behavior ", id
                 self.DoingBehavior = 1
                 MultiStage01.gotoStage(self.NpcName, id,dirFlag=1,isForward=1)
-            if type(self.ZandiFace) == type(""):
+            if isinstance(self.ZandiFace, str):
                 print "using zandi face anim:", self.ZandiFace
                 self.NpcName.avatar.playSimpleAnimation(self.ZandiFace)
 
@@ -214,7 +214,7 @@ class clftNpcZandi(ptModifier):
         vault = ptVault()
         chron = vault.findChronicleEntry("JourneyClothProgress")
         jcProgress = ""
-        if not type(chron) == type(None):
+        if not chron is None:
             ageChronRefList = chron.getChildNodeRefList()
             for ageChron in ageChronRefList:
                 ageChild = ageChron.getChild()
@@ -258,7 +258,7 @@ class clftNpcZandi(ptModifier):
         print "in haven't seen imager message"
         vault = ptVault()
         entry = vault.findChronicleEntry("YeeshaVisionViewed")
-        if type(entry) == type(None):
+        if entry is None:
             PtDebugPrint("ERROR: clftNpcZandi.HaventSeenImagerMessage: cannot find YeeshaVisionViewed chronicle entry")
             return 1
 
@@ -275,7 +275,7 @@ class clftNpcZandi(ptModifier):
         
         vault = ptVault()
         entry = vault.findChronicleEntry("ZandiWelcome")
-        if type(entry) == type(None):
+        if entry is None:
             if not clicked:
                 vault.addChronicleEntry("ZandiWelcome", 0, "1")
             return 1

--- a/Python/clftRS.py
+++ b/Python/clftRS.py
@@ -120,7 +120,7 @@ class clftRS(ptModifier):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtLoadDialog(Vignette.value,self.key)
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -134,7 +134,7 @@ class clftRS(ptModifier):
 
         Telescope.popTelescope()
         # exit every thing
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtHideDialog(Vignette.value)
         virtCam = ptCamera()
         virtCam.restore(Camera.sceneobject.getKey())

--- a/Python/clftRS.py
+++ b/Python/clftRS.py
@@ -120,7 +120,7 @@ class clftRS(ptModifier):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtLoadDialog(Vignette.value,self.key)
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -134,7 +134,7 @@ class clftRS(ptModifier):
 
         Telescope.popTelescope()
         # exit every thing
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtHideDialog(Vignette.value)
         virtCam = ptCamera()
         virtCam.restore(Camera.sceneobject.getKey())

--- a/Python/clftWindmill.py
+++ b/Python/clftWindmill.py
@@ -99,14 +99,14 @@ class clftWindmill(ptResponder):
         global windmillUnstuck
         global boolTomahnaActive
         
-        if type(stringSDLVarLocked.value) == type("") and stringSDLVarLocked.value != "":
+        if isinstance(stringSDLVarLocked.value, str) and stringSDLVarLocked.value != "":
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(stringSDLVarLocked.value,1,1)
             self.ageSDL.sendToClients(stringSDLVarLocked.value)
         else:
             PtDebugPrint("clftWindmill.OnFirstUpdate():\tERROR: missing SDL var locked in max file")
 
-        if type(stringSDLVarRunning.value) == type("") and stringSDLVarRunning.value != "":
+        if isinstance(stringSDLVarRunning.value, str) and stringSDLVarRunning.value != "":
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(stringSDLVarRunning.value,1,1)
             self.ageSDL.sendToClients(stringSDLVarRunning.value)
@@ -116,7 +116,7 @@ class clftWindmill(ptResponder):
         respLightsOnOff.run(self.key,state='Off')
         respImagerButtonLight.run(self.key,state='Off')
 
-        if type(stringSDLVarUnstuck.value) == type("") and stringSDLVarUnstuck.value != "":
+        if isinstance(stringSDLVarUnstuck.value, str) and stringSDLVarUnstuck.value != "":
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(stringSDLVarUnstuck.value,1,1)
             self.ageSDL.sendToClients(stringSDLVarUnstuck.value)

--- a/Python/clftWindmill.py
+++ b/Python/clftWindmill.py
@@ -99,14 +99,14 @@ class clftWindmill(ptResponder):
         global windmillUnstuck
         global boolTomahnaActive
         
-        if isinstance(stringSDLVarLocked.value, str) and stringSDLVarLocked.value != "":
+        if stringSDLVarLocked.value:
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(stringSDLVarLocked.value,1,1)
             self.ageSDL.sendToClients(stringSDLVarLocked.value)
         else:
             PtDebugPrint("clftWindmill.OnFirstUpdate():\tERROR: missing SDL var locked in max file")
 
-        if isinstance(stringSDLVarRunning.value, str) and stringSDLVarRunning.value != "":
+        if stringSDLVarRunning.value:
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(stringSDLVarRunning.value,1,1)
             self.ageSDL.sendToClients(stringSDLVarRunning.value)
@@ -116,7 +116,7 @@ class clftWindmill(ptResponder):
         respLightsOnOff.run(self.key,state='Off')
         respImagerButtonLight.run(self.key,state='Off')
 
-        if isinstance(stringSDLVarUnstuck.value, str) and stringSDLVarUnstuck.value != "":
+        if stringSDLVarUnstuck.value:
             self.ageSDL = PtGetAgeSDL()
             self.ageSDL.setFlags(stringSDLVarUnstuck.value,1,1)
             self.ageSDL.sendToClients(stringSDLVarUnstuck.value)

--- a/Python/clftYeeshaPage08.py
+++ b/Python/clftYeeshaPage08.py
@@ -167,16 +167,15 @@ class clftYeeshaPage08(ptModifier):
             else:
                 PtDebugPrint ("DEBUG: clftYeeshaPage08.py: Yeesha Page #8 is new to you.")       
                 PtDebugPrint ("DEBUG: clftYeeshaPage08.py: Trying to update the value of the SDL variable %s to 1" % ("YeeshaPage8"))
-                vault = ptVault()
-                if vault is not None: #is the Vault online?    
-                    psnlSDL = vault.getPsnlAgeSDL()
-                    if psnlSDL:
-                        YeeshaPageVar = psnlSDL.findVar("YeeshaPage8")    
-                        YeeshaPageVar.setInt(1)
-                        vault.updatePsnlAgeSDL (psnlSDL)
-                        mydialog = PtGetDialogFromString(DialogName)
-                        ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage08)).disable()
-                        PtSendKIMessageInt(kStartBookAlert,0)
+                vault = ptVault()  
+                psnlSDL = vault.getPsnlAgeSDL()
+                if psnlSDL:
+                    YeeshaPageVar = psnlSDL.findVar("YeeshaPage8")    
+                    YeeshaPageVar.setInt(1)
+                    vault.updatePsnlAgeSDL (psnlSDL)
+                    mydialog = PtGetDialogFromString(DialogName)
+                    ptGUIControlButton(mydialog.getControlFromTag(kYeeshaPage08)).disable()
+                    PtSendKIMessageInt(kStartBookAlert,0)
 
         elif event == kAction and btnID == kYeeshaPageCancel:
             RespClose.run(self.key)
@@ -186,22 +185,18 @@ class clftYeeshaPage08(ptModifier):
 
 
     def GotPage(self):
-        vault = ptVault()
-        if vault is not None: #is the Vault online?    
-            psnlSDL = vault.getPsnlAgeSDL()
-            if psnlSDL:
-                YeeshaPageVar = psnlSDL.findVar("YeeshaPage8")    
-                PtDebugPrint ("DEBUG: clftYeeshaPage08.py: The previous value of the SDL variable %s is %s" % ("YeeshaPage8", YeeshaPageVar.getInt()))
-                if YeeshaPageVar.getInt() != 0: 
-                    PtDebugPrint ("DEBUG: clftYeeshaPage08.py: You've already found Yeesha Page #8. Move along. Move along.")
-                    return 1
-                else:
-                    return 0
+        vault = ptVault()  
+        psnlSDL = vault.getPsnlAgeSDL()
+        if psnlSDL:
+            YeeshaPageVar = psnlSDL.findVar("YeeshaPage8")    
+            PtDebugPrint ("DEBUG: clftYeeshaPage08.py: The previous value of the SDL variable %s is %s" % ("YeeshaPage8", YeeshaPageVar.getInt()))
+            if YeeshaPageVar.getInt() != 0: 
+                PtDebugPrint ("DEBUG: clftYeeshaPage08.py: You've already found Yeesha Page #8. Move along. Move along.")
+                return 1
             else:
-                PtDebugPrint("ERROR: clftYeeshaPage08: Error trying to access the Chronicle psnlSDL. psnlSDL = %s" % ( psnlSDL))
                 return 0
         else:
-            PtDebugPrint("ERROR: clftYeeshaPage08: Error trying to access the Vault. Can't access YeeshaPageChanges chronicle." )
+            PtDebugPrint("ERROR: clftYeeshaPage08: Error trying to access the Chronicle psnlSDL. psnlSDL = %s" % ( psnlSDL))
             return 0
 
 

--- a/Python/clftYeeshaPage08.py
+++ b/Python/clftYeeshaPage08.py
@@ -168,7 +168,7 @@ class clftYeeshaPage08(ptModifier):
                 PtDebugPrint ("DEBUG: clftYeeshaPage08.py: Yeesha Page #8 is new to you.")       
                 PtDebugPrint ("DEBUG: clftYeeshaPage08.py: Trying to update the value of the SDL variable %s to 1" % ("YeeshaPage8"))
                 vault = ptVault()
-                if type(vault) != type(None): #is the Vault online?    
+                if vault is not None: #is the Vault online?    
                     psnlSDL = vault.getPsnlAgeSDL()
                     if psnlSDL:
                         YeeshaPageVar = psnlSDL.findVar("YeeshaPage8")    
@@ -187,7 +187,7 @@ class clftYeeshaPage08(ptModifier):
 
     def GotPage(self):
         vault = ptVault()
-        if type(vault) != type(None): #is the Vault online?    
+        if vault is not None: #is the Vault online?    
             psnlSDL = vault.getPsnlAgeSDL()
             if psnlSDL:
                 YeeshaPageVar = psnlSDL.findVar("YeeshaPage8")    

--- a/Python/dsntKILightMachine.py
+++ b/Python/dsntKILightMachine.py
@@ -181,7 +181,7 @@ class dsntKILightMachine(ptModifier):
     def SetKILightChron(self,remaining):
         vault = ptVault()
         entry = vault.findChronicleEntry("KILightStop")
-        if type(entry) != type(None):
+        if entry is not None:
             entryValue = entry.chronicleGetValue()
             oldVal = string.atoi(entryValue)
             if remaining == oldVal:

--- a/Python/ercaCallCar.py
+++ b/Python/ercaCallCar.py
@@ -93,13 +93,13 @@ class ercaCallCar(ptResponder):
         
         if AgeStartedIn == PtGetAgeName():
             
-            if isinstance(SDLCarPos.value, str) and SDLCarPos.value != "":
+            if SDLCarPos.value:
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setFlags(SDLCarPos.value,1,1)
                 ageSDL.sendToClients(SDLCarPos.value)
             else:
                 PtDebugPrint("ERROR: ercaCallCar.OnFirstUpdate():\tERROR: missing SDL var name")
-            if isinstance(SDLCarLev.value, str) and SDLCarLev.value != "":
+            if SDLCarLev.value:
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setFlags(SDLCarLev.value,1,1)
                 ageSDL.sendToClients(SDLCarLev.value)

--- a/Python/ercaCallCar.py
+++ b/Python/ercaCallCar.py
@@ -93,13 +93,13 @@ class ercaCallCar(ptResponder):
         
         if AgeStartedIn == PtGetAgeName():
             
-            if type(SDLCarPos.value) == type("") and SDLCarPos.value != "":
+            if isinstance(SDLCarPos.value, str) and SDLCarPos.value != "":
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setFlags(SDLCarPos.value,1,1)
                 ageSDL.sendToClients(SDLCarPos.value)
             else:
                 PtDebugPrint("ERROR: ercaCallCar.OnFirstUpdate():\tERROR: missing SDL var name")
-            if type(SDLCarLev.value) == type("") and SDLCarLev.value != "":
+            if isinstance(SDLCarLev.value, str) and SDLCarLev.value != "":
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setFlags(SDLCarLev.value,1,1)
                 ageSDL.sendToClients(SDLCarLev.value)

--- a/Python/ercaLadderHatch.py
+++ b/Python/ercaLadderHatch.py
@@ -154,7 +154,7 @@ class ercaLadderHatch(ptResponder):
         for event in events:
         # multistage callback from stage 2 send when advancing
             if event[0] == kMultiStageEvent:
-                if type(LocalAvatar) == type(None):
+                if LocalAvatar is None:
                     return
                 if PtFindAvatar(events) == LocalAvatar:
                     

--- a/Python/ercaOvenScope.py
+++ b/Python/ercaOvenScope.py
@@ -202,7 +202,7 @@ class ercaOvenScope(ptModifier):
         byteAmount = ageSDL[amountSDL][0]
         byteTemp = ageSDL[tempSDL][0]
 
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtLoadDialog(Vignette.value,self.key)
 
 
@@ -452,7 +452,7 @@ class ercaOvenScope(ptModifier):
                     bakeBtn.enable()
 
         elif event == kValueChanged:
-            if type(control) != type(None):
+            if control is not None:
                 knobID = control.getTagID()
                 if knobID == kTimeSlider:
                     newVal = int(round(timeSlider.getValue()))
@@ -468,7 +468,7 @@ class ercaOvenScope(ptModifier):
                         ageSDL[tempSDL] = (newVal,)
         
         elif event == kAction:
-            if type(control) != type(None):
+            if control is not None:
                 btnID = control.getTagID()
                 if btnID == kBakeBtn:
                     if isinstance(control,ptGUIControlButton) and control.isButtonDown():
@@ -561,7 +561,7 @@ class ercaOvenScope(ptModifier):
             WasPowered = 0
             virtCam.save(CameraBad.sceneobject.getKey())
             # show the cockpit
-            if type(VignetteBad.value) != type(None) and VignetteBad.value != "":
+            if VignetteBad.value is not None and VignetteBad.value != "":
                 PtLoadDialog(VignetteBad.value,self.key)
                 if ( PtIsDialogLoaded(VignetteBad.value) ):
                     PtShowDialog(VignetteBad.value)
@@ -585,7 +585,7 @@ class ercaOvenScope(ptModifier):
         # exit every thing
         
         if WasPowered:
-            if type(Vignette.value) != type(None) and Vignette.value != "":
+            if Vignette.value is not None and Vignette.value != "":
                 PtHideDialog(Vignette.value)
             virtCam = ptCamera()
             virtCam.restore(Camera.sceneobject.getKey())
@@ -593,7 +593,7 @@ class ercaOvenScope(ptModifier):
             RespSfxTimerWheel.run(self.key,state="off")
             tempWheel.setValue(0)
         else:
-            if type(VignetteBad.value) != type(None) and VignetteBad.value != "":
+            if VignetteBad.value is not None and VignetteBad.value != "":
                 PtHideDialog(VignetteBad.value)
             virtCam = ptCamera()
             virtCam.restore(CameraBad.sceneobject.getKey())

--- a/Python/ercaOvenScope.py
+++ b/Python/ercaOvenScope.py
@@ -202,7 +202,7 @@ class ercaOvenScope(ptModifier):
         byteAmount = ageSDL[amountSDL][0]
         byteTemp = ageSDL[tempSDL][0]
 
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtLoadDialog(Vignette.value,self.key)
 
 
@@ -561,7 +561,7 @@ class ercaOvenScope(ptModifier):
             WasPowered = 0
             virtCam.save(CameraBad.sceneobject.getKey())
             # show the cockpit
-            if VignetteBad.value is not None and VignetteBad.value != "":
+            if VignetteBad.value:
                 PtLoadDialog(VignetteBad.value,self.key)
                 if ( PtIsDialogLoaded(VignetteBad.value) ):
                     PtShowDialog(VignetteBad.value)
@@ -585,7 +585,7 @@ class ercaOvenScope(ptModifier):
         # exit every thing
         
         if WasPowered:
-            if Vignette.value is not None and Vignette.value != "":
+            if Vignette.value:
                 PtHideDialog(Vignette.value)
             virtCam = ptCamera()
             virtCam.restore(Camera.sceneobject.getKey())
@@ -593,7 +593,7 @@ class ercaOvenScope(ptModifier):
             RespSfxTimerWheel.run(self.key,state="off")
             tempWheel.setValue(0)
         else:
-            if VignetteBad.value is not None and VignetteBad.value != "":
+            if VignetteBad.value:
                 PtHideDialog(VignetteBad.value)
             virtCam = ptCamera()
             virtCam.restore(CameraBad.sceneobject.getKey())

--- a/Python/ercaPelletRoom.py
+++ b/Python/ercaPelletRoom.py
@@ -154,7 +154,7 @@ class ercaPelletRoom(ptResponder):
 
         vault = ptVault()
         entry = vault.findChronicleEntry("GotPellet")
-        if type(entry) != type(None):
+        if entry is not None:
             entryValue = entry.chronicleGetValue()
             oldGotPellet = string.atoi(entryValue)
             if oldGotPellet != 0:
@@ -550,7 +550,7 @@ class ercaPelletRoom(ptResponder):
             
             vault = ptVault()
             entry = vault.findChronicleEntry("GotPellet")
-            if type(entry) != type(None):
+            if entry is not None:
                 entry.chronicleSetValue("%d" % (Recipe))
                 entry.save()
                 PtDebugPrint("Chronicle entry GotPellet already added, setting to Recipe value of %d" % (Recipe))
@@ -767,7 +767,7 @@ class ercaPelletRoom(ptResponder):
         caveLink.setAgeInfo(caveInfo)
         caveInfo = caveLink.getAgeInfo()
         caveInstance = caveInfo
-        if type(caveInstance) == type(None):
+        if caveInstance is None:
             PtDebugPrint("pellet cave instance is none, aborting link")
             return;
         info = ptAgeInfoStruct()

--- a/Python/ercaSDLIntShowHide.py
+++ b/Python/ercaSDLIntShowHide.py
@@ -72,7 +72,7 @@ class ercaSDLIntShowHide(ptMultiModifier):
 
 
     def OnServerInitComplete(self):
-        if isinstance(stringVarName.value, str) and stringVarName.value != "":
+        if stringVarName.value:
             ageSDL = PtGetAgeSDL()
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)
@@ -89,7 +89,7 @@ class ercaSDLIntShowHide(ptMultiModifier):
         
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 #PtDebugPrint("Setting notify on %s..." % stringVarName.value)
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
                 try:
@@ -137,7 +137,7 @@ class ercaSDLIntShowHide(ptMultiModifier):
         self.sceneobject.physics.suppress(true)
 
     def OnBackdoorMsg(self, target, param):
-        if stringVarName.value is not None and stringVarName.value != "":
+        if stringVarName.value:
             if target == stringVarName.value:
                 if param.lower() in self.enabledStateList:
                     self.DisableObject()

--- a/Python/ercaSDLIntShowHide.py
+++ b/Python/ercaSDLIntShowHide.py
@@ -72,7 +72,7 @@ class ercaSDLIntShowHide(ptMultiModifier):
 
 
     def OnServerInitComplete(self):
-        if type(stringVarName.value) == type("") and stringVarName.value != "":
+        if isinstance(stringVarName.value, str) and stringVarName.value != "":
             ageSDL = PtGetAgeSDL()
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)
@@ -89,7 +89,7 @@ class ercaSDLIntShowHide(ptMultiModifier):
         
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 #PtDebugPrint("Setting notify on %s..." % stringVarName.value)
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
                 try:
@@ -137,7 +137,7 @@ class ercaSDLIntShowHide(ptMultiModifier):
         self.sceneobject.physics.suppress(true)
 
     def OnBackdoorMsg(self, target, param):
-        if type(stringVarName.value) != type(None) and stringVarName.value != "":
+        if stringVarName.value is not None and stringVarName.value != "":
             if target == stringVarName.value:
                 if param.lower() in self.enabledStateList:
                     self.DisableObject()

--- a/Python/grsnPrisonRandomSDLItems.py
+++ b/Python/grsnPrisonRandomSDLItems.py
@@ -154,10 +154,10 @@ class grsnPrisonRandomSDLItems(ptResponder):
         vault = ptVault()
                 
 
-        if type(vault) != type(None): #is the Vault online?
+        if vault is not None: #is the Vault online?
             entry = vault.findChronicleEntry("VisitedGrsnPrison")
             
-            if type(entry) == type(None): 
+            if entry is None: 
                 vault.addChronicleEntry("VisitedGrsnPrison",1,"yes")
                 PtDebugPrint ("grsnPrisonRandomItems: This is your first visit to the Prison. Updated Chronicle.")
                 

--- a/Python/grsnPrisonRandomSDLItems.py
+++ b/Python/grsnPrisonRandomSDLItems.py
@@ -154,28 +154,24 @@ class grsnPrisonRandomSDLItems(ptResponder):
         vault = ptVault()
                 
 
-        if vault is not None: #is the Vault online?
-            entry = vault.findChronicleEntry("VisitedGrsnPrison")
+        entry = vault.findChronicleEntry("VisitedGrsnPrison")
+        
+        if entry is None: 
+            vault.addChronicleEntry("VisitedGrsnPrison",1,"yes")
+            PtDebugPrint ("grsnPrisonRandomItems: This is your first visit to the Prison. Updated Chronicle.")
             
-            if entry is None: 
-                vault.addChronicleEntry("VisitedGrsnPrison",1,"yes")
-                PtDebugPrint ("grsnPrisonRandomItems: This is your first visit to the Prison. Updated Chronicle.")
-                
-            else:
-                PtDebugPrint ("grsnPrisonRandomItems: You've been to the Prison before.")
-                
-                chance = random.random()
-                ageSDL = PtGetAgeSDL()
-                if chance > (1-kChanceOfYP):
-                    ageSDL["grsnYeeshaPage02Vis"] = (1,)
-                    PtDebugPrint ("grsnPrisonRandomItems: A YP is here.")
-                else:
-                    ageSDL["grsnYeeshaPage02Vis"] = (0,)
-                    PtDebugPrint ("grsnPrisonRandomItems: A YP is NOT here.")
-                
-                ageSDL.sendToClients("grsnYeeshaPage02Vis")
-                        
         else:
-            PtDebugPrint("grsnPrisonRandomItems: Error trying to access the Chronicle." )
+            PtDebugPrint ("grsnPrisonRandomItems: You've been to the Prison before.")
+            
+            chance = random.random()
+            ageSDL = PtGetAgeSDL()
+            if chance > (1-kChanceOfYP):
+                ageSDL["grsnYeeshaPage02Vis"] = (1,)
+                PtDebugPrint ("grsnPrisonRandomItems: A YP is here.")
+            else:
+                ageSDL["grsnYeeshaPage02Vis"] = (0,)
+                PtDebugPrint ("grsnPrisonRandomItems: A YP is NOT here.")
+            
+            ageSDL.sendToClients("grsnYeeshaPage02Vis")
 
 

--- a/Python/grtzKIMarkerMachine.py
+++ b/Python/grtzKIMarkerMachine.py
@@ -120,7 +120,7 @@ def ResetMarkerGame():
 
     # First, reset the KI Marker Level
     entry = vault.findChronicleEntry(kChronicleKIMarkerLevel)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("0")
         entry.save()
 
@@ -130,7 +130,7 @@ def ResetMarkerGame():
     # Now reset the chronicle display settings
     resetString = "0 off:off 0:0"
     entry = vault.findChronicleEntry(kChronicleGZGames)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue(resetString)
 
     #Who knows what state we were in so we'll reset the CGZs as well!!!
@@ -149,7 +149,7 @@ def UpdateGZMarkers(markerStatus):
 
     vault = ptVault()
     entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
-    if type(entry) != type(None):
+    if entry is not None:
         markers = entry.chronicleGetValue()
         resetValue = markerStatus * len(markers)
         entry.chronicleSetValue(resetValue)
@@ -227,7 +227,7 @@ class grtzKIMarkerMachine(ptModifier):
                     #Since we're turning on for the first time, we'll enable each marker
                     vault = ptVault()
                     entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
-                    if type(entry) == type(None):
+                    if entry is None:
                         # if there is none, then just add another entry - start off as active
                         markers = kGZMarkerAvailable * kNumGZMarkers
                         vault.addChronicleEntry(kChronicleGZMarkersAquired,kChronicleGZMarkersAquiredType,markers)
@@ -277,7 +277,7 @@ class grtzKIMarkerMachine(ptModifier):
         # is there a chronicle for the GZ games?
         entry = vault.findChronicleEntry(kChronicleGZGames)
         error = 0
-        if type(entry) != type(None):
+        if entry is not None:
             markerGameString = entry.chronicleGetValue()
             args = markerGameString.split()
             
@@ -339,7 +339,7 @@ class grtzKIMarkerMachine(ptModifier):
         # is there a chronicle for the GZ games?
         entry = vault.findChronicleEntry(kChronicleGZGames)
         upstring = "%d %s:%s %d:%d" % (gGZPlaying,gMarkerGottenColor,gMarkerToGetColor,gMarkerGottenNumber,gMarkerToGetNumber)
-        if type(entry) != type(None):
+        if entry is not None:
             entry.chronicleSetValue(upstring)
             entry.save()
         else:
@@ -409,7 +409,7 @@ class grtzKIMarkerMachine(ptModifier):
                 vault = ptVault()
                 # is there a chronicle for the GZ games?
                 entry = vault.findChronicleEntry(kChronicleGZGames)
-                if type(entry) != type(None):
+                if entry is not None:
                     entry.chronicleSetValue("0")
                     entry.save()
                 # they've made it to the next level
@@ -461,7 +461,7 @@ class grtzKIMarkerMachine(ptModifier):
         for content in contents:
             link = content.getChild()
             link = link.upcastToAgeLinkNode()
-            if type(link) != type(None):
+            if link is not None:
                 info = link.getAgeInfo()
             if not info: continue
             ageName = info.getAgeFilename()
@@ -471,7 +471,7 @@ class grtzKIMarkerMachine(ptModifier):
     
     def IGetHoodInfoNode(self):
         link = self.IGetHoodLinkNode()
-        if type(link) == type(None):
+        if link is None:
             return None
         info = link.getAgeInfo()
         return info
@@ -525,7 +525,7 @@ class grtzKIMarkerMachine(ptModifier):
         CityLinks = []
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
-        if type(entryCityLinks) != type(None):
+        if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
             print "valCityLinks = ",valCityLinks
             CityLinks = valCityLinks.split(",")

--- a/Python/islmMemorialImager.py
+++ b/Python/islmMemorialImager.py
@@ -249,7 +249,7 @@ class islmMemorialImager(ptModifier):
             PtDebugPrint("islmMemorialImager: looking at node " + str(child),level=kDebugDumpLevel)
             node = child.getChild()
             folderNode = node.upcastToFolderNode()
-            if type(folderNode) != type(None):
+            if folderNode is not None:
                 PtDebugPrint("islmMemorialImager: node is named %s" % (folderNode.getFolderName()),level=kDebugDumpLevel)
                 if folderNode.getFolderName() == "MemorialImager":
                     folderNodeChildList = folderNode.getChildNodeRefList()
@@ -257,7 +257,7 @@ class islmMemorialImager(ptModifier):
                         PtDebugPrint("islmMemorialImager: looking at child node " + str(folderChild),level=kDebugDumpLevel)
                         childNode = folderChild.getChild()
                         textNode = childNode.upcastToTextNoteNode()
-                        if type(textNode) != type(None):
+                        if textNode is not None:
                             PtDebugPrint("islmMemorialImager: child node is named %s" % (textNode.getTitle()),level=kDebugDumpLevel)
                             if textNode.getTitle() == "MemorialImager":
                                 if textNode.getText() == "":

--- a/Python/islmPodMap.py
+++ b/Python/islmPodMap.py
@@ -81,7 +81,7 @@ class islmPodMap(ptResponder):
     def IGetAgeFilename(self):
         "returns the .age file name of the age"
         ageInfo = PtGetAgeInfo()
-        if type(ageInfo) != type(None):
+        if ageInfo is not None:
             return ageInfo.getAgeFilename()
         else:
             return "GUI" # use default GUI age if we can't find the age name for some reason
@@ -145,7 +145,7 @@ class islmPodMap(ptResponder):
         "Disengage and exit"
         global LocalAvatar
         # exit every thing
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtSendKIMessage(kEnableKIandBB,0)
             PtHideDialog(Vignette.value)
             print "Dialog: %s goes down" % Vignette.value

--- a/Python/islmPodMap.py
+++ b/Python/islmPodMap.py
@@ -145,7 +145,7 @@ class islmPodMap(ptResponder):
         "Disengage and exit"
         global LocalAvatar
         # exit every thing
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtSendKIMessage(kEnableKIandBB,0)
             PtHideDialog(Vignette.value)
             print "Dialog: %s goes down" % Vignette.value

--- a/Python/islmRandomBahroScream.py
+++ b/Python/islmRandomBahroScream.py
@@ -77,7 +77,7 @@ class islmRandomBahroScream(ptModifier):
         global ScreamChanceVar
         
         if AgeStartedIn == PtGetAgeName():
-            if type(strChanceVar.value) == type("") and len(strChanceVar.value) > 0:
+            if isinstance(strChanceVar.value, str) and len(strChanceVar.value) > 0:
                 ScreamChanceVar = strChanceVar.value
             
             PtAtTimeCallback(self.key, 60, TimerID.TurnOn)

--- a/Python/islmRandomBahroScream.py
+++ b/Python/islmRandomBahroScream.py
@@ -77,7 +77,7 @@ class islmRandomBahroScream(ptModifier):
         global ScreamChanceVar
         
         if AgeStartedIn == PtGetAgeName():
-            if isinstance(strChanceVar.value, str) and len(strChanceVar.value) > 0:
+            if strChanceVar.value:
                 ScreamChanceVar = strChanceVar.value
             
             PtAtTimeCallback(self.key, 60, TimerID.TurnOn)

--- a/Python/islmRegisterNexusLink.py
+++ b/Python/islmRegisterNexusLink.py
@@ -98,7 +98,7 @@ class islmRegisterNexusLink(ptModifier):
             if stationName.value == "Kveer":
                 entryName = "GotLinkToKveerPublic"
                 entry = vault.findChronicleEntry(entryName)
-                if type(entry) != type(None):
+                if entry is not None:
                     entryValue = entry.chronicleGetValue()
                     if entryValue != "yes":
                         entry.chronicleSetValue("yes")
@@ -112,7 +112,7 @@ class islmRegisterNexusLink(ptModifier):
                 # just business-as-usual here
                 self.avatar = 0
                 cityLink = vault.getLinkToCity()
-                if type(cityLink) != type(None):
+                if cityLink is not None:
                     if not cityLink.hasSpawnPoint(linkpointName.value):
                         #Display link added message
                         PtDebugPrint( "Nexus Link added message displayed %s,%s" % (stationName.value,linkpointName.value) )

--- a/Python/kemoJourneyClothGate.py
+++ b/Python/kemoJourneyClothGate.py
@@ -100,7 +100,7 @@ class kemoJourneyClothGate(ptResponder):
         global GateCurrentlyClosed
         
         if AgeStartedIn == PtGetAgeName():
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setFlags(stringVarName.value,1,1)
                 ageSDL.sendToClients(stringVarName.value)
@@ -108,7 +108,7 @@ class kemoJourneyClothGate(ptResponder):
                 PtDebugPrint("kemoJourneyClothGate.OnFirstUpdate():\tERROR: missing SDL var name")
 
             ageSDL = PtGetAgeSDL()
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
                 try:
                     GateCurrentlyClosed = ageSDL[stringVarName.value][0]

--- a/Python/kemoJourneyClothGate.py
+++ b/Python/kemoJourneyClothGate.py
@@ -100,7 +100,7 @@ class kemoJourneyClothGate(ptResponder):
         global GateCurrentlyClosed
         
         if AgeStartedIn == PtGetAgeName():
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setFlags(stringVarName.value,1,1)
                 ageSDL.sendToClients(stringVarName.value)
@@ -108,7 +108,7 @@ class kemoJourneyClothGate(ptResponder):
                 PtDebugPrint("kemoJourneyClothGate.OnFirstUpdate():\tERROR: missing SDL var name")
 
             ageSDL = PtGetAgeSDL()
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
                 try:
                     GateCurrentlyClosed = ageSDL[stringVarName.value][0]
@@ -155,7 +155,7 @@ class kemoJourneyClothGate(ptResponder):
             PtDebugPrint ("You're likely to be eaten by a grue...")
             vault = ptVault()
             entry = vault.findChronicleEntry("JourneyClothProgress")
-            if type(entry) != type(None):
+            if entry is not None:
                 FoundJCs = entry.chronicleGetValue()
                 length = len(FoundJCs)
                 PtDebugPrint ("Are you the one? You've found %s Cloths." % (length))
@@ -192,10 +192,10 @@ class kemoJourneyClothGate(ptResponder):
 
         print "You clicked on the Gate"
         vault = ptVault()
-        if type(vault) != type(None): #is the Vault online?
+        if vault is not None: #is the Vault online?
             
             entry = vault.findChronicleEntry("JourneyClothProgress")
-            if type(entry) == type(None): # is this the player's first Journey Cloth?
+            if entry is None: # is this the player's first Journey Cloth?
                 print "No cloths have been found. Get to work!"
             else:
                 FoundJCs = entry.chronicleGetValue()

--- a/Python/kemoJourneyClothGate.py
+++ b/Python/kemoJourneyClothGate.py
@@ -192,44 +192,40 @@ class kemoJourneyClothGate(ptResponder):
 
         print "You clicked on the Gate"
         vault = ptVault()
-        if vault is not None: #is the Vault online?
             
-            entry = vault.findChronicleEntry("JourneyClothProgress")
-            if entry is None: # is this the player's first Journey Cloth?
-                print "No cloths have been found. Get to work!"
-            else:
-                FoundJCs = entry.chronicleGetValue()
-                length = len(FoundJCs)
-                all = len(AllCloths)
-
-                print "You've found the following %d Journey Cloths: %s" % (length, FoundJCs)
-                
-                if length < 0 or length > 11: 
-                    print "xJourneyClothGate: ERROR: Unexpected length value received."
-                    return
-                    
-                if "Z" in FoundJCs:
-                    print "You've been here before, traveller."
-                    PalmGlowStrong.run(self.key)                    
-                    self.ToggleSDL("fromOutside")
-                    return
-
-                for each in FoundJCs:
-                    if each not in AllCloths:
-                        print "Unexpected value among the 10 letters in the Chronicle:", each
-                        return
-
-                if length < all:
-                    print "There are more Cloths out there. Get to work."
-                    PalmGlowWeak.run(self.key)
-                 
-                elif length == all:
-                    print "All expected Cloths were found. Opening Door."
-                    PalmGlowStrong.run(self.key)
-                    self.ToggleSDL("fromOutside")
-           
+        entry = vault.findChronicleEntry("JourneyClothProgress")
+        if entry is None: # is this the player's first Journey Cloth?
+            print "No cloths have been found. Get to work!"
         else:
-            PtDebugPrint("kemoJourneyClothGate: Error trying to access the Vault. Can't access JourneyClothProgress chronicle." )
+            FoundJCs = entry.chronicleGetValue()
+            length = len(FoundJCs)
+            all = len(AllCloths)
+
+            print "You've found the following %d Journey Cloths: %s" % (length, FoundJCs)
+            
+            if length < 0 or length > 11: 
+                print "xJourneyClothGate: ERROR: Unexpected length value received."
+                return
+                
+            if "Z" in FoundJCs:
+                print "You've been here before, traveller."
+                PalmGlowStrong.run(self.key)                    
+                self.ToggleSDL("fromOutside")
+                return
+
+            for each in FoundJCs:
+                if each not in AllCloths:
+                    print "Unexpected value among the 10 letters in the Chronicle:", each
+                    return
+
+            if length < all:
+                print "There are more Cloths out there. Get to work."
+                PalmGlowWeak.run(self.key)
+                
+            elif length == all:
+                print "All expected Cloths were found. Opening Door."
+                PalmGlowStrong.run(self.key)
+                self.ToggleSDL("fromOutside")
 
             
     def ToggleSDL(self,hint):

--- a/Python/kemoStormWaterModifier.py
+++ b/Python/kemoStormWaterModifier.py
@@ -123,10 +123,10 @@ class kemoStormWaterModifier(ptModifier):
 
                     startval = getattr(theWater.waveset, "get" + x[3:])()
 
-                    if isinstance(p, type(ptColor()).red()):
+                    if ifisinstance(p, ptColor):
                         print "\tstartval = " + str( (startval.getRed(), startval.getGreen(), startval.getBlue()) )
                         print "\tsetting to " + str( (p.getRed(), p.getGreen(), p.getBlue()) )
-                    elif isinstance(p, type(ptPoint3())) or isinstance(p, type(ptVector3())):
+                    elif isinstance(p, (ptPoint3, ptVector3)):
                         print "\tstartval = " + str( (startval.getX(), startval.getY(), startval.getZ()) )
                         print "\tsetting to " + str( (p.getX(), p.getY(), p.getZ()) )
                     else:
@@ -137,9 +137,9 @@ class kemoStormWaterModifier(ptModifier):
 
                     endval = getattr(theWater.waveset, "get" + x[3:])()
 
-                    if isinstance(p, type(ptColor()).red()):
+                    if ifisinstance(p, ptColor):
                         print "\tendval = " + str( (endval.getRed(), endval.getGreen(), endval.getBlue()) )
-                    elif isinstance(p, type(ptPoint3())) or isinstance(p, type(ptVector3())):
+                    elif isinstance(p, (ptPoint3, ptVector3)):
                         print "\tendval = " + str( (endval.getX(), endval.getY(), endval.getZ()) )
                     else:
                         print "\tendval = " + str(endval)

--- a/Python/kemoStormWaterModifier.py
+++ b/Python/kemoStormWaterModifier.py
@@ -123,10 +123,10 @@ class kemoStormWaterModifier(ptModifier):
 
                     startval = getattr(theWater.waveset, "get" + x[3:])()
 
-                    if type(p) == type(ptColor().red()):
+                    if isinstance(p, type(ptColor()).red()):
                         print "\tstartval = " + str( (startval.getRed(), startval.getGreen(), startval.getBlue()) )
                         print "\tsetting to " + str( (p.getRed(), p.getGreen(), p.getBlue()) )
-                    elif type(p) == type(ptPoint3()) or type(p) == type(ptVector3()):
+                    elif isinstance(p, type(ptPoint3())) or isinstance(p, type(ptVector3())):
                         print "\tstartval = " + str( (startval.getX(), startval.getY(), startval.getZ()) )
                         print "\tsetting to " + str( (p.getX(), p.getY(), p.getZ()) )
                     else:
@@ -137,9 +137,9 @@ class kemoStormWaterModifier(ptModifier):
 
                     endval = getattr(theWater.waveset, "get" + x[3:])()
 
-                    if type(p) == type(ptColor().red()):
+                    if isinstance(p, type(ptColor()).red()):
                         print "\tendval = " + str( (endval.getRed(), endval.getGreen(), endval.getBlue()) )
-                    elif type(p) == type(ptPoint3()) or type(p) == type(ptVector3()):
+                    elif isinstance(p, type(ptPoint3())) or isinstance(p, type(ptVector3())):
                         print "\tendval = " + str( (endval.getX(), endval.getY(), endval.getZ()) )
                     else:
                         print "\tendval = " + str(endval)

--- a/Python/ki/__init__.py
+++ b/Python/ki/__init__.py
@@ -2354,50 +2354,46 @@ class xKI(ptModifier):
 
         pageDefs = ""
         vault = ptVault()
-        if vault is not None:
-            psnlSDL = vault.getPsnlAgeSDL()
-            if psnlSDL:
-                for SDLVar, page in xLinkingBookDefs.xYeeshaPages:
-                    FoundValue = psnlSDL.findVar(SDLVar)
-                    if FoundValue is not None:
-                        PtDebugPrint(u"xKI.GetYeeshaPageDefs(): The previous value of the SDL variable \"{}\" is {}.".format(SDLVar, FoundValue.getInt()), level=kDebugDumpLevel)
-                        state = FoundValue.getInt() % 10
-                        if state != 0:
-                            active = 1
-                            if state == 2 or state == 3:
-                                active = 0
-                            try:
-                                pageDefs += page % (active)
-                            except LookupError:
-                                pageDefs += "<pb><pb>Bogus page {}".format(SDLVar)
-            else:
-                PtDebugPrint(u"xKI.GetYeeshaPageDefs(): Trying to access the Chronicle psnlSDL failed: psnlSDL = \"{}\".".format(psnlSDL), level=kErrorLevel)
+        psnlSDL = vault.getPsnlAgeSDL()
+        if psnlSDL:
+            for SDLVar, page in xLinkingBookDefs.xYeeshaPages:
+                FoundValue = psnlSDL.findVar(SDLVar)
+                if FoundValue is not None:
+                    PtDebugPrint(u"xKI.GetYeeshaPageDefs(): The previous value of the SDL variable \"{}\" is {}.".format(SDLVar, FoundValue.getInt()), level=kDebugDumpLevel)
+                    state = FoundValue.getInt() % 10
+                    if state != 0:
+                        active = 1
+                        if state == 2 or state == 3:
+                            active = 0
+                        try:
+                            pageDefs += page % (active)
+                        except LookupError:
+                            pageDefs += "<pb><pb>Bogus page {}".format(SDLVar)
         else:
-            PtDebugPrint(u"xKI.GetYeeshaPageDefs(): Trying to access the Vault failed, can't access YeeshaPageChanges Chronicle.", level=kErrorLevel)
+            PtDebugPrint(u"xKI.GetYeeshaPageDefs(): Trying to access the Chronicle psnlSDL failed: psnlSDL = \"{}\".".format(psnlSDL), level=kErrorLevel)
         return pageDefs
 
     ## Turns on and off the Yeesha pages' SDL values.
     def ToggleYeeshaPageSDL(self, varName, on):
         vault = ptVault()
-        if vault is not None:
-            psnlSDL = vault.getPsnlAgeSDL()
-            if psnlSDL:
-                ypageSDL = psnlSDL.findVar(varName)
-                if ypageSDL:
-                    size, state = divmod(ypageSDL.getInt(), 10)
-                    value = None
-                    if state == 1 and not on:
-                        value = 3
-                    elif state == 3 and on:
-                        value = 1
-                    elif state == 2 and on:
-                        value = 4
-                    elif state == 4 and not on:
-                        value = 2
-                    if value is not None:
-                        PtDebugPrint(u"xKI.ToggleYeeshaPageSDL(): Setting {} to {}.".format(varName, value), level=kDebugDumpLevel)
-                        ypageSDL.setInt((size * 10) + value)
-                        vault.updatePsnlAgeSDL(psnlSDL)
+        psnlSDL = vault.getPsnlAgeSDL()
+        if psnlSDL:
+            ypageSDL = psnlSDL.findVar(varName)
+            if ypageSDL:
+                size, state = divmod(ypageSDL.getInt(), 10)
+                value = None
+                if state == 1 and not on:
+                    value = 3
+                elif state == 3 and on:
+                    value = 1
+                elif state == 2 and on:
+                    value = 4
+                elif state == 4 and not on:
+                    value = 2
+                if value is not None:
+                    PtDebugPrint(u"xKI.ToggleYeeshaPageSDL(): Setting {} to {}.".format(varName, value), level=kDebugDumpLevel)
+                    ypageSDL.setInt((size * 10) + value)
+                    vault.updatePsnlAgeSDL(psnlSDL)
 
     #~~~~~~~~~~~#
     # Censoring #

--- a/Python/nb01DRCImager.py
+++ b/Python/nb01DRCImager.py
@@ -99,7 +99,7 @@ class nb01DRCImager(ptModifier):
     #            imagerdevice = device.getChild()
     #            break
         
-    #    if type(imagerdevice) != type(None):
+    #    if imagerdevice is not None:
     #        for node in imagerdevice.getChildNodeRefList():
     #            imagerdevice.removeNode(node.getChild())
     
@@ -124,7 +124,7 @@ class nb01DRCImager(ptModifier):
     
     def SetImage(self,id):
         
-        if type(self.inbox) != type(None):
+        if self.inbox is not None:
             PtDebugPrint("nb01DRCImager.SetImage: inbox %s id = %d" % (self.inbox.folderGetName(),self.inbox.getID()))
             
             if self.number_of_images > 0:
@@ -174,7 +174,7 @@ class nb01DRCImager(ptModifier):
                 
                     folder = self.inbox.getChildNodeRefList()
                     element = folder[self.current_image].getChild()
-                    if type(element) != type(None):
+                    if element is not None:
                         nextID = element.getID()
                     else:
                         nextID = -1

--- a/Python/nb01RegisterNexusLink.py
+++ b/Python/nb01RegisterNexusLink.py
@@ -132,15 +132,15 @@ class nb01RegisterNexusLink(ptModifier):
 #            # player should become registered visitor of this hood
 #            
 #            hoodMgr = ptNeighborhoodMgr()
-#            if type(hoodMgr) == type(None):
+#            if hoodMgr is None:
 #                PtDebugPrint("nb01RegisterNexusLink:\thood manager type is None")
 #                return
 #            ageVault = ptAgeVault()
-#            if type(ageVault) == type(None):
+#            if ageVault is None:
 #                PtDebugPrint("nb01RegisterNexusLink:\tage vault type is None")
 #                return
 #            hoodNode = ageVault.getNeighborhood()
-#            if type(hoodNode) == type(None):
+#            if hoodNode is None:
 #                PtDebugPrint("nb01RegisterNexusLink:\thood node type is None")
 #                return
 #            hoodID = hoodNode.getID()
@@ -153,7 +153,7 @@ class nb01RegisterNexusLink(ptModifier):
 #            # player can choose to join or if declines, becomes visitor as well as prosepective member
 #            joinString = "You have been invited to join our neighborhood.  Would you like to become a member?"
 #            ageVault = ptAgeVault()
-#            if type(ageVault) != type(None):
+#            if ageVault is not None:
 #                hoodNode = ageVault.getNeighborhood()
 #                hoodName = hoodNode.hoodGetTitle()
 #                joinString = "You have been invited to join our neighborhood.  Would you like to become a member of %s?" % hoodName

--- a/Python/nb01UpdateHoodInfoImager.py
+++ b/Python/nb01UpdateHoodInfoImager.py
@@ -178,7 +178,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
         hoodpoints = score.getPoints()
         hoodpelletscore = 0
         deviceInbox = self.IGetDeviceInbox()
-        if type(deviceInbox) != type(None):
+        if deviceInbox is not None:
             items = deviceInbox.getChildNodeRefList()
             for item in items:
                 item = item.getChild()
@@ -204,7 +204,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
 
     def IUpdatePelletScores(self, newplayername, pelletscore):
         deviceInbox = self.IGetDeviceInbox()
-        if type(deviceInbox) != type(None):
+        if deviceInbox is not None:
             pelletscores = None
             items = deviceInbox.getChildNodeRefList()
             for item in items:
@@ -259,7 +259,7 @@ class nb01UpdateHoodInfoImager(ptResponder):
     def ISendNotify(self, receiver, name, value):
         notify = ptNotify(self.key)
         notify.clearReceivers()
-        if type(receiver) == type([]):
+        if isinstance(receiver, list):
             for key in receiver:
                 notify.addReceiver(key)
         else:

--- a/Python/nglnTreeMonkey.py
+++ b/Python/nglnTreeMonkey.py
@@ -234,7 +234,7 @@ class nglnTreeMonkey(ptResponder):
         print "nglnTreeMonkey: Generated a valid spawn time: %d" % (firstTime)
         spawnTimes = [firstTime]
 
-        while type(spawnTimes[-1]) == type(long(1)):
+        while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:

--- a/Python/nglnUrwinBrain.py
+++ b/Python/nglnUrwinBrain.py
@@ -325,7 +325,7 @@ class nglnUrwinBrain(ptResponder):
         print "nglnUrwinBrain: Generated a valid spawn time: %d" % (firstTime)
         spawnTimes = [firstTime]
 
-        while type(spawnTimes[-1]) == type(long(1)):
+        while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
@@ -387,7 +387,7 @@ class nglnUrwinBrain(ptResponder):
                     kFirstMorningSpawn = 445
                     self.InitNewSDLVars()
 
-                elif type(param) == type(""):
+                elif isinstance(param, str):
                     newTimes = param.split(";")
                     kMinimumTimeBetweenSpawns = int(newTimes[0])
                     kMaximumTimeBetweenSpawns = int(newTimes[1])

--- a/Python/payiUrwinBrain.py
+++ b/Python/payiUrwinBrain.py
@@ -430,7 +430,7 @@ class payiUrwinBrain(ptResponder):
         print "payiUrwinBrain: Generated a valid spawn time: %d" % (firstTime)
         spawnTimes = [firstTime]
 
-        while type(spawnTimes[-1]) == type(long(1)):
+        while isinstance(spawnTimes[-1], long):
             randnum = random.randint(kMinimumTimeBetweenSpawns, kMaximumTimeBetweenSpawns)
             newTime = spawnTimes[-1] + randnum
             if newTime < endOfToday:
@@ -492,7 +492,7 @@ class payiUrwinBrain(ptResponder):
                     kFirstMorningSpawn = 445
                     self.InitNewSDLVars()
 
-                elif type(param) == type(""):
+                elif isinstance(param, str):
                     newTimes = param.split(";")
                     kMinimumTimeBetweenSpawns = int(newTimes[0])
                     kMaximumTimeBetweenSpawns = int(newTimes[1])

--- a/Python/plasma/PlasmaKITypes.py
+++ b/Python/plasma/PlasmaKITypes.py
@@ -164,7 +164,7 @@ def PtDetermineKILevel():
     import string
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(kChronicleKILevel)
-    if type(entry) != type(None):
+    if entry is not None:
         level = string.atoi(entry.chronicleGetValue())
         # make sure it is a valid level
         if level >= kLowestKILevel and level <= kHighestKILevel:
@@ -179,7 +179,7 @@ def PtDetermineCensorLevel():
     import string
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(kChronicleCensorLevel)
-    if type(entry) != type(None):
+    if entry is not None:
         level = string.atoi(entry.chronicleGetValue())
         return level
     # if couldn't be determine... just assume lowest form
@@ -192,7 +192,7 @@ def PtDetermineKIMarkerLevel():
     import string
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(kChronicleKIMarkerLevel)
-    if type(entry) != type(None):
+    if entry is not None:
         level = string.atoi(entry.chronicleGetValue())
         return level
     # if couldn't be determine... just assume lowest form

--- a/Python/plasma/PlasmaTypes.py
+++ b/Python/plasma/PlasmaTypes.py
@@ -164,7 +164,7 @@ def PtAssert(cond, msg):
 def PtGetObjectName(obj):
     "Given a ptSceneobject, return its name"
     if isinstance(obj,ptSceneobject):
-        if type(obj.getKey()) != type(None):
+        if obj.getKey() is not None:
             return obj.getKey().getName()
     return "nil"
 
@@ -386,7 +386,7 @@ class ptAttribSceneobjectList(ptAttributeList):
         if self.netForce:
             value.netForce(1)
         self.value.append(value)
-        if type(self.byObject) == type({}):
+        if isinstance(self.byObject, dict):
             name = value.getName()
             self.byObject[name] = value
 
@@ -402,12 +402,12 @@ class ptAttributeKeyList(ptAttributeList):
             self.byObject = None
     def enable(self,objectName=None):
         if self.value != None:
-            if type(objectName) != type(None) and type(self.byObject) != type(None):
+            if objectName is not None and self.byObject is not None:
                 pkey = self.byObject[objectName]
                 if self.netForce:
                     pkey.netForce(1)
                 pkey.enable()
-            elif type(self.value)==type([]):
+            elif isinstance(self.value, list):
                 for pkey in self.value:
                     if self.netForce:
                         pkey.netForce(1)
@@ -418,12 +418,12 @@ class ptAttributeKeyList(ptAttributeList):
                 self.value.enable()
     def disable(self,objectName=None):
         if self.value != None:
-            if type(objectName) != type(None) and type(self.byObject) != type(None):
+            if objectName is not None and self.byObject is not None:
                 pkey = self.byObject[objectName]
                 if self.netForce:
                     pkey.netForce(1)
                 pkey.disable()
-            elif type(self.value)==type([]):
+            elif isinstance(self.value, list):
                 for pkey in self.value:
                     if self.netForce:
                         pkey.netForce(1)
@@ -436,7 +436,7 @@ class ptAttributeKeyList(ptAttributeList):
         if self.netForce:
             value.netForce(1)
         self.value.append(value)
-        if type(self.byObject) == type({}):
+        if isinstance(self.byObject, dict):
             name = value.getName()
             self.byObject[name] = value
 
@@ -472,13 +472,13 @@ class ptAttribResponder(ptAttributeKeyList):
         return (self.id,self.name,9)
     def run(self,key,state=None,events=None,avatar=None,objectName=None,netForce=0,netPropagate=None,fastforward=0):
         # has the value been set?
-        if type(self.value) != type(None):
+        if self.value is not None:
             nt = ptNotify(key)
             nt.clearReceivers()
             # see if the value is a list or byObject or a single
-            if type(objectName) != type(None) and type(self.byObject) != type(None):
+            if objectName is not None and self.byObject is not None:
                 nt.addReceiver(self.byObject[objectName])
-            elif type(self.value)==type([]):
+            elif isinstance(self.value, list):
                 for resp in self.value:
                     nt.addReceiver(resp)
             else:
@@ -490,10 +490,10 @@ class ptAttribResponder(ptAttributeKeyList):
             if netForce or self.netForce:
                 nt.netForce(1)
             # see if the state is specified
-            if type(state) == type(0):
+            if isinstance(state, int):
                 raise ptResponderStateError,"Specifying state as a number is no longer supported"
-            elif type(state) == type(''):
-                if type(self.state_list) != type(None):
+            elif isinstance(state, str):
+                if self.state_list is not None:
                     try:
                         idx = self.state_list.index(state)
                         nt.addResponderState(idx)
@@ -502,9 +502,9 @@ class ptAttribResponder(ptAttributeKeyList):
                 else:
                     raise ptResponderStateError,"There is no state list provided"
             # see if there are events to pass on
-            if type(events) != type(None):
+            if events is not None:
                 PtAddEvents(nt,events)
-            if type(avatar) != type(None):
+            if avatar is not None:
                 nt.addCollisionEvent(1,avatar.getKey(),avatar.getKey())
             if fastforward:
                 nt.setType(PtNotificationType.kResponderFF)
@@ -515,13 +515,13 @@ class ptAttribResponder(ptAttributeKeyList):
             nt.send()
     def setState(self,key,state,objectName=None,netForce=0,netPropagate=None):
         # has the value been set?
-        if type(self.value) != type(None):
+        if self.value is not None:
             nt = ptNotify(key)
             nt.clearReceivers()
             # see if the value is a list or byObject or a single
-            if type(objectName) != type(None) and type(self.byObject) != type(None):
+            if objectName is not None and self.byObject is not None:
                 nt.addReceiver(self.byObject[objectName])
-            elif type(self.value)==type([]):
+            elif isinstance(self.value, list):
                 for resp in self.value:
                     nt.addReceiver(resp)
             else:
@@ -533,10 +533,10 @@ class ptAttribResponder(ptAttributeKeyList):
             if netForce or self.netForce:
                 nt.netForce(1)
             # see if the state is specified
-            if type(state) == type(0):
+            if isinstance(state, int):
                 raise ptResponderStateError,"Specifying state as a number is no longer supported"
-            elif type(state) == type(''):
-                if type(self.state_list) != type(None):
+            elif isinstance(state, str):
+                if self.state_list is not None:
                     try:
                         idx = self.state_list.index(state)
                         nt.addResponderState(idx)
@@ -550,8 +550,8 @@ class ptAttribResponder(ptAttributeKeyList):
             nt.send()
 
     def getState(self):
-        if (type(self.value) != type(None)):
-            if type(self.value)==type([]):
+        if (self.value is not None):
+            if isinstance(self.value, list):
                 for resp in self.value:
                     obj = resp.getSceneObject()
                     idx = obj.getResponderState()
@@ -623,20 +623,20 @@ class ptAttribExcludeRegion(ptAttribute):
     def getdef(self):
         return (self.id,self.name,13)
     def clear(self,sender):
-        if type(self.value) != type(None):
+        if self.value is not None:
             PtExcludeRegionSet(sender,self.value,kExRegClear)
     def release(self,sender):
-        if type(self.value) != type(None):
+        if self.value is not None:
             PtExcludeRegionSet(sender,self.value,kExRegRelease)
     def enable(self):
         self.sceneobject.physics.enable()
     def disable(self):
         self.sceneobject.physics.disable()
     def clearNow(self,sender):
-        if type(self.value) != type(None):
+        if self.value is not None:
             PtExcludeRegionSetNow(sender,self.value,kExRegClear)
     def releaseNow(self,sender):
-        if type(self.value) != type(None):
+        if self.value is not None:
             PtExcludeRegionSetNow(sender,self.value,kExRegRelease)
 
 class ptAttribWaveSet(ptAttribute):
@@ -715,7 +715,7 @@ class ptAttribAnimation(ptAttribute):
     # this is to set the value via method (only called if defined)
     def __setvalue__(self,value):
         # has a ptAnimation already been made
-        if type(value) == type(""):
+        if isinstance(value, str):
             self.animName = value
             try:
                 self.animation.setAnimName(value)
@@ -766,35 +766,35 @@ class ptAttribBehavior(ptAttribute):
         return (self.id,self.name,15)
     def run(self,avatar):
         "This will run the behavior on said avatar"
-        if type(self.value) != type(None):
+        if self.value is not None:
             if self.netForce:
                 self.value.netForce(1)
                 avatar.avatar.netForce(1)
             avatar.avatar.runBehavior(self.value,self.netForce,self.netProp)
     def nextStage(self,avatar,transitionTime=1.0,setTimeFlag=1,newTime=0.0,dirFlag=0,isForward=1):
         "This will go to the next stage in a multi-stage behavior"
-        if type(self.value) != type(None):
+        if self.value is not None:
             if self.netForce:
                 self.value.netForce(1)
                 avatar.avatar.netForce(1)
             avatar.avatar.nextStage(self.value,transitionTime,setTimeFlag,newTime,dirFlag,isForward,self.netForce)
     def previousStage(self,avatar,transitionTime=1.0,setTimeFlag=1,newTime=0.0,dirFlag=0,isForward=1):
         "This will go to the next stage in a multi-stage behavior"
-        if type(self.value) != type(None):
+        if self.value is not None:
             if self.netForce:
                 self.value.netForce(1)
                 avatar.avatar.netForce(1)
             avatar.avatar.previousStage(self.value,transitionTime,setTimeFlag,newTime,dirFlag,isForward,self.netForce)
     def gotoStage(self,avatar,stage,transitionTime=1.0,setTimeFlag=1,newTime=0.0,dirFlag=0,isForward=1):
         "This will go to the next stage in a multi-stage behavior"
-        if type(self.value) != type(None):
+        if self.value is not None:
             if self.netForce:
                 self.value.netForce(1)
                 avatar.avatar.netForce(1)
             avatar.avatar.gotoStage(self.value,stage,transitionTime,setTimeFlag,newTime,dirFlag,isForward,self.netForce)
     def setLoopCount(self,stage,loopCount):
         "This will set the loop count for a stage"
-        if type(self.value) != type(None):
+        if self.value is not None:
             PtSetBehaviorLoopCount(self.value,stage,loopCount,self.netForce)
 
 # Material texture attribute pick button
@@ -817,7 +817,7 @@ class ptAttribMaterialAnimation(ptAttribute):
         self.animation = None
 
     def __setvalue__(self, value):
-        if type(self.animation) == type(None):
+        if self.animation is None:
             self.animation = ptAnimation()
             self.animation.addKey(value)
             self.value = self.animation
@@ -845,7 +845,7 @@ class ptAttribMaterialList(ptAttributeList):
         if self.netForce:
             value.netForce(1)
         self.value.append(value)
-        if type(self.byObject) == type({}):
+        if isinstance(self.byObject, dict):
             name = value.getName()
             self.byObject[name] = value
 

--- a/Python/plasma/glue.py
+++ b/Python/plasma/glue.py
@@ -71,7 +71,7 @@ def glue_getClass():
     return glue_cl
 def glue_getInst():
     global glue_inst
-    if type(glue_inst) == type(None):
+    if glue_inst is None:
         cl = glue_getClass()
         if cl != None:
             glue_inst = cl()
@@ -81,7 +81,7 @@ def glue_delInst():
     global glue_cl
     global glue_params
     global glue_paramKeys
-    if type(glue_inst) != type(None):
+    if glue_inst is not None:
         del glue_inst
     # remove our references
     glue_cl = None
@@ -100,20 +100,20 @@ def glue_findAndAddAttribs(obj, glue_params):
                 print "%s has id %d which is already defined in %s" % (obj.name, obj.id, glue_params[obj.id].name)
         else:
             glue_params[obj.id] = obj
-    elif type(obj) == type([]):
+    elif isinstance(obj, list):
         for o in obj:
             glue_findAndAddAttribs(o, glue_params)
-    elif type(obj) == type({}):
+    elif isinstance(obj, dict):
         for o in obj.values():
             glue_findAndAddAttribs(o, glue_params)
-    elif type(obj) == type( () ):
+    elif isinstance(obj, tuple):
         for o in obj:
             glue_findAndAddAttribs(o, glue_params)
             
 def glue_getParamDict():
     global glue_params
     global glue_paramKeys
-    if type(glue_params) == type(None):
+    if glue_params is None:
         glue_params = {}
         gd = globals()
         for obj in gd.values():
@@ -149,7 +149,7 @@ def glue_getParam(number):
     pd = glue_getParamDict()
     if pd != None:
         # see if there is a paramKey list
-        if type(glue_paramKeys) == type([]):
+        if isinstance(glue_paramKeys, list):
             if number >= 0 and number < len(glue_paramKeys):
                 return pd[glue_paramKeys[number]].getdef()
             else:
@@ -174,7 +174,7 @@ def glue_setParam(id,value):
             except AttributeError:
                 if isinstance(pd[id],ptAttributeList):
                     try:
-                        if type(pd[id].value) != type([]):
+                        if not isinstance(pd[id].value, list):
                             pd[id].value = []   # make sure that the value starts as an empty list
                     except AttributeError:
                         pd[id].value = []   # or if value hasn't been defined yet, then do it now
@@ -208,7 +208,7 @@ def glue_getVisInfo(number):
     pd = glue_getParamDict()
     if pd != None:
         # see if there is a paramKey list
-        if type(glue_paramKeys) == type([]):
+        if isinstance(glue_paramKeys, list):
             if number >= 0 and number < len(glue_paramKeys):
                 return pd[glue_paramKeys[number]].getVisInfo()
             else:

--- a/Python/plasma/pch.py
+++ b/Python/plasma/pch.py
@@ -110,9 +110,9 @@ def selmod(idx=None):
     "select a module from the list"
     global __pmods
     global __sel
-    if type(idx) == type(None):
+    if idx is None:
         idx = __sel
-    elif type(idx) == type(""):
+    elif isinstance(idx, str):
         # its a string, then find it by module name
         i = 0
         for mod in __pmods:
@@ -164,7 +164,7 @@ def selattrib(id=None):
     global __pmods
     global __sel
     global __selattr
-    if type(id) == type(None):
+    if id is None:
         id = __selattr
     for name in __pmods[__sel][1].__dict__.keys():
         ist = __pmods[__sel][1].__dict__[name]
@@ -183,7 +183,7 @@ def setattrib(value):
         ist = __pmods[__sel][1].__dict__[name]
         if isinstance(ist,PlasmaTypes.ptAttribute):
             if __selattr == ist.id:
-                if type(ist.value) == type(None) or type(ist.value) == type(value):
+                if ist.value is None or isinstance(ist.value, type(value)):
                     # see if there is a __setvalue__ method
                     try:
                         ist.__setvalue__(value)
@@ -205,7 +205,7 @@ def showglobals():
         if not hasattr(Plasma,name) and not hasattr(PlasmaTypes,name):
             if not isinstance(ist,PlasmaTypes.ptAttribute) and not isinstance(ist,PlasmaTypes.ptModifier):
                 if name[:2] != '__' and name[:4] != 'glue':
-                    if type(ist) != type(sys) and type(ist) != type(PlasmaTypes.ptAttribute):
+                    if not isinstance(ist, type(sys)) and not isinstance(ist, type(PlasmaTypes.ptAttribute)):
                         print "  %s =" % (name),ist
 def setglobal(name,value):
     "set a global variable to a value with in the selected module"

--- a/Python/psnlBahroPoles.py
+++ b/Python/psnlBahroPoles.py
@@ -723,19 +723,18 @@ class psnlBahroPoles(ptModifier):
         
         vault = ptVault()
 
-        if vault is not None:
-            chron = vault.findChronicleEntry("JourneyClothProgress")
+        chron = vault.findChronicleEntry("JourneyClothProgress")
 
-            if chron is not None:
-                ageChronRefList = chron.getChildNodeRefList()
+        if chron is not None:
+            ageChronRefList = chron.getChildNodeRefList()
 
-                for ageChron in ageChronRefList:
-                    ageChild = ageChron.getChild()
+            for ageChron in ageChronRefList:
+                ageChild = ageChron.getChild()
 
-                    ageChild = ageChild.upcastToChronicleNode()
+                ageChild = ageChild.upcastToChronicleNode()
 
-                    if ageChild.chronicleGetName() == age:
-                        return len(ageChild.chronicleGetValue() )
+                if ageChild.chronicleGetName() == age:
+                    return len(ageChild.chronicleGetValue() )
 
         return 0
 
@@ -903,12 +902,11 @@ class psnlBahroPoles(ptModifier):
     def SetJCProgressComplete(self):
         vault = ptVault()
 
-        if vault is not None:
-            chron = vault.findChronicleEntry("JourneyClothProgress")
+        chron = vault.findChronicleEntry("JourneyClothProgress")
 
-            if chron is not None:
-                chron.chronicleSetValue("Z")
-                chron.save()
+        if chron is not None:
+            chron.chronicleSetValue("Z")
+            chron.save()
 
         #sdl = xPsnlVaultSDL(1)
         #sdl["CleftVisited"] = (1,)

--- a/Python/psnlBahroPoles.py
+++ b/Python/psnlBahroPoles.py
@@ -198,7 +198,7 @@ class psnlBahroPoles(ptModifier):
         PtDebugPrint("DEBUG: psnlBahroPoles.OnServerInitComplete():\tEverything ok so far")
 
         ageVault = ptAgeVault()
-        if type(ageVault) != type(None): #is the Vault online?
+        if ageVault is not None: #is the Vault online?
             ageSDL = ageVault.getAgeSDL()
             if ageSDL:
                 try:
@@ -238,7 +238,7 @@ class psnlBahroPoles(ptModifier):
             vault = ptVault()
             if ptVault().amOwnerOfCurrentAge():
                 entry = vault.findChronicleEntry("CleftSolved")
-                if type(entry) != type(None):
+                if entry is not None:
                     if entry.chronicleGetValue() == "yes":
                         boolCleftSolved = 1
                         ageSDL["psnlCleftSolved"] = (1,)
@@ -686,7 +686,7 @@ class psnlBahroPoles(ptModifier):
             #ageSDL = PtGetAgeSDL()
             ageSDL = xPsnlVaultSDL(1)
 
-            if type(ageSDL) != type(None):
+            if ageSDL is not None:
                 sdllist = ageSDL.BatchGet( ["TeledahnPoleState", "GardenPoleState", "GarrisonPoleState", "KadishPoleState"] )
                 self.Poles["Teledahn"]["State"] = sdllist["TeledahnPoleState"]
                 self.Poles["Garden"]["State"] = sdllist["GardenPoleState"]
@@ -723,10 +723,10 @@ class psnlBahroPoles(ptModifier):
         
         vault = ptVault()
 
-        if type(vault) != type(None):
+        if vault is not None:
             chron = vault.findChronicleEntry("JourneyClothProgress")
 
-            if type(chron) != type(None):
+            if chron is not None:
                 ageChronRefList = chron.getChildNodeRefList()
 
                 for ageChron in ageChronRefList:
@@ -903,10 +903,10 @@ class psnlBahroPoles(ptModifier):
     def SetJCProgressComplete(self):
         vault = ptVault()
 
-        if type(vault) != type(None):
+        if vault is not None:
             chron = vault.findChronicleEntry("JourneyClothProgress")
 
-            if type(chron) != type(None):
+            if chron is not None:
                 chron.chronicleSetValue("Z")
                 chron.save()
 
@@ -1106,7 +1106,7 @@ class psnlBahroPoles(ptModifier):
     def CheckBahroCaveSolution(self):
         vault = ptVault()
         entry = vault.findChronicleEntry("BahroCave")
-        if type(entry) == type(None):
+        if entry is None:
             return 0
         else:
             var = self.GetAgeVariable("Teledahn", "SolutionSymbol")
@@ -1129,7 +1129,7 @@ class psnlBahroPoles(ptModifier):
 
         vault = ptVault()
         entry = vault.findChronicleEntry("BahroCave")
-        if type(entry) == type(None):
+        if entry is None:
             #PtDebugPrint("DEBUG: psnlBahroPoles.OnServerInitComplete: Did not find BahroCave chronicle...creating")
             vault.addChronicleEntry("BahroCave",0,"0")
 

--- a/Python/psnlBookshelf.py
+++ b/Python/psnlBookshelf.py
@@ -288,7 +288,7 @@ class psnlBookshelf(ptModifier):
     def OnSDLNotify(self,VARname,SDLname,playerID,tag):
         if VARname == "ShelfAUserID":
             ageSDL = PtGetAgeSDL()
-            if type(ageSDL) != type(None):
+            if ageSDL is not None:
                 if ageSDL["ShelfAUserID"][0] == -1:
                     actBookshelf.enable()
 
@@ -373,7 +373,7 @@ class psnlBookshelf(ptModifier):
             for event in events:
                 if event[0] == kVariableEvent:
                     print "psnlBookshelf: Received a message from the Book GUI: ", event[1]
-                    if event[1] == "IShelveBook" and type(objBookPicked) != type(None):
+                    if event[1] == "IShelveBook" and objBookPicked is not None:
                         self.IShelveBook()
                         
                     if event[1].split(",")[0] == "ILink": # parse the spawn point info off the entire note (which comes through as "ILink, SpawnPointName,SpawnPointTitle")
@@ -590,7 +590,7 @@ class psnlBookshelf(ptModifier):
                         lockName = objLock.getName()
 
                         # show as locked if both are locked, or one is locked and the other doesn't exist
-                        if ( type(citylinklocked) == type(None) or citylinklocked) and ( type(bcolinklocked) == type(None) or bcolinklocked):
+                        if ( citylinklocked is None or citylinklocked) and ( bcolinklocked is None or bcolinklocked):
                             # find lock associated with this book
                             objLockPicked = objLocks.value[index]
                             lockName = objLockPicked.getName()
@@ -668,9 +668,9 @@ class psnlBookshelf(ptModifier):
                     # Do not use the age link node of a Hood child age for the city book clasp!
                     if IsChildLink:
                         link = self.GetOwnedAgeLink(ptAgeVault(), "city")
-                    if type(link) == type(None):
+                    if link is None:
                         return
-                    if type(link) != type(ptVaultAgeLinkNode()) or link.getLocked():
+                    if not isinstance(link, type(ptVaultAgeLinkNode())) or link.getLocked():
                         # find lock associated with this book
 
                         objLockPicked = objLocks.value[index]
@@ -697,7 +697,7 @@ class psnlBookshelf(ptModifier):
             actBookshelfExit.disable()
             return
         
-        if id==respPresentBook.id and type(objBookPicked) != type(None):
+        if id==respPresentBook.id and objBookPicked is not None:
             # book is finished presenting - now link
             if boolLinkerIsMe:
                 #~ self.ILink()
@@ -728,7 +728,7 @@ class psnlBookshelf(ptModifier):
                 lockName = objLock.getName()
 
                 # show as locked if both are locked, or one is locked and the other doesn't exist
-                if ( type(citylinklocked) == type(None) or citylinklocked) and ( type(bcolinklocked) == type(None) or bcolinklocked):
+                if ( citylinklocked is None or citylinklocked) and ( bcolinklocked is None or bcolinklocked):
                     lockName = objLockPicked.getName()
                     # find the corresponding responder modifier
                     for rkey,rvalue in respCloseLock.byObject.items():
@@ -748,10 +748,10 @@ class psnlBookshelf(ptModifier):
             # Do not use the age link node of a Hood child age for the city book clasp!
             if IsChildLink:
                 link = self.GetOwnedAgeLink(ptAgeVault(), "city")
-            if type(link) == type(None):
+            if link is None:
                 return
                 
-            if type(link) == type("") and link == "Ahnonay":
+            if isinstance(link, str) and link == "Ahnonay":
                 locked = 0
                 ageVault = ptAgeVault()
                 ageInfoNode = ageVault.getAgeInfo()
@@ -788,7 +788,7 @@ class psnlBookshelf(ptModifier):
                     self.IUpdateLinks()
                     return                    
 
-            if type(link) == type(ptAgeLinkStruct()) or link.getLocked(): #close the clasp
+            if isinstance(link, type(ptAgeLinkStruct())) or link.getLocked(): #close the clasp
                 lockName = objLockPicked.getName()
                 # find the corresponding responder modifier
                 for rkey,rvalue in respCloseLock.byObject.items():
@@ -834,7 +834,7 @@ class psnlBookshelf(ptModifier):
                         citylinklocked = citylink and citylink.getLocked()
                         bcolinklocked = bcolink and bcolink.getLocked()
 
-                        if ( type(citylinklocked) == type(None) or citylinklocked) and ( type(bcolinklocked) == type(None) or bcolinklocked):
+                        if ( citylinklocked is None or citylinklocked) and ( bcolinklocked is None or bcolinklocked):
                             for rkey,rvalue in respOpenLock.byObject.items():
                                 parent = rvalue.getParentKey()
                                 if parent:
@@ -865,11 +865,11 @@ class psnlBookshelf(ptModifier):
                     # Do not use the age link node of a Hood child age for the city book clasp!
                     if IsChildLink:
                         link = self.GetOwnedAgeLink(ptAgeVault(), "city")
-                    if type(link) == type(None):
+                    if link is None:
                         return
                     lockName = objLockPicked.getName()
                     
-                    if type(link) == type("") and link == "Ahnonay":
+                    if isinstance(link, str) and link == "Ahnonay":
                         ageVault = ptAgeVault()
                         ageInfoNode = ageVault.getAgeInfo()
                         ageInfoChildren = ageInfoNode.getChildNodeRefList()
@@ -927,7 +927,7 @@ class psnlBookshelf(ptModifier):
 
                         return
 
-                    if type(link) != type(ptVaultAgeLinkNode()):
+                    if not isinstance(link, type(ptVaultAgeLinkNode())):
                         self.IUpdateLinks()
                         return
                     if link.getLocked():
@@ -1146,7 +1146,7 @@ class psnlBookshelf(ptModifier):
                     break
         print "psnlBookshelf.IGetLinkFromBook(): after city lookup, ageName = ",ageName        	        
 
-        if type(ageName) == type(None):
+        if ageName is None:
             print "psnlBookshelf.IGetLinkFromBook():\tERROR -- conversion from book to link element failed"
             return None
 
@@ -1238,7 +1238,7 @@ class psnlBookshelf(ptModifier):
             lockName = objLock.getName()
 
             # show as locked if both are locked, or one is locked and the other doesn't exist
-            if ( type(citylinklocked) == type(None) or citylinklocked) and ( type(bcolinklocked) == type(None) or bcolinklocked):
+            if ( citylinklocked is None or citylinklocked) and ( bcolinklocked is None or bcolinklocked):
                 print "psnlBookshelf.IUpdateLocksAndTrays():\tsetting city book clasp to locked: ",lockName
                 for rkey,rvalue in respCloseLock.byObject.items():
                     parent = rvalue.getParentKey()
@@ -1435,7 +1435,7 @@ class psnlBookshelf(ptModifier):
         
         ageVault = ptAgeVault()
         PAL = ageVault.getAgesIOwnFolder()
-        if type(PAL) != type(None):
+        if PAL is not None:
             contents = PAL.getChildNodeRefList()
 
             for content in contents:
@@ -1641,10 +1641,10 @@ class psnlBookshelf(ptModifier):
         global SpawnPointTitle
         
         link = self.IGetLinkFromBook(SpawnPointTitle)
-        if type(link) == type(None):
+        if link is None:
             print "psnlBookshelf.ILink():\tERROR -- conversion from book to link failed -- aborting"
             return
-        elif type(link) == type("") and link == "Ahnonay":
+        elif isinstance(link, str) and link == "Ahnonay":
             info = ptAgeInfoStruct()
             info.setAgeFilename("Ahnonay")
             info.setAgeInstanceName("Ahnonay")
@@ -1680,7 +1680,7 @@ class psnlBookshelf(ptModifier):
         print "Ilink: SpawnPointTitle = ", SpawnPointTitle, "; SpawnPointName = ", SpawnPointName
         spnpnt = None
         
-        if type(link) == type(ptAgeLinkStruct()):
+        if isinstance(link, type(ptAgeLinkStruct())):
             als = link
         else:
             als = link.asAgeLinkStruct()
@@ -1831,7 +1831,7 @@ class psnlBookshelf(ptModifier):
         for content in contents:
             link = content.getChild()
             link = link.upcastToAgeLinkNode()
-            if type(link) != type(None):
+            if link is not None:
                 info = link.getAgeInfo()
             if not info:
                 continue
@@ -1843,7 +1843,7 @@ class psnlBookshelf(ptModifier):
 
     def IGetHoodInfoNode(self):
         link = self.IGetHoodLinkNode()
-        if type(link) == type(None):
+        if link is None:
             return None
         info = link.getAgeInfo()
         return info
@@ -1853,7 +1853,7 @@ class psnlBookshelf(ptModifier):
         hoodInfo = self.IGetHoodInfoNode()
         if hoodInfo:
             childAgeFolder = hoodInfo.getChildAgesFolder()
-            if type(childAgeFolder) != type(None):
+            if childAgeFolder is not None:
                 contents = childAgeFolder.getChildNodeRefList()
                 #childAgeLinkNodes = []
                 #GZLinkNode = None
@@ -1893,7 +1893,7 @@ class psnlBookshelf(ptModifier):
         CityLinks = []
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
-        if type(entryCityLinks) != type(None):
+        if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
             print "valCityLinks = ",valCityLinks
             CityLinks = valCityLinks.split(",")
@@ -1913,7 +1913,7 @@ class psnlBookshelf(ptModifier):
             print "age = ",age
             print "agelink = ",agelink
 
-            if type(agelink) != type(None):
+            if agelink is not None:
                 spawnPoints = agelink.getSpawnPoints()
 
                 for sp in spawnPoints:
@@ -1930,7 +1930,7 @@ class psnlBookshelf(ptModifier):
         print "age = the city"
         print "agelink = ",agelink
 
-        if type(agelink) != type(None):
+        if agelink is not None:
             spawnPoints = agelink.getSpawnPoints()
 
             for sp in spawnPoints:
@@ -1948,7 +1948,7 @@ class psnlBookshelf(ptModifier):
 
     def GetOwnedAgeLink(self, vault, age):
         PAL = vault.getAgesIOwnFolder()
-        if type(PAL) != type(None):
+        if PAL is not None:
             contents = PAL.getChildNodeRefList()
             for content in contents:
                 link = content.getChild().upcastToAgeLinkNode()

--- a/Python/psnlBookshelf.py
+++ b/Python/psnlBookshelf.py
@@ -670,7 +670,7 @@ class psnlBookshelf(ptModifier):
                         link = self.GetOwnedAgeLink(ptAgeVault(), "city")
                     if link is None:
                         return
-                    if not isinstance(link, type(ptVaultAgeLinkNode())) or link.getLocked():
+                    if not isinstance(link, ptVaultAgeLinkNode) or link.getLocked():
                         # find lock associated with this book
 
                         objLockPicked = objLocks.value[index]
@@ -788,7 +788,7 @@ class psnlBookshelf(ptModifier):
                     self.IUpdateLinks()
                     return                    
 
-            if isinstance(link, type(ptAgeLinkStruct())) or link.getLocked(): #close the clasp
+            if isinstance(link, ptAgeLinkStruct) or link.getLocked(): #close the clasp
                 lockName = objLockPicked.getName()
                 # find the corresponding responder modifier
                 for rkey,rvalue in respCloseLock.byObject.items():
@@ -927,7 +927,7 @@ class psnlBookshelf(ptModifier):
 
                         return
 
-                    if not isinstance(link, type(ptVaultAgeLinkNode())):
+                    if not isinstance(link, ptVaultAgeLinkNode):
                         self.IUpdateLinks()
                         return
                     if link.getLocked():
@@ -1680,7 +1680,7 @@ class psnlBookshelf(ptModifier):
         print "Ilink: SpawnPointTitle = ", SpawnPointTitle, "; SpawnPointName = ", SpawnPointName
         spnpnt = None
         
-        if isinstance(link, type(ptAgeLinkStruct())):
+        if isinstance(link, ptAgeLinkStruct):
             als = link
         else:
             als = link.asAgeLinkStruct()

--- a/Python/psnlBookshelf.py
+++ b/Python/psnlBookshelf.py
@@ -751,7 +751,7 @@ class psnlBookshelf(ptModifier):
             if link is None:
                 return
                 
-            if isinstance(link, str) and link == "Ahnonay":
+            if link == "Ahnonay":
                 locked = 0
                 ageVault = ptAgeVault()
                 ageInfoNode = ageVault.getAgeInfo()
@@ -869,7 +869,7 @@ class psnlBookshelf(ptModifier):
                         return
                     lockName = objLockPicked.getName()
                     
-                    if isinstance(link, str) and link == "Ahnonay":
+                    if link == "Ahnonay":
                         ageVault = ptAgeVault()
                         ageInfoNode = ageVault.getAgeInfo()
                         ageInfoChildren = ageInfoNode.getChildNodeRefList()
@@ -1644,7 +1644,7 @@ class psnlBookshelf(ptModifier):
         if link is None:
             print "psnlBookshelf.ILink():\tERROR -- conversion from book to link failed -- aborting"
             return
-        elif isinstance(link, str) and link == "Ahnonay":
+        elif link == "Ahnonay":
             info = ptAgeInfoStruct()
             info.setAgeFilename("Ahnonay")
             info.setAgeInstanceName("Ahnonay")

--- a/Python/psnlBugs.py
+++ b/Python/psnlBugs.py
@@ -65,22 +65,20 @@ class psnlBugs(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is None:
-                # not found... add chronicle
-                vault.addChronicleEntry(chronicleEntryName,0,str(count))
-            else:
-                entry.chronicleSetValue(str(count))
-                entry.save()
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is None:
+            # not found... add chronicle
+            vault.addChronicleEntry(chronicleEntryName,0,str(count))
+        else:
+            entry.chronicleSetValue(str(count))
+            entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is not None:
-                return int(entry.chronicleGetValue())
-        return 0 # no vault or no chronicle var
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is not None:
+            return int(entry.chronicleGetValue())
+        return 0 # no chronicle var
 
     def OnServerInitComplete(self):
         avatar = 0

--- a/Python/psnlBugs.py
+++ b/Python/psnlBugs.py
@@ -65,9 +65,9 @@ class psnlBugs(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add chronicle
                 vault.addChronicleEntry(chronicleEntryName,0,str(count))
             else:
@@ -76,9 +76,9 @@ class psnlBugs(ptResponder):
     
     def IGetBugCount(self):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) != type(None):
+            if entry is not None:
                 return int(entry.chronicleGetValue())
         return 0 # no vault or no chronicle var
 

--- a/Python/psnlVaultSDLBoolRespond.py
+++ b/Python/psnlVaultSDLBoolRespond.py
@@ -78,7 +78,7 @@ class psnlVaultSDLBoolRespond(ptResponder):
 
     def OnFirstUpdate(self):
         PtDebugPrint("psnlVaultSDLBoolRespond.OnFirstUpdate():\t attached to sceneobject: %s" % self.sceneobject.getName())
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: psnlVaultSDLBoolRespond.OnFirstUpdate():\tERROR: missing SDL var name")
             pass
 
@@ -92,7 +92,7 @@ class psnlVaultSDLBoolRespond(ptResponder):
     def IFinishInit(self):
         try:
             ageSDL = xPsnlVaultSDL(1)
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 if ageSDL[stringVarName.value][0]:
                     PtDebugPrint("DEBUG: psnlVaultSDLBoolRespond.IFinishInit():\tRunning true responder on %s, fastforward=%d" % (self.sceneobject.getName(), boolFFOnInit.value))
                     respBoolTrue.run(self.key,fastforward=boolFFOnInit.value)

--- a/Python/psnlVaultSDLBoolRespond.py
+++ b/Python/psnlVaultSDLBoolRespond.py
@@ -78,7 +78,7 @@ class psnlVaultSDLBoolRespond(ptResponder):
 
     def OnFirstUpdate(self):
         PtDebugPrint("psnlVaultSDLBoolRespond.OnFirstUpdate():\t attached to sceneobject: %s" % self.sceneobject.getName())
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: psnlVaultSDLBoolRespond.OnFirstUpdate():\tERROR: missing SDL var name")
             pass
 
@@ -92,7 +92,7 @@ class psnlVaultSDLBoolRespond(ptResponder):
     def IFinishInit(self):
         try:
             ageSDL = xPsnlVaultSDL(1)
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 if ageSDL[stringVarName.value][0]:
                     PtDebugPrint("DEBUG: psnlVaultSDLBoolRespond.IFinishInit():\tRunning true responder on %s, fastforward=%d" % (self.sceneobject.getName(), boolFFOnInit.value))
                     respBoolTrue.run(self.key,fastforward=boolFFOnInit.value)

--- a/Python/psnlVaultSDLBoolShowHide.py
+++ b/Python/psnlVaultSDLBoolShowHide.py
@@ -67,14 +67,14 @@ class psnlVaultSDLBoolShowHide(ptMultiModifier):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: psnlVaultSDLBoolShowHide.OnFirstUpdate():\tERROR: missing SDL var name on %s" % self.sceneobject.getName())
             pass
 
         if boolFirstUpdate.value:
             try:
                 ageSDL = xPsnlVaultSDL(1)
-                if isinstance(stringVarName.value, str) and stringVarName.value != "":
+                if stringVarName.value:
                     if not (ageSDL[stringVarName.value][0] ^ boolShowOnTrue.value):
                         self.EnableObject()
                     else:
@@ -89,7 +89,7 @@ class psnlVaultSDLBoolShowHide(ptMultiModifier):
         if not boolFirstUpdate.value:
             try:
                 ageSDL = xPsnlVaultSDL(1)
-                if isinstance(stringVarName.value, str) and stringVarName.value != "":
+                if stringVarName.value:
                     if not (ageSDL[stringVarName.value][0] ^ boolShowOnTrue.value):
                         self.EnableObject()
                     else:
@@ -132,7 +132,7 @@ class psnlVaultSDLBoolShowHide(ptMultiModifier):
         self.sceneobject.physics.suppress(true)
 
     def OnBackdoorMsg(self, target, param):
-        if stringVarName.value is not None and stringVarName.value != "":
+        if stringVarName.value:
             if target == stringVarName.value:
                 if param.lower() in ("on", "1", "true"):
                     self.EnableObject()

--- a/Python/psnlVaultSDLBoolShowHide.py
+++ b/Python/psnlVaultSDLBoolShowHide.py
@@ -67,14 +67,14 @@ class psnlVaultSDLBoolShowHide(ptMultiModifier):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: psnlVaultSDLBoolShowHide.OnFirstUpdate():\tERROR: missing SDL var name on %s" % self.sceneobject.getName())
             pass
 
         if boolFirstUpdate.value:
             try:
                 ageSDL = xPsnlVaultSDL(1)
-                if type(stringVarName.value) == type("") and stringVarName.value != "":
+                if isinstance(stringVarName.value, str) and stringVarName.value != "":
                     if not (ageSDL[stringVarName.value][0] ^ boolShowOnTrue.value):
                         self.EnableObject()
                     else:
@@ -89,7 +89,7 @@ class psnlVaultSDLBoolShowHide(ptMultiModifier):
         if not boolFirstUpdate.value:
             try:
                 ageSDL = xPsnlVaultSDL(1)
-                if type(stringVarName.value) == type("") and stringVarName.value != "":
+                if isinstance(stringVarName.value, str) and stringVarName.value != "":
                     if not (ageSDL[stringVarName.value][0] ^ boolShowOnTrue.value):
                         self.EnableObject()
                     else:
@@ -132,7 +132,7 @@ class psnlVaultSDLBoolShowHide(ptMultiModifier):
         self.sceneobject.physics.suppress(true)
 
     def OnBackdoorMsg(self, target, param):
-        if type(stringVarName.value) != type(None) and stringVarName.value != "":
+        if stringVarName.value is not None and stringVarName.value != "":
             if target == stringVarName.value:
                 if param.lower() in ("on", "1", "true"):
                     self.EnableObject()

--- a/Python/psnlYeeshaPageChanges.py
+++ b/Python/psnlYeeshaPageChanges.py
@@ -131,7 +131,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
         CurrentPage = 0
         
         AgeVault = ptAgeVault()
-        if type(AgeVault) != type(None): #is the Vault online?
+        if AgeVault is not None: #is the Vault online?
 
             self.ageSDL = AgeVault.getAgeSDL()
             if self.ageSDL:
@@ -175,7 +175,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                             try:
                                 ageSDL = xPsnlVaultSDL(1)
 
-                                if type(ageSDL) != type(None):
+                                if ageSDL is not None:
                                     sdllist = ageSDL.BatchGet( ["TeledahnPoleState", "GardenPoleState", "GarrisonPoleState", "KadishPoleState"] )
                                     pole1 = sdllist["TeledahnPoleState"]
                                     pole2 = sdllist["GardenPoleState"]
@@ -206,7 +206,7 @@ class psnlYeeshaPageChanges(ptMultiModifier):
                     for thispage in range(1,TotalPossibleYeeshaPages+1):
                         FoundValue = self.ageSDL.findVar("YeeshaPage" + str(thispage))
                         PtDebugPrint ("\t The previous value of the SDL variable %s is %s" % ("YeeshaPage" + str(thispage), FoundValue.getInt()))
-                        if type(FoundValue) != type(None) and FoundValue.getInt() != 0: 
+                        if FoundValue is not None and FoundValue.getInt() != 0: 
                             PtDebugPrint ("psnlYeeshaPageChanges: You have found Yeesha Page # %s." % (thispage))
                             
             else:

--- a/Python/tldnBucketBrain.py
+++ b/Python/tldnBucketBrain.py
@@ -875,7 +875,7 @@ class tldnBucketBrain(ptResponder):
             #Tye: note this is something that can be refactored....
             avaKey = PtGetAvatarKeyFromClientID(avaIDAtDump)
             avaObj = avaKey.getSceneObject()
-            if type(avaObj) == type(None):
+            if avaObj is None:
                 return
 
             avaObj.physics.enable(1)

--- a/Python/tldnHatchLadderBottom.py
+++ b/Python/tldnHatchLadderBottom.py
@@ -129,7 +129,7 @@ class tldnHatchLadderBottom(ptModifier):
         for event in events:
             # multistage callback from stage 2 send when advancing
             if event[0] == kMultiStageEvent:
-                if type(LocalAvatar) == type(None):
+                if LocalAvatar is None:
                     return
                 if PtFindAvatar(events) == LocalAvatar:
                     if event[2] == kAdvanceNextStage:

--- a/Python/tldnHatchLadderTop.py
+++ b/Python/tldnHatchLadderTop.py
@@ -166,7 +166,7 @@ class tldnHatchLadderTop(ptModifier):
             for event in events:
                 # multistage callback from stage 2 send when advancing
                 if event[0] == kMultiStageEvent:
-                    if type(ClimbingAvatar) == type(None):
+                    if ClimbingAvatar is None:
                         return
                     if PtFindAvatar(events) == ClimbingAvatar:
                         stageNum = event[1]

--- a/Python/tldnPTPumpCount.py
+++ b/Python/tldnPTPumpCount.py
@@ -95,13 +95,13 @@ class tldnPTPumpCount(ptResponder):
         
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 ageSDL.setFlags(stringVarName.value,1,1)
                 ageSDL.sendToClients(stringVarName.value)
             else:
                 PtDebugPrint("ERROR: tldnPTPumpCount.OnFirstUpdate():\tERROR: missing SDL var name in max file")
                 pass
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
                 try:
                     intCurrentValue = ageSDL[stringVarName.value][0]
@@ -122,12 +122,12 @@ class tldnPTPumpCount(ptResponder):
         if not PtWasLocallyNotified(self.key):
             return
         else:
-            if type(actTrigger.value) == type([]) and len(actTrigger.value) > 0:
+            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
                 PtDebugPrint("DEBUG: tldnPTPumpCount.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
                 pass
                 
         # error check
-        if type(stringVarName.value) != type("") or stringVarName.value == "":
+        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
             PtDebugPrint("ERROR: tldnPTPumpCount.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/tldnPTPumpCount.py
+++ b/Python/tldnPTPumpCount.py
@@ -95,13 +95,13 @@ class tldnPTPumpCount(ptResponder):
         
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 ageSDL.setFlags(stringVarName.value,1,1)
                 ageSDL.sendToClients(stringVarName.value)
             else:
                 PtDebugPrint("ERROR: tldnPTPumpCount.OnFirstUpdate():\tERROR: missing SDL var name in max file")
                 pass
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
                 try:
                     intCurrentValue = ageSDL[stringVarName.value][0]
@@ -122,12 +122,12 @@ class tldnPTPumpCount(ptResponder):
         if not PtWasLocallyNotified(self.key):
             return
         else:
-            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
+            if actTrigger.value:
                 PtDebugPrint("DEBUG: tldnPTPumpCount.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
                 pass
                 
         # error check
-        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
+        if not stringVarName.value:
             PtDebugPrint("ERROR: tldnPTPumpCount.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/tldnPwrTwrPeriscope.py
+++ b/Python/tldnPwrTwrPeriscope.py
@@ -118,7 +118,7 @@ class tldnPwrTwrPeriscope(ptResponder):
     def OnFirstUpdate(self):
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtLoadDialog(Vignette.value,self.key, "Teledahn")
         # non-age SDL vars
         self.SDL.setDefault("scopeSpdLeft",(0,))
@@ -549,7 +549,7 @@ class tldnPwrTwrPeriscope(ptResponder):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtLoadDialog(Vignette.value,self.key, "Teledahn")
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -562,7 +562,7 @@ class tldnPwrTwrPeriscope(ptResponder):
         global LocalAvatar
         global boolScopeOperator
         # exit every thing
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtHideDialog(Vignette.value)
         virtCam = ptCamera()
         virtCam.restore(Camera.sceneobject.getKey())

--- a/Python/tldnPwrTwrPeriscope.py
+++ b/Python/tldnPwrTwrPeriscope.py
@@ -118,7 +118,7 @@ class tldnPwrTwrPeriscope(ptResponder):
     def OnFirstUpdate(self):
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtLoadDialog(Vignette.value,self.key, "Teledahn")
         # non-age SDL vars
         self.SDL.setDefault("scopeSpdLeft",(0,))
@@ -549,7 +549,7 @@ class tldnPwrTwrPeriscope(ptResponder):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtLoadDialog(Vignette.value,self.key, "Teledahn")
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -562,7 +562,7 @@ class tldnPwrTwrPeriscope(ptResponder):
         global LocalAvatar
         global boolScopeOperator
         # exit every thing
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtHideDialog(Vignette.value)
         virtCam = ptCamera()
         virtCam.restore(Camera.sceneobject.getKey())

--- a/Python/tldnSlavePrisonDoors.py
+++ b/Python/tldnSlavePrisonDoors.py
@@ -244,7 +244,7 @@ class tldnSlavePrisonDoors(ptResponder):
                     break
             else:
                 # otherwise look at the responder states
-                if type(resp.value) == type([]) and len(resp.value) > 0:
+                if isinstance(resp.value, list) and len(resp.value) > 0:
                     plate = resp.value[0].getSceneObject().getResponderState()
                     # plate == 0 is up (no weight) and plate == 1 is pressed down (has weight)
     

--- a/Python/tldnSlavePrisonDoors.py
+++ b/Python/tldnSlavePrisonDoors.py
@@ -244,7 +244,7 @@ class tldnSlavePrisonDoors(ptResponder):
                     break
             else:
                 # otherwise look at the responder states
-                if isinstance(resp.value, list) and len(resp.value) > 0:
+                if resp.value:
                     plate = resp.value[0].getSceneObject().getResponderState()
                     # plate == 0 is up (no weight) and plate == 1 is pressed down (has weight)
     

--- a/Python/tldnSlavePrisonPanels.py
+++ b/Python/tldnSlavePrisonPanels.py
@@ -84,7 +84,7 @@ class tldnSlavePrisonPanels(ptResponder):
     def OnServerInitComplete(self):
         global boolCurrentValue
         ageSDL = PtGetAgeSDL()
-        if type(stringVarName.value) == type("") and stringVarName.value != "":
+        if isinstance(stringVarName.value, str) and stringVarName.value != "":
             ageSDL = PtGetAgeSDL()
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)

--- a/Python/tldnSlavePrisonPanels.py
+++ b/Python/tldnSlavePrisonPanels.py
@@ -84,7 +84,7 @@ class tldnSlavePrisonPanels(ptResponder):
     def OnServerInitComplete(self):
         global boolCurrentValue
         ageSDL = PtGetAgeSDL()
-        if isinstance(stringVarName.value, str) and stringVarName.value != "":
+        if stringVarName.value:
             ageSDL = PtGetAgeSDL()
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)

--- a/Python/tldnVaporScope.py
+++ b/Python/tldnVaporScope.py
@@ -166,7 +166,7 @@ class tldnVaporScope(ptModifier):
             
     def __del__(self):
         "unload the dialog that we loaded"
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtUnloadDialog(Vignette.value)
 
     def OnNotify(self,state,id,events):
@@ -227,7 +227,7 @@ class tldnVaporScope(ptModifier):
                 zoomSlider.setValue(zsliderValue)
                 PtDebugPrint("tldnVaporScope:ShowDialog:  current FOVh at %f - setting slider to %f" % (gInitialFOV,zsliderValue))
         elif event == kValueChanged:
-            if type(control) != type(None):
+            if control is not None:
                 knobID = control.getTagID()
                 if knobID == kZoomSlider:
                     newFOV = (control.getValue() * kDegreesPerSlider) + kMaxFOV
@@ -235,7 +235,7 @@ class tldnVaporScope(ptModifier):
                     curCam.setFOV(newFOV,0.5)
                     PtDebugPrint("tldnVaporScope:ValueChange:  slider=%f and setting FOV to %f" % (control.getValue(),newFOV))
         elif event == kAction:
-            if type(control) != type(None):
+            if control is not None:
                 btnID = control.getTagID()
                 if btnID == kLeftScopeBtn:
                     if isinstance(control,ptGUIControlButton) and control.isButtonDown():
@@ -289,7 +289,7 @@ class tldnVaporScope(ptModifier):
                         PtRequestLOSScreen(self.key,42,0.5,0.5,10000,PtLOSObjectType.kShootable,PtLOSReportType.kReportHitOrMiss)
                         gThrottleShooting = 1
                         try:
-                            if type(Vignette.value) != type(None) and Vignette.value != "":
+                            if Vignette.value is not None and Vignette.value != "":
                                 scopeDlg = PtGetDialogFromString(Vignette.value)
                                 if scopeDlg:
                                     try:
@@ -374,7 +374,7 @@ class tldnVaporScope(ptModifier):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtLoadDialog(Vignette.value,self.key, "Teledahn")
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -416,7 +416,7 @@ class tldnVaporScope(ptModifier):
             # we can not let firing happen... again
             gThrottleShooting = 0
             try:
-                if type(Vignette.value) != type(None) and Vignette.value != "":
+                if Vignette.value is not None and Vignette.value != "":
                     scopeDlg = PtGetDialogFromString(Vignette.value)
                     if scopeDlg:
                         try:

--- a/Python/tldnVaporScope.py
+++ b/Python/tldnVaporScope.py
@@ -166,7 +166,7 @@ class tldnVaporScope(ptModifier):
             
     def __del__(self):
         "unload the dialog that we loaded"
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtUnloadDialog(Vignette.value)
 
     def OnNotify(self,state,id,events):
@@ -289,7 +289,7 @@ class tldnVaporScope(ptModifier):
                         PtRequestLOSScreen(self.key,42,0.5,0.5,10000,PtLOSObjectType.kShootable,PtLOSReportType.kReportHitOrMiss)
                         gThrottleShooting = 1
                         try:
-                            if Vignette.value is not None and Vignette.value != "":
+                            if Vignette.value:
                                 scopeDlg = PtGetDialogFromString(Vignette.value)
                                 if scopeDlg:
                                     try:
@@ -374,7 +374,7 @@ class tldnVaporScope(ptModifier):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtLoadDialog(Vignette.value,self.key, "Teledahn")
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -416,7 +416,7 @@ class tldnVaporScope(ptModifier):
             # we can not let firing happen... again
             gThrottleShooting = 0
             try:
-                if Vignette.value is not None and Vignette.value != "":
+                if Vignette.value:
                     scopeDlg = PtGetDialogFromString(Vignette.value)
                     if scopeDlg:
                         try:

--- a/Python/xAgeSDLBoolAndRespond.py
+++ b/Python/xAgeSDLBoolAndRespond.py
@@ -78,9 +78,9 @@ class xAgeSDLBoolAndRespond(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not(isinstance(stringVar1Name.value, str) and stringVar1Name.value != ""):
+        if not stringVar1Name.value:
             PtDebugPrint("ERROR: xAgeSDLBoolAndRespond.OnFirstUpdate():\tERROR: missing SDL var1 name in max file")
-        if not(isinstance(stringVar2Name.value, str) and stringVar2Name.value != ""):
+        if not stringVar2Name.value:
             PtDebugPrint("ERROR: xAgeSDLBoolAndRespond.OnFirstUpdate():\tERROR: missing SDL var2 name in max file")
 
     def OnServerInitComplete(self):

--- a/Python/xAgeSDLBoolAndRespond.py
+++ b/Python/xAgeSDLBoolAndRespond.py
@@ -78,9 +78,9 @@ class xAgeSDLBoolAndRespond(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not(type(stringVar1Name.value) == type("") and stringVar1Name.value != ""):
+        if not(isinstance(stringVar1Name.value, str) and stringVar1Name.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolAndRespond.OnFirstUpdate():\tERROR: missing SDL var1 name in max file")
-        if not(type(stringVar2Name.value) == type("") and stringVar2Name.value != ""):
+        if not(isinstance(stringVar2Name.value, str) and stringVar2Name.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolAndRespond.OnFirstUpdate():\tERROR: missing SDL var2 name in max file")
 
     def OnServerInitComplete(self):

--- a/Python/xAgeSDLBoolAndSet.py
+++ b/Python/xAgeSDLBoolAndSet.py
@@ -68,11 +68,11 @@ class xAgeSDLBoolAndSet(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (type(stringOpA.value) == type("") and stringOpA.value != ""):
+        if not (isinstance(stringOpA.value, str) and stringOpA.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLOpA var name in max file")
-        if not (type(stringOpB.value) == type("") and stringOpB.value != ""):
+        if not (isinstance(stringOpB.value, str) and stringOpB.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLOpB var name in max file")
-        if not (type(stringResult.value) == type("") and stringResult.value != ""):
+        if not (isinstance(stringResult.value, str) and stringResult.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLResult var name in max file")
             
     def OnServerInitComplete(self):

--- a/Python/xAgeSDLBoolAndSet.py
+++ b/Python/xAgeSDLBoolAndSet.py
@@ -68,11 +68,11 @@ class xAgeSDLBoolAndSet(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (isinstance(stringOpA.value, str) and stringOpA.value != ""):
+        if not stringOpA.value:
             PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLOpA var name in max file")
-        if not (isinstance(stringOpB.value, str) and stringOpB.value != ""):
+        if not stringOpB.value:
             PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLOpB var name in max file")
-        if not (isinstance(stringResult.value, str) and stringResult.value != ""):
+        if not stringResult.value:
             PtDebugPrint("ERROR: xAgeSDLBoolAndSet.OnFirstUpdate():\tERROR: missing SDLResult var name in max file")
             
     def OnServerInitComplete(self):

--- a/Python/xAgeSDLBoolCondResp.py
+++ b/Python/xAgeSDLBoolCondResp.py
@@ -71,7 +71,7 @@ class xAgeSDLBoolCondResp(ptResponder):
         self.initFinished = 0
 
     def OnFirstUpdate(self):
-        if not isinstance(strSDLVar.value, str) or strSDLVar.value == "":
+        if not strSDLVar.value:
             PtDebugPrint("ERROR: xAgeSDLBoolCondResp.OnFirstUpdate():\tCannot bind to SDL variable, invalid string")
             self.invalidVarName = 1
         else:

--- a/Python/xAgeSDLBoolCondResp.py
+++ b/Python/xAgeSDLBoolCondResp.py
@@ -71,7 +71,7 @@ class xAgeSDLBoolCondResp(ptResponder):
         self.initFinished = 0
 
     def OnFirstUpdate(self):
-        if type(strSDLVar.value) != type("") or strSDLVar.value == "":
+        if not isinstance(strSDLVar.value, str) or strSDLVar.value == "":
             PtDebugPrint("ERROR: xAgeSDLBoolCondResp.OnFirstUpdate():\tCannot bind to SDL variable, invalid string")
             self.invalidVarName = 1
         else:

--- a/Python/xAgeSDLBoolSet.py
+++ b/Python/xAgeSDLBoolSet.py
@@ -68,7 +68,7 @@ class xAgeSDLBoolSet(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not(isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLBoolSet.OnFirstUpdate():\tERROR: missing SDL var name in max file")
     
     def OnServerInitComplete(self):
@@ -83,12 +83,12 @@ class xAgeSDLBoolSet(ptResponder):
         if not PtWasLocallyNotified(self.key):
             return
         else:
-            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
+            if actTrigger.value:
                 PtDebugPrint("DEBUG: xAgeSDLBoolSet.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
                 pass
                 
         # error check
-        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLBoolSet.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/xAgeSDLBoolSet.py
+++ b/Python/xAgeSDLBoolSet.py
@@ -68,7 +68,7 @@ class xAgeSDLBoolSet(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not(type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not(isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolSet.OnFirstUpdate():\tERROR: missing SDL var name in max file")
     
     def OnServerInitComplete(self):
@@ -83,12 +83,12 @@ class xAgeSDLBoolSet(ptResponder):
         if not PtWasLocallyNotified(self.key):
             return
         else:
-            if type(actTrigger.value) == type([]) and len(actTrigger.value) > 0:
+            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
                 PtDebugPrint("DEBUG: xAgeSDLBoolSet.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
                 pass
                 
         # error check
-        if type(stringVarName.value) != type("") or stringVarName.value == "":
+        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
             PtDebugPrint("ERROR: xAgeSDLBoolSet.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/xAgeSDLBoolToggle.py
+++ b/Python/xAgeSDLBoolToggle.py
@@ -73,7 +73,7 @@ class xAgeSDLBoolToggle(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLBoolToggle.OnFirstUpdate():\tERROR: missing SDL var name")
 
     def OnServerInitComplete(self):
@@ -82,7 +82,7 @@ class xAgeSDLBoolToggle(ptResponder):
         ageSDL = PtGetAgeSDL()
         ageSDL.setFlags(stringVarName.value,1,1)
         ageSDL.sendToClients(stringVarName.value)
-        if isinstance(stringVarName.value, str) and stringVarName.value != "":
+        if stringVarName.value:
             ageSDL.setNotify(self.key,stringVarName.value,0.0)
             try:
                 boolCurrentValue = ageSDL[stringVarName.value][0]
@@ -97,13 +97,13 @@ class xAgeSDLBoolToggle(ptResponder):
 
         # is this notify something I should act on?
         if id == actTrigger.id and state and PtFindAvatar(events) == PtGetLocalAvatar():
-            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
+            if actTrigger.value:
                 PtDebugPrint("DEBUG: xAgeSDLBoolToggle.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
         else:
             return
                 
         # error check
-        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLBoolToggle.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/xAgeSDLBoolToggle.py
+++ b/Python/xAgeSDLBoolToggle.py
@@ -73,7 +73,7 @@ class xAgeSDLBoolToggle(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolToggle.OnFirstUpdate():\tERROR: missing SDL var name")
 
     def OnServerInitComplete(self):
@@ -82,7 +82,7 @@ class xAgeSDLBoolToggle(ptResponder):
         ageSDL = PtGetAgeSDL()
         ageSDL.setFlags(stringVarName.value,1,1)
         ageSDL.sendToClients(stringVarName.value)
-        if type(stringVarName.value) == type("") and stringVarName.value != "":
+        if isinstance(stringVarName.value, str) and stringVarName.value != "":
             ageSDL.setNotify(self.key,stringVarName.value,0.0)
             try:
                 boolCurrentValue = ageSDL[stringVarName.value][0]
@@ -97,13 +97,13 @@ class xAgeSDLBoolToggle(ptResponder):
 
         # is this notify something I should act on?
         if id == actTrigger.id and state and PtFindAvatar(events) == PtGetLocalAvatar():
-            if type(actTrigger.value) == type([]) and len(actTrigger.value) > 0:
+            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
                 PtDebugPrint("DEBUG: xAgeSDLBoolToggle.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
         else:
             return
                 
         # error check
-        if type(stringVarName.value) != type("") or stringVarName.value == "":
+        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
             PtDebugPrint("ERROR: xAgeSDLBoolToggle.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/xAgeSDLBoolToggleDependent.py
+++ b/Python/xAgeSDLBoolToggleDependent.py
@@ -75,9 +75,9 @@ class xAgeSDLBoolToggleDependent(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (type(stringVarEnabler.value) == type("") and stringVarEnabler.value != ""):
+        if not (isinstance(stringVarEnabler.value, str) and stringVarEnabler.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolToggleDependent.OnFirstUpdate():\tERROR: missing SDLEnabler var name")
-        if not (type(stringVarTarget.value) == type("") and stringVarTarget.value != ""):
+        if not (isinstance(stringVarTarget.value, str) and stringVarTarget.value != ""):
             PtDebugPrint("ERROR: xAgeSDLBoolToggleDependent.OnFirstUpdate():\tERROR: missing SDLTarget var name")
 
     def OnServerInitComplete(self):

--- a/Python/xAgeSDLBoolToggleDependent.py
+++ b/Python/xAgeSDLBoolToggleDependent.py
@@ -75,9 +75,9 @@ class xAgeSDLBoolToggleDependent(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (isinstance(stringVarEnabler.value, str) and stringVarEnabler.value != ""):
+        if not stringVarEnabler.value:
             PtDebugPrint("ERROR: xAgeSDLBoolToggleDependent.OnFirstUpdate():\tERROR: missing SDLEnabler var name")
-        if not (isinstance(stringVarTarget.value, str) and stringVarTarget.value != ""):
+        if not stringVarTarget.value:
             PtDebugPrint("ERROR: xAgeSDLBoolToggleDependent.OnFirstUpdate():\tERROR: missing SDLTarget var name")
 
     def OnServerInitComplete(self):

--- a/Python/xAgeSDLIntActEnabler.py
+++ b/Python/xAgeSDLIntActEnabler.py
@@ -66,7 +66,7 @@ class xAgeSDLIntActEnabler(ptResponder):
         print "__init__xAgeSDLIntActEnabler v.", version
     
     def OnFirstUpdate(self):
-        if not (type(stringSDLVarName.value) == type("") and stringSDLVarName.value != ""):
+        if not (isinstance(stringSDLVarName.value, str) and stringSDLVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLIntActEnabler.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
     

--- a/Python/xAgeSDLIntActEnabler.py
+++ b/Python/xAgeSDLIntActEnabler.py
@@ -66,7 +66,7 @@ class xAgeSDLIntActEnabler(ptResponder):
         print "__init__xAgeSDLIntActEnabler v.", version
     
     def OnFirstUpdate(self):
-        if not (isinstance(stringSDLVarName.value, str) and stringSDLVarName.value != ""):
+        if not stringSDLVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntActEnabler.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
     

--- a/Python/xAgeSDLIntChange.py
+++ b/Python/xAgeSDLIntChange.py
@@ -80,7 +80,7 @@ class xAgeSDLIntChange(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLIntChange.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
             
@@ -88,7 +88,7 @@ class xAgeSDLIntChange(ptResponder):
         global intCurrentValue
         
         ageSDL = PtGetAgeSDL()
-        if type(stringVarName.value) == type("") and stringVarName.value != "":
+        if isinstance(stringVarName.value, str) and stringVarName.value != "":
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)
             ageSDL.setNotify(self.key,stringVarName.value,0.0)
@@ -111,12 +111,12 @@ class xAgeSDLIntChange(ptResponder):
         if not PtWasLocallyNotified(self.key):
             return
         else:
-            if type(actTrigger.value) == type([]) and len(actTrigger.value) > 0:
+            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
                 PtDebugPrint("DEBUG: xAgeSDLIntChange.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
                 pass
                 
         # error check
-        if type(stringVarName.value) != type("") or stringVarName.value == "":
+        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
             PtDebugPrint("ERROR: xAgeSDLIntChange.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/xAgeSDLIntChange.py
+++ b/Python/xAgeSDLIntChange.py
@@ -80,7 +80,7 @@ class xAgeSDLIntChange(ptResponder):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntChange.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
             
@@ -88,7 +88,7 @@ class xAgeSDLIntChange(ptResponder):
         global intCurrentValue
         
         ageSDL = PtGetAgeSDL()
-        if isinstance(stringVarName.value, str) and stringVarName.value != "":
+        if stringVarName.value:
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)
             ageSDL.setNotify(self.key,stringVarName.value,0.0)
@@ -111,12 +111,12 @@ class xAgeSDLIntChange(ptResponder):
         if not PtWasLocallyNotified(self.key):
             return
         else:
-            if isinstance(actTrigger.value, list) and len(actTrigger.value) > 0:
+            if actTrigger.value:
                 PtDebugPrint("DEBUG: xAgeSDLIntChange.OnNotify():\t local player requesting %s change via %s" % (stringVarName.value,actTrigger.value[0].getName()) )
                 pass
                 
         # error check
-        if not isinstance(stringVarName.value, str) or stringVarName.value == "":
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntChange.OnNotify():\tERROR: missing SDL var name")
             return
             

--- a/Python/xAgeSDLIntRespList.py
+++ b/Python/xAgeSDLIntRespList.py
@@ -75,11 +75,11 @@ class xAgeSDLIntRespList(ptResponder):
         print "__init__xAgeSDLIntRespList v.", self.version
     
     def OnFirstUpdate(self):
-        if type(stringSDLVarName.value) != type("") or stringSDLVarName.value == "":
+        if not isinstance(stringSDLVarName.value, str) or stringSDLVarName.value == "":
             PtDebugPrint("ERROR: xAgeSDLIntRespList.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
             
-        elif type(stringFormat.value) != type("") or stringFormat.value == "":
+        elif not isinstance(stringFormat.value, str) or stringFormat.value == "":
             PtDebugPrint("ERROR: xAgeSDLIntRespList.OnFirstUpdate():\tERROR: missing responder name format string in max file")
             pass
     

--- a/Python/xAgeSDLIntRespList.py
+++ b/Python/xAgeSDLIntRespList.py
@@ -75,11 +75,11 @@ class xAgeSDLIntRespList(ptResponder):
         print "__init__xAgeSDLIntRespList v.", self.version
     
     def OnFirstUpdate(self):
-        if not isinstance(stringSDLVarName.value, str) or stringSDLVarName.value == "":
+        if not stringSDLVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntRespList.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
             
-        elif not isinstance(stringFormat.value, str) or stringFormat.value == "":
+        elif not stringFormat.value:
             PtDebugPrint("ERROR: xAgeSDLIntRespList.OnFirstUpdate():\tERROR: missing responder name format string in max file")
             pass
     

--- a/Python/xAgeSDLIntShowHide.py
+++ b/Python/xAgeSDLIntShowHide.py
@@ -67,7 +67,7 @@ class xAgeSDLIntShowHide(ptMultiModifier):
         self.enabledStateList = []
 
     def OnFirstUpdate(self):
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntShowHide.OnFirstUpdate():\tERROR: missing SDL var name")
             pass
         
@@ -80,7 +80,7 @@ class xAgeSDLIntShowHide(ptMultiModifier):
     
     def Initialize(self):
         ageSDL = PtGetAgeSDL()
-        if isinstance(stringVarName.value, str) and stringVarName.value != "":
+        if stringVarName.value:
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)
             try:
@@ -147,7 +147,7 @@ class xAgeSDLIntShowHide(ptMultiModifier):
         self.sceneobject.physics.suppress(true)
 
     def OnBackdoorMsg(self, target, param):
-        if stringVarName.value is not None and stringVarName.value != "":
+        if stringVarName.value:
             if target == stringVarName.value:
                 if int(param) in self.enabledStateList:
                     self.EnableObject()

--- a/Python/xAgeSDLIntShowHide.py
+++ b/Python/xAgeSDLIntShowHide.py
@@ -67,7 +67,7 @@ class xAgeSDLIntShowHide(ptMultiModifier):
         self.enabledStateList = []
 
     def OnFirstUpdate(self):
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLIntShowHide.OnFirstUpdate():\tERROR: missing SDL var name")
             pass
         
@@ -80,7 +80,7 @@ class xAgeSDLIntShowHide(ptMultiModifier):
     
     def Initialize(self):
         ageSDL = PtGetAgeSDL()
-        if type(stringVarName.value) == type("") and stringVarName.value != "":
+        if isinstance(stringVarName.value, str) and stringVarName.value != "":
             ageSDL.setFlags(stringVarName.value,1,1)
             ageSDL.sendToClients(stringVarName.value)
             try:
@@ -147,7 +147,7 @@ class xAgeSDLIntShowHide(ptMultiModifier):
         self.sceneobject.physics.suppress(true)
 
     def OnBackdoorMsg(self, target, param):
-        if type(stringVarName.value) != type(None) and stringVarName.value != "":
+        if stringVarName.value is not None and stringVarName.value != "":
             if target == stringVarName.value:
                 if int(param) in self.enabledStateList:
                     self.EnableObject()

--- a/Python/xAgeSDLIntStartStopResp.py
+++ b/Python/xAgeSDLIntStartStopResp.py
@@ -71,7 +71,7 @@ class xAgeSDLIntStartStopResp(ptResponder):
         print "__init__xAgeSDLIntStartStopResp v.", version
     
     def OnFirstUpdate(self):
-        if not (type(stringSDLVarName.value) == type("") and stringSDLVarName.value != ""):
+        if not (isinstance(stringSDLVarName.value, str) and stringSDLVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLIntStartStopResp.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
     

--- a/Python/xAgeSDLIntStartStopResp.py
+++ b/Python/xAgeSDLIntStartStopResp.py
@@ -71,7 +71,7 @@ class xAgeSDLIntStartStopResp(ptResponder):
         print "__init__xAgeSDLIntStartStopResp v.", version
     
     def OnFirstUpdate(self):
-        if not (isinstance(stringSDLVarName.value, str) and stringSDLVarName.value != ""):
+        if not stringSDLVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntStartStopResp.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
     

--- a/Python/xAgeSDLIntStateListResp.py
+++ b/Python/xAgeSDLIntStateListResp.py
@@ -126,7 +126,7 @@ class xAgeSDLIntStateListResp(ptResponder):
         print "__init__xAgeSDLIntStateListResp v", version
     
     def OnFirstUpdate(self):
-        if not (isinstance(strSDLVarName.value, str) and strSDLVarName.value != ""):
+        if not strSDLVarName.value:
             PtDebugPrint("ERROR: xAgeSDLIntStateListResp.OnFirstUpdate():\tERROR: missing SDL var name in max file")
 
         if boolFirstUpdate.value:

--- a/Python/xAgeSDLIntStateListResp.py
+++ b/Python/xAgeSDLIntStateListResp.py
@@ -67,13 +67,13 @@ from PlasmaTypes import *
 class ptAttribStateResponder(ptAttribResponder):
     def run(self,key,state=None,events=None,avatar=None,objectName=None,netForce=0,netPropagate=1,fastforward=0):
         # has the value been set?
-        if type(self.value) != type(None):
+        if self.value is not None:
             nt = ptNotify(key)
             nt.clearReceivers()
             # see if the value is a list or byObject or a single
-            if type(objectName) != type(None) and type(self.byObject) != type(None):
+            if objectName is not None and self.byObject is not None:
                 nt.addReceiver(self.byObject[objectName])
-            elif type(self.value)==type([]):
+            elif isinstance(self.value, list):
                 for resp in self.value:
                     nt.addReceiver(resp)
             else:
@@ -84,15 +84,15 @@ class ptAttribStateResponder(ptAttribResponder):
             if netForce or self.netForce:
                 nt.netForce(1)
             # see if the state is specified
-            if type(state) == type(0) and state >= 0:
+            if isinstance(state, int) and state >= 0:
                 nt.addResponderState(state)
             else:
                 raise ptResponderStateError("State must be a positive integer")
             
             # see if there are events to pass on
-            if type(events) != type(None):
+            if events is not None:
                 PtAddEvents(nt,events)
-            if type(avatar) != type(None):
+            if avatar is not None:
                 nt.addCollisionEvent(1,avatar.getKey(),avatar.getKey())
             if fastforward:
                 nt.setType(PtNotificationType.kResponderFF)
@@ -126,7 +126,7 @@ class xAgeSDLIntStateListResp(ptResponder):
         print "__init__xAgeSDLIntStateListResp v", version
     
     def OnFirstUpdate(self):
-        if not (type(strSDLVarName.value) == type("") and strSDLVarName.value != ""):
+        if not (isinstance(strSDLVarName.value, str) and strSDLVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLIntStateListResp.OnFirstUpdate():\tERROR: missing SDL var name in max file")
 
         if boolFirstUpdate.value:

--- a/Python/xAgeSDLVarSet.py
+++ b/Python/xAgeSDLVarSet.py
@@ -74,7 +74,7 @@ class xAgeSDLVarSet(ptResponder):
         print "__init__xAgeSDLVarSet v.", version
     
     def OnFirstUpdate(self):
-        if not (isinstance(stringSDLVarName.value, str) and stringSDLVarName.value != ""):
+        if not stringSDLVarName.value:
             PtDebugPrint("ERROR: xAgeSDLVarSet.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
     
@@ -114,7 +114,7 @@ class xAgeSDLVarSet(ptResponder):
         # Check if the current SDL value represents a state in the dictionary and set the other SDL value to the value in the dictionary (yay for values!)
         if  self.enabledStateDict.has_key(int(SDLvalue)):
             ageSDL[stringSDLVarToSet.value] = (self.enabledStateDict[int(SDLvalue)],)
-            if stringSDLVarToSet is not None and stringSDLVarToSet.value != "":
+            if stringSDLVarToSet:
                 ageSDL.setTagString(stringSDLVarToSet.value,stringTag.value)
             PtDebugPrint("DEBUG: xAgeSDLVarSet.OnServerInitComplete:\t%s setting %s to %d" % (stringSDLVarName.value, stringSDLVarToSet.value, self.enabledStateDict[int(SDLvalue)]))
         
@@ -135,7 +135,7 @@ class xAgeSDLVarSet(ptResponder):
         # Check if the current SDL value represents a state in the dictionary and set the other SDL value to the value in the dictionary (yay for values!)
         if  self.enabledStateDict.has_key(int(SDLvalue)):
             ageSDL[stringSDLVarToSet.value] = (self.enabledStateDict[int(SDLvalue)],)
-            if stringSDLVarToSet is not None and stringSDLVarToSet.value != "":
+            if stringSDLVarToSet:
                 ageSDL.setTagString(stringSDLVarToSet.value,stringTag.value)
             PtDebugPrint("DEBUG: xAgeSDLVarSet.OnServerInitComplete:\t%s setting %s to %d, tag string: %s" % (stringSDLVarName.value, stringSDLVarToSet.value, self.enabledStateDict[int(SDLvalue)], stringTag.value))
         

--- a/Python/xAgeSDLVarSet.py
+++ b/Python/xAgeSDLVarSet.py
@@ -74,7 +74,7 @@ class xAgeSDLVarSet(ptResponder):
         print "__init__xAgeSDLVarSet v.", version
     
     def OnFirstUpdate(self):
-        if not (type(stringSDLVarName.value) == type("") and stringSDLVarName.value != ""):
+        if not (isinstance(stringSDLVarName.value, str) and stringSDLVarName.value != ""):
             PtDebugPrint("ERROR: xAgeSDLVarSet.OnFirstUpdate():\tERROR: missing SDL var name in max file")
             pass
     
@@ -114,7 +114,7 @@ class xAgeSDLVarSet(ptResponder):
         # Check if the current SDL value represents a state in the dictionary and set the other SDL value to the value in the dictionary (yay for values!)
         if  self.enabledStateDict.has_key(int(SDLvalue)):
             ageSDL[stringSDLVarToSet.value] = (self.enabledStateDict[int(SDLvalue)],)
-            if type(stringSDLVarToSet) != type(None) and stringSDLVarToSet.value != "":
+            if stringSDLVarToSet is not None and stringSDLVarToSet.value != "":
                 ageSDL.setTagString(stringSDLVarToSet.value,stringTag.value)
             PtDebugPrint("DEBUG: xAgeSDLVarSet.OnServerInitComplete:\t%s setting %s to %d" % (stringSDLVarName.value, stringSDLVarToSet.value, self.enabledStateDict[int(SDLvalue)]))
         
@@ -135,7 +135,7 @@ class xAgeSDLVarSet(ptResponder):
         # Check if the current SDL value represents a state in the dictionary and set the other SDL value to the value in the dictionary (yay for values!)
         if  self.enabledStateDict.has_key(int(SDLvalue)):
             ageSDL[stringSDLVarToSet.value] = (self.enabledStateDict[int(SDLvalue)],)
-            if type(stringSDLVarToSet) != type(None) and stringSDLVarToSet.value != "":
+            if stringSDLVarToSet is not None and stringSDLVarToSet.value != "":
                 ageSDL.setTagString(stringSDLVarToSet.value,stringTag.value)
             PtDebugPrint("DEBUG: xAgeSDLVarSet.OnServerInitComplete:\t%s setting %s to %d, tag string: %s" % (stringSDLVarName.value, stringSDLVarToSet.value, self.enabledStateDict[int(SDLvalue)], stringTag.value))
         

--- a/Python/xAvatarCustomization.py
+++ b/Python/xAvatarCustomization.py
@@ -699,7 +699,7 @@ class xAvatarCustomization(ptModifier):
                             listboxDict[tagID + kAccessoryLBOffset].UpdateListbox()
                             listbox = ptGUIControlListBox(AvCustGUI.dialog.getControlFromTag(tagID+kAccessoryLBOffset))
                             self.OnGUINotify(AvCustGUI.id, listbox, kValueChanged) # fake a mouse down
-                    elif type(clothing_group) != type(None):
+                    elif clothing_group is not None:
                         # found list box
                         itemselect = control.getSelection()
                         if itemselect == -1:
@@ -712,7 +712,7 @@ class xAvatarCustomization(ptModifier):
                             # get the current worn item to see what color it was
                             lastitem = FindWornItem(clothing_group.clothingType)
                             avatar = PtGetLocalAvatar()
-                            if type(lastitem) != type(None):
+                            if lastitem is not None:
                                 # just get the color straight from the item
                                 lastcolor1 = avatar.avatar.getTintClothingItem(lastitem.name,1)
                                 lastcolor2 = avatar.avatar.getTintClothingItem(lastitem.name,2)
@@ -722,7 +722,7 @@ class xAvatarCustomization(ptModifier):
                             # if we need to grab a second object (like a second shoe), then get and wear it
                             if clothing_group.numberItems > 1:
                                 matchingItem = avatar.avatar.getMatchingClothingItem(newitem.name)
-                                if type(matchingItem) == type([]):
+                                if isinstance(matchingItem, list):
                                     avatar.avatar.wearClothingItem(matchingItem[0],0)
                                     avatar.avatar.tintClothingItem(matchingItem[0],lastcolor1,0)
                                     avatar.avatar.tintClothingItemLayer(matchingItem[0],lastcolor2,2,0)
@@ -758,7 +758,7 @@ class xAvatarCustomization(ptModifier):
                         if tagID-kAccessoryLBOffset == kUpperBodyOptionsLB or tagID-kAccessoryLBOffset == kLwrBodyOptionsLB:
                             # this "accessory" listbox is actually a textures listbox, treat as clothing
                             clothing_group = TheCloset[tagID-kAccessoryLBOffset]
-                            if type(clothing_group) != type(None):
+                            if clothing_group is not None:
                                 itemselect = control.getSelection()
                                 # if there is only one texture, it isn't shown, so fake it into selecting the first item
                                 if len(listboxDict[tagID].clothingList) == 1:
@@ -773,7 +773,7 @@ class xAvatarCustomization(ptModifier):
                                     avatar = PtGetLocalAvatar()
                                     # get the current worn item to see what color it was
                                     lastitem = FindWornItem(clothing_group.clothingType)
-                                    if type(lastitem) != type(None):
+                                    if lastitem is not None:
                                         # just get the color straight from the item
                                         lastcolor1 = avatar.avatar.getTintClothingItem(lastitem.name,1)
                                         lastcolor2 = avatar.avatar.getTintClothingItem(lastitem.name,2)
@@ -803,7 +803,7 @@ class xAvatarCustomization(ptModifier):
                                         self.IShowColorPicker(kColor2ClickMap)
                                         colorbar2.setStringW(newitem.colorlabel2)
                                         self.IDrawPickerThingy(kColor2ClickMap,lastcolor2)
-                        elif type(clothing_group) != type(None):
+                        elif clothing_group is not None:
                             itemselect = control.getSelection()
                             if itemselect == -1:
                                 avatar = PtGetLocalAvatar()
@@ -823,7 +823,7 @@ class xAvatarCustomization(ptModifier):
                                     if newitem.coloredAsHair:
                                         # find the hair color and color this item
                                         haircolor = self.IGetHairColor()
-                                        if type(haircolor) != type(None):
+                                        if haircolor is not None:
                                             avatar.avatar.wearClothingItem(newitem.name,0)
                                             avatar.avatar.tintClothingItem(newitem.name,haircolor)
                                         else:
@@ -893,7 +893,7 @@ class xAvatarCustomization(ptModifier):
                             self.ILinkToCloset()
 
                             #Disable other logic... no more going to the cleft from the AVC
-                            #~if type(entry) != type(None):
+                            #~if entry is not None:
                                 # player has solved the cleft
                                 # just go back to your personal age
                             #~        self.ILinkToCloset()
@@ -932,7 +932,7 @@ class xAvatarCustomization(ptModifier):
                             linkmgr.linkToAge(ageLink)
                             
                             #Disable other logic... no more going to cleft from the AVC!
-                            #~if type(entry) != type(None):
+                            #~if entry is not None:
                                 # player has solved the cleft
                                 # just go back to your personal age
                             #~    linkmgr = ptNetLinkingMgr()
@@ -1082,7 +1082,7 @@ class xAvatarCustomization(ptModifier):
             avatar.avatar.tintClothingItemLayer(item.name,color2,2)
             # add the matching item, if it exists
             matchingItem = avatar.avatar.getMatchingClothingItem(item.name)
-            if type(matchingItem) == type([]):
+            if isinstance(matchingItem, list):
                 avatar.avatar.wearClothingItem(matchingItem[0],0)
                 avatar.avatar.tintClothingItem(matchingItem[0],color1,0)
                 avatar.avatar.tintClothingItemLayer(matchingItem[0],color2,2,0)
@@ -1160,7 +1160,7 @@ class xAvatarCustomization(ptModifier):
                 avatar.avatar.tintClothingItemLayer(item,clr2,2)
                 # add the matching item, if it exists
                 matchingItem = avatar.avatar.getMatchingClothingItem(item)
-                if type(matchingItem) == type([]):
+                if isinstance(matchingItem, list):
                     avatar.avatar.wearClothingItem(matchingItem[0],0)
                     avatar.avatar.tintClothingItem(matchingItem[0],clr1,0)
                     avatar.avatar.tintClothingItemLayer(matchingItem[0],clr2,2,0)
@@ -1215,12 +1215,12 @@ class xAvatarCustomization(ptModifier):
         entry = vault.findChronicleEntry(kAvaCustaIsDone)
 
         InAvatarCloset = 0      # assume never been here before, until proven otherwise
-        if type(entry) != type(None):
+        if entry is not None:
             InAvatarCloset = 1
         PtDebugPrint("AvaCusta: InAvatarCloset is %d" % (InAvatarCloset))
 
         entry = vault.findChronicleEntry("GiveYeeshaReward")
-        if type(entry) != type(None):
+        if entry is not None:
             # we need to give the yeesha clothing (probably an imported char)
             avatar = PtGetLocalAvatar()
             currentgender = avatar.avatar.getAvatarClothingGroup()
@@ -1235,7 +1235,7 @@ class xAvatarCustomization(ptModifier):
             else:
                 print "player already has Yeesha reward clothing, doing nothing"
             folder = vault.getChronicleFolder()
-            if type(folder) != type(None):
+            if folder is not None:
                 folder.removeNode(entry)
 
     def IInitAvaCusta(self):
@@ -1406,7 +1406,7 @@ class xAvatarCustomization(ptModifier):
             # find the item that is worn that is in this clothing type
             wornItem = FindWornItem(clothing_type)
             # did we find the item that is being worn in this clothing group?
-            if type(wornItem) != type(None):
+            if wornItem is not None:
                 # if the saturation is zero then don't allow tiniting
                 if controlID == kColor1ClickMap or controlID == kColor2ClickMap:
                     #Make sure that we're not zoomed in (changing eye color)
@@ -1428,7 +1428,7 @@ class xAvatarCustomization(ptModifier):
                     clothing_group = TheCloset[CLxref[clothing_panel][1]]
                     if clothing_group.numberItems > 1:
                         matchingItem = avatar.avatar.getMatchingClothingItem(wornItem.name)
-                        if type(matchingItem) == type([]):
+                        if isinstance(matchingItem, list):
                             avatar.avatar.tintClothingItemLayer(matchingItem[0],colorit,layer,0)
                     avatar.avatar.tintClothingItemLayer(wornItem.name,colorit,layer)
                     # if we are messing with the face, color the accessory too! (only on layer 2 color)
@@ -1571,7 +1571,7 @@ class xAvatarCustomization(ptModifier):
             clothing_type = CLxref[clothing_panel][0]
             # find the clothing type in what is being worn
             wornitem = FindWornItem(clothing_type)
-            if type(wornitem) != type(None):
+            if wornitem is not None:
                 descbox = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kClothingDesc))
                 descbox.setStringW(wornitem.description)
                 colorbar1 = ptGUIControlTextBox(AvCustGUI.dialog.getControlFromTag(kColorbarName1))
@@ -2144,7 +2144,7 @@ class ClothingCloset:
             accCI = ClothingItem(accitem,0,0.0,1,0,0) # default is inCloset
             if CanShowClothingItem(accCI):
                 group = self.findGroup(accCI.groupwith)
-                if type(group) != type(None):
+                if group is not None:
                     # if this is not donotwear, then append at end
                     if not accCI.donotwear:
                         group.accessories.append(accCI)
@@ -2356,7 +2356,7 @@ class ScrollingListBox:
                         pass # we probably went to far, so just don't add the non-existant item
         # displayItems now has the correct 8 (or 4) items to show
         for item in displayItems:
-            if type(item.thumbnail) != type(0):
+            if not isinstance(item.thumbnail, int):
                 listbox.addImageInBox(item.thumbnail,kCLBImageX,kCLBImageY,kCLBImageWidth,kCLBImageHeight,1)
             else:
                 listbox.addStringInBox(item.name,kCLBMinWidth,kCLBMinHeight)

--- a/Python/xBugsGoAway.py
+++ b/Python/xBugsGoAway.py
@@ -62,9 +62,9 @@ class xBugsGoAway(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add chronicle
                 vault.addChronicleEntry(chronicleEntryName,0,str(count))
             else:
@@ -73,9 +73,9 @@ class xBugsGoAway(ptResponder):
     
     def IGetBugCount(self):
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleEntryName)
-            if type(entry) != type(None):
+            if entry is not None:
                 return int(entry.chronicleGetValue())
         return 0 # no vault or no chronicle var
 

--- a/Python/xBugsGoAway.py
+++ b/Python/xBugsGoAway.py
@@ -62,22 +62,20 @@ class xBugsGoAway(ptResponder):
     
     def ISaveBugCount(self, count):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is None:
-                # not found... add chronicle
-                vault.addChronicleEntry(chronicleEntryName,0,str(count))
-            else:
-                entry.chronicleSetValue(str(count))
-                entry.save()
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is None:
+            # not found... add chronicle
+            vault.addChronicleEntry(chronicleEntryName,0,str(count))
+        else:
+            entry.chronicleSetValue(str(count))
+            entry.save()
     
     def IGetBugCount(self):
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleEntryName)
-            if entry is not None:
-                return int(entry.chronicleGetValue())
-        return 0 # no vault or no chronicle var
+        entry = vault.findChronicleEntry(chronicleEntryName)
+        if entry is not None:
+            return int(entry.chronicleGetValue())
+        return 0 # no chronicle var
 
     def OnServerInitComplete(self):
         avatar = 0

--- a/Python/xCalendarStar.py
+++ b/Python/xCalendarStar.py
@@ -87,7 +87,7 @@ class xCalendarStar(ptResponder):
         global boolCalStar
 
         AgeStartedIn = PtGetAgeName()
-        if not (isinstance(sdlCalStar.value, str) and sdlCalStar.value != ""):
+        if not sdlCalStar.value:
             PtDebugPrint("ERROR: xCalendarStar.OnFirstUpdate():\tERROR: missing SDL var name")
             pass
 

--- a/Python/xCalendarStar.py
+++ b/Python/xCalendarStar.py
@@ -148,17 +148,16 @@ class xCalendarStar(ptResponder):
 
     def GotPage(self):
         vault = ptVault()
-        if vault is not None: #is the Vault online?
-            psnlSDL = xPsnlVaultSDL()
-            psnlSDL = vault.getPsnlAgeSDL()
-            if psnlSDL:
-                ypageSDL = psnlSDL.findVar("YeeshaPage20")
-                if ypageSDL:
-                    size, state = divmod(ypageSDL.getInt(), 10)
-                    print "YeeshaPage20 = ",state
-                    if state:
-                        return 1
-            return 0
+        psnlSDL = xPsnlVaultSDL()
+        psnlSDL = vault.getPsnlAgeSDL()
+        if psnlSDL:
+            ypageSDL = psnlSDL.findVar("YeeshaPage20")
+            if ypageSDL:
+                size, state = divmod(ypageSDL.getInt(), 10)
+                print "YeeshaPage20 = ",state
+                if state:
+                    return 1
+        return 0
 
 
 #    def OnSDLNotify(self,VARname,SDLname,playerID,tag):

--- a/Python/xCalendarStar.py
+++ b/Python/xCalendarStar.py
@@ -87,7 +87,7 @@ class xCalendarStar(ptResponder):
         global boolCalStar
 
         AgeStartedIn = PtGetAgeName()
-        if not (type(sdlCalStar.value) == type("") and sdlCalStar.value != ""):
+        if not (isinstance(sdlCalStar.value, str) and sdlCalStar.value != ""):
             PtDebugPrint("ERROR: xCalendarStar.OnFirstUpdate():\tERROR: missing SDL var name")
             pass
 
@@ -148,7 +148,7 @@ class xCalendarStar(ptResponder):
 
     def GotPage(self):
         vault = ptVault()
-        if type(vault) != type(None): #is the Vault online?
+        if vault is not None: #is the Vault online?
             psnlSDL = xPsnlVaultSDL()
             psnlSDL = vault.getPsnlAgeSDL()
             if psnlSDL:

--- a/Python/xChatChannelRegion.py
+++ b/Python/xChatChannelRegion.py
@@ -93,7 +93,7 @@ class xChatChannelRegion(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             self.SDL.setDefault("intSDLChatMembers",(-1,-1,-1,-1,-1,-1,-1,-1))
-            if type(doorVarName.value) == type("") and doorVarName.value != "":
+            if isinstance(doorVarName.value, str) and doorVarName.value != "":
                 ageSDL.setNotify(self.key,doorVarName.value,0.0)
 
     def OnFirstUpdate(self):

--- a/Python/xChatChannelRegion.py
+++ b/Python/xChatChannelRegion.py
@@ -93,7 +93,7 @@ class xChatChannelRegion(ptResponder):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
             self.SDL.setDefault("intSDLChatMembers",(-1,-1,-1,-1,-1,-1,-1,-1))
-            if isinstance(doorVarName.value, str) and doorVarName.value != "":
+            if doorVarName.value:
                 ageSDL.setNotify(self.key,doorVarName.value,0.0)
 
     def OnFirstUpdate(self):

--- a/Python/xCheat.py
+++ b/Python/xCheat.py
@@ -51,64 +51,55 @@ def ListYeeshaPages(args):
     import Plasma
     import xLinkingBookDefs
     vault = Plasma.ptVault()
-    if vault is not None: #is the Vault online?
-        psnlSDL = vault.getPsnlAgeSDL()
-        if psnlSDL:
-            for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
-                FoundValue = psnlSDL.findVar(sdlvar)
-                print "%s is %d" % (sdlvar, FoundValue.getInt())
-        else:
-            print "Could not find personal age SDL"
+    psnlSDL = vault.getPsnlAgeSDL()
+    if psnlSDL:
+        for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
+            FoundValue = psnlSDL.findVar(sdlvar)
+            print "%s is %d" % (sdlvar, FoundValue.getInt())
     else:
-        print "Could not find vault"
+        print "Could not find personal age SDL"
 
 
 def GetAllYeeshaPages(args):
     import Plasma
     import xLinkingBookDefs
     vault = Plasma.ptVault()
-    if vault is not None: #is the Vault online?
-        psnlSDL = vault.getPsnlAgeSDL()
-        if psnlSDL:
-            if args == "0":
-                newval = 0
-                print "xCheat.GetYeeshaPage(): removing all Yeesha pages..."
-            else:
-                newval = 1
-                print "xCheat.GetYeeshaPage(): adding all Yeesha pages..."
-            for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
-                FoundValue = psnlSDL.findVar(sdlvar)
-                FoundValue.setInt(newval)
-            vault.updatePsnlAgeSDL(psnlSDL)
+    psnlSDL = vault.getPsnlAgeSDL()
+    if psnlSDL:
+        if args == "0":
+            newval = 0
+            print "xCheat.GetYeeshaPage(): removing all Yeesha pages..."
         else:
-            print "Could not find personal age SDL"
+            newval = 1
+            print "xCheat.GetYeeshaPage(): adding all Yeesha pages..."
+        for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
+            FoundValue = psnlSDL.findVar(sdlvar)
+            FoundValue.setInt(newval)
+        vault.updatePsnlAgeSDL(psnlSDL)
     else:
-        print "Could not find vault"
+        print "Could not find personal age SDL"
 
 
 def GetYeeshaPage(args):
     import Plasma
     import xLinkingBookDefs
     vault = Plasma.ptVault()
-    if vault is not None: #is the Vault online?
-        psnlSDL = vault.getPsnlAgeSDL()
-        if args == None or args == "":
-            print "xCheat.GetYeeshaPage(): ERROR.  Must provide a Yeesha Page number."
-            return
-        thispage = "YeeshaPage" + args
-        if psnlSDL:
-            for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
-                if sdlvar == thispage:
-                    FoundValue = psnlSDL.findVar(sdlvar)
-                    FoundValue.setInt(1)
-                    vault.updatePsnlAgeSDL(psnlSDL)
-                    print "xCheat.GetYeeshaPage(): Done. Have added: ",sdlvar
-                    return
-            print "xCheat.GetYeeshaPage(): ERROR.  Could not find Yeesha page: ",thispage
-        else:
-            print "xCheat.GetYeeshaPage(): ERROR.  Could not find personal age SDL"
+    psnlSDL = vault.getPsnlAgeSDL()
+    if not args:
+        print "xCheat.GetYeeshaPage(): ERROR.  Must provide a Yeesha Page number."
+        return
+    thispage = "YeeshaPage" + args
+    if psnlSDL:
+        for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
+            if sdlvar == thispage:
+                FoundValue = psnlSDL.findVar(sdlvar)
+                FoundValue.setInt(1)
+                vault.updatePsnlAgeSDL(psnlSDL)
+                print "xCheat.GetYeeshaPage(): Done. Have added: ",sdlvar
+                return
+        print "xCheat.GetYeeshaPage(): ERROR.  Could not find Yeesha page: ",thispage
     else:
-        print "xCheat.GetYeeshaPage(): ERROR.  Could not find vault"
+        print "xCheat.GetYeeshaPage(): ERROR.  Could not find personal age SDL"
 
 
 def GetAgeJourneyCloths(args):

--- a/Python/xCheat.py
+++ b/Python/xCheat.py
@@ -51,7 +51,7 @@ def ListYeeshaPages(args):
     import Plasma
     import xLinkingBookDefs
     vault = Plasma.ptVault()
-    if type(vault) != type(None): #is the Vault online?
+    if vault is not None: #is the Vault online?
         psnlSDL = vault.getPsnlAgeSDL()
         if psnlSDL:
             for sdlvar,page in xLinkingBookDefs.xYeeshaPages:
@@ -67,7 +67,7 @@ def GetAllYeeshaPages(args):
     import Plasma
     import xLinkingBookDefs
     vault = Plasma.ptVault()
-    if type(vault) != type(None): #is the Vault online?
+    if vault is not None: #is the Vault online?
         psnlSDL = vault.getPsnlAgeSDL()
         if psnlSDL:
             if args == "0":
@@ -90,7 +90,7 @@ def GetYeeshaPage(args):
     import Plasma
     import xLinkingBookDefs
     vault = Plasma.ptVault()
-    if type(vault) != type(None): #is the Vault online?
+    if vault is not None: #is the Vault online?
         psnlSDL = vault.getPsnlAgeSDL()
         if args == None or args == "":
             print "xCheat.GetYeeshaPage(): ERROR.  Must provide a Yeesha Page number."
@@ -136,7 +136,7 @@ def GetAgeJourneyCloths(args):
             ageChronNode = ageChild
             break
 
-    if type(ageChronNode) == type(None):
+    if ageChronNode is None:
         newNode = Plasma.ptVaultChronicleNode(0)
         newNode.chronicleSetName(ageName)
         newNode.chronicleSetValue("abcdefg")
@@ -279,7 +279,7 @@ def GZSetGame(args):
     vault = Plasma.ptVault()
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue(gameString)
         entry.save()
     else:
@@ -307,7 +307,7 @@ def GZGetMarkers(args):
         vault = Plasma.ptVault()
         # is there a chronicle for the GZ games?
         entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
-        if type(entry) != type(None):
+        if entry is not None:
             gameString = entry.chronicleGetValue()
             gargs = gameString.split()
             if len(gargs) == 3:
@@ -329,7 +329,7 @@ def GZGetMarkers(args):
                     # just pick some marker to have gotten
                     # is there a chronicle for the GZ games?
                     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZMarkersAquired)
-                    if type(entry) != type(None):
+                    if entry is not None:
                         markers = entry.chronicleGetValue()
                         for mnum in range(markersToGet):
                             markerIdx = markers.index(PlasmaKITypes.kGZMarkerAvailable)
@@ -373,7 +373,7 @@ def GZGiveMeFullAccess(args):
     resetString = "0 off:off 0:0"
     vault = Plasma.ptVault()
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue(resetString)
 
     # Finally, update the KI display
@@ -397,17 +397,17 @@ def RemoveMarkerTag(args):
     vault = Plasma.ptVault()
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleKIMarkerLevel)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue(newlevel)
         entry.save()
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZGames)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("0")
         entry.save()
     # is there a chronicle for the GZ games?
     entry = vault.findChronicleEntry(PlasmaKITypes.kChronicleGZMarkersAquired)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("")
         entry.save()
     Plasma.PtSendKIMessage(PlasmaKITypes.kGZUpdated,0)
@@ -415,12 +415,12 @@ def RemoveMarkerTag(args):
     MGs = [ 'MG01','MG02','MG03','MG04','MG05','MG06','MG07','MG08','MG09','MG10','MG11','MG12','MG13','MG14']
     for mg in MGs:
         entry = vault.findChronicleEntry(mg)
-        if type(entry) != type(None):
+        if entry is not None:
             entry.chronicleSetValue("")
             entry.save()
    
     entry = vault.findChronicleEntry("CGZPlaying")
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("")
         entry.save()
     # remove the marker games from the hidden folder--- later
@@ -434,11 +434,11 @@ def CGZKillAll(args):
     MGs = [ 'MG01','MG02','MG03','MG04','MG05','MG06','MG07','MG08','MG09','MG10','MG11','MG12','MG13','MG14']
     for mg in MGs:
         entry = vault.findChronicleEntry(mg)
-        if type(entry) != type(None):
+        if entry is not None:
             entry.chronicleSetValue("")
             entry.save()
     entry = vault.findChronicleEntry("CGZPlaying")
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("")
         entry.save()
 
@@ -448,12 +448,12 @@ def ShowHiddenFolder(args):
     vault = Plasma.ptVault()
     jfolder = None
     master_agefolder = vault.getAgeJournalsFolder()
-    if type(master_agefolder) != type(None):
+    if master_agefolder is not None:
         agefolderRefs = master_agefolder.getChildNodeRefList()
         for agefolderRef in agefolderRefs:
             agefolder = agefolderRef.getChild()
             agefolder = agefolder.upcastToFolderNode()
-            if type(agefolder) != type(None):
+            if agefolder is not None:
                 # look for the Hidden folder
                 if "Hidden" == agefolder.folderGetName():
                     jfolder = agefolder
@@ -466,7 +466,7 @@ def ShowHiddenFolder(args):
             jnode = jref.getChild()
             jnode = jnode.upcastToMarkerListNode()
             # is it a marker folder list?
-            if type(jnode) != type(None):
+            if jnode is not None:
                 # is it named the right one?
                 print "markerFolder - ",jnode.folderGetName()
     else:
@@ -480,12 +480,12 @@ def RemoveHiddenContent(args):
     vault = Plasma.ptVault()
     jfolder = None
     master_agefolder = vault.getAgeJournalsFolder()
-    if type(master_agefolder) != type(None):
+    if master_agefolder is not None:
         agefolderRefs = master_agefolder.getChildNodeRefList()
         for agefolderRef in agefolderRefs:
             agefolder = agefolderRef.getChild()
             agefolder = agefolder.upcastToFolderNode()
-            if type(agefolder) != type(None):
+            if agefolder is not None:
                 # look for the Hidden folder
                 if "Hidden" == agefolder.folderGetName():
                     jfolder = agefolder
@@ -523,7 +523,7 @@ def _DumpEm(f,markerfolder,mfNumber):
     for markerRef in markerRefs:
         marker = markerRef.getChild()
         marker = marker.upcastToMarkerNode()
-        if type(marker) != type(None):
+        if marker is not None:
             f.write('    [ "%s", ' % (marker.markerGetText()))
             pos = marker.markerGetPosition()
             f.write("%g, %g, %g, " % (pos.getX(),pos.getY(),(pos.getZ())))
@@ -554,12 +554,12 @@ def DumpMarkers(args):
     vault = Plasma.ptVault()
     jfolder = None
     master_agefolder = vault.getAgeJournalsFolder()
-    if type(master_agefolder) != type(None):
+    if master_agefolder is not None:
         agefolderRefs = master_agefolder.getChildNodeRefList()
         for agefolderRef in agefolderRefs:
             agefolder = agefolderRef.getChild()
             agefolder = agefolder.upcastToFolderNode()
-            if type(agefolder) != type(None):
+            if agefolder is not None:
                 # might be a foldername with spaces! so see if it starts with the name
                 if argresidual.startswith(agefolder.folderGetName()):
                     jfolder = agefolder
@@ -574,7 +574,7 @@ def DumpMarkers(args):
             for jfolderRef in jfolderRefs:
                 jentry = jfolderRef.getChild()
                 jentry = jentry.upcastToMarkerListNode()
-                if type(jentry) != type(None):
+                if jentry is not None:
                     # see if we are looking for a particular markerfolder
                     if len(argresidual) > 0 and argresidual == jentry.getFolderName():
                         # only dump the one
@@ -621,12 +621,12 @@ def ImportGames(args):
     vault = Plasma.ptVault()
     jfolder = None
     master_agefolder = vault.getAgeJournalsFolder()
-    if type(master_agefolder) != type(None):
+    if master_agefolder is not None:
         agefolderRefs = master_agefolder.getChildNodeRefList()
         for agefolderRef in agefolderRefs:
             agefolder = agefolderRef.getChild()
             agefolder = agefolder.upcastToFolderNode()
-            if type(agefolder) != type(None):
+            if agefolder is not None:
                 # might be a foldername with spaces! so see if it starts with the name
                 if argresidual.startswith(agefolder.folderGetName()):
                     jfolder = agefolder
@@ -665,12 +665,12 @@ def ImportMarkers(args):
     vault = Plasma.ptVault()
     jfolder = None
     master_agefolder = vault.getAgeJournalsFolder()
-    if type(master_agefolder) != type(None):
+    if master_agefolder is not None:
         agefolderRefs = master_agefolder.getChildNodeRefList()
         for agefolderRef in agefolderRefs:
             agefolder = agefolderRef.getChild()
             agefolder = agefolder.upcastToFolderNode()
-            if type(agefolder) != type(None):
+            if agefolder is not None:
                 # might be a foldername with spaces! so see if it starts with the name
                 if argresidual.startswith(agefolder.folderGetName()):
                     jfolder = agefolder
@@ -685,7 +685,7 @@ def ImportMarkers(args):
                 jnode = jref.getChild()
                 jnode = jnode.upcastToMarkerListNode()
                 # is it a marker folder list?
-                if type(jnode) != type(None):
+                if jnode is not None:
                     # is it named the right one?
                     if jnode.folderGetName() == mg[1]:
                         # yes, add the markers to this game

--- a/Python/xChronicleCounter.py
+++ b/Python/xChronicleCounter.py
@@ -81,13 +81,13 @@ class xChronicleCounter(ptResponder):
             return
         
         if id == act.id:
-            if type(var.value) == type(None):
+            if var.value is None:
                 PtDebugPrint("xChronicleCounter.py:\t-- ERROR: missing chronicle variable name, can't record --")
                 return
             
             vault = ptVault()
             entry = vault.findChronicleEntry(var.value)
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add current level chronicle
                 vault.addChronicleEntry(var.value,kChronicleVarType,"%d" %(kInitialValue))
                 PtDebugPrint("xChronicleCounter:\tentered new chronicle counter %s, count is %d" % (var.value,kInitialValue))

--- a/Python/xDialogStartUp.py
+++ b/Python/xDialogStartUp.py
@@ -434,7 +434,7 @@ class xDialogStartUp(ptResponder):
 
             vault = ptVault()
             entry = vault.findChronicleEntry("InitialAvCustomizationsDone")
-            if type(entry) != type(None):
+            if entry is not None:
                 ageInfo.setAgeFilename("Personal")
             else:
                 ageInfo.setAgeFilename("AvatarCustomization")

--- a/Python/xDialogToggle.py
+++ b/Python/xDialogToggle.py
@@ -92,7 +92,7 @@ class xDialogToggle(ptModifier):
     def IGetAgeFilename(self):
         "returns the .age file name of the age"
         ageInfo = PtGetAgeInfo()
-        if type(ageInfo) != type(None):
+        if ageInfo is not None:
             return ageInfo.getAgeFilename()
         else:
             return "GUI" # use default GUI age if we can't find the age name for some reason
@@ -145,7 +145,7 @@ class xDialogToggle(ptModifier):
         "Disengage and exit"
         global LocalAvatar
         # exit every thing
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtHideDialog(Vignette.value)
             print "Dialog: %s goes down" % Vignette.value
         else:

--- a/Python/xDialogToggle.py
+++ b/Python/xDialogToggle.py
@@ -145,7 +145,7 @@ class xDialogToggle(ptModifier):
         "Disengage and exit"
         global LocalAvatar
         # exit every thing
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtHideDialog(Vignette.value)
             print "Dialog: %s goes down" % Vignette.value
         else:

--- a/Python/xEnum.py
+++ b/Python/xEnum.py
@@ -64,11 +64,11 @@ class Enum:
             else:
                 x = x[0].strip()
                 
-            if type(x) == types.TupleType:
+            if isinstance(x, tuple):
                 x, i = x
-            if type(x) != types.StringType:
+            if not isinstance(x, str):
                 raise EnumException("enum name is not a string: " + x)
-            if type(i) != types.IntType:
+            if not isinstance(i, int):
                 raise EnumException("enum value is not an integer: " + i)
             if x in uniqueNames:
                 raise EnumException("enum name is not unique: " + x)

--- a/Python/xEventTrigger.py
+++ b/Python/xEventTrigger.py
@@ -71,7 +71,7 @@ class xEventTrigger(ptResponder):
         AgeStartedIn = PtGetAgeName()
     
     def OnServerInitComplete(self):
-        if type(EventName.value) == type("") and EventName.value != "":
+        if isinstance(EventName.value, str) and EventName.value != "":
             ageSDL = PtGetAgeSDL()
             ageSDL.setNotify(self.key,EventName.value,0.0)
         
@@ -84,18 +84,18 @@ class xEventTrigger(ptResponder):
                 if ageSDL[EventName.value][0]:
                     #~ PtDebugPrint("Event %s is true!" % (VARname))
                     # are we paging things in?
-                    if type(PageNames.value) == type("") and PageNames.value != "":
+                    if isinstance(PageNames.value, str) and PageNames.value != "":
                         names = string.split(PageNames.value,",")
                         for name in names:
                             PtPageInNode(name)
-                    if type(Responder.value) != type(None):
+                    if Responder.value is not None:
                         Responder.run(self.key,state="true")
                 else:
                     #~ PtDebugPrint("Event %s is false!" % (VARname))
                     # are we paging things in?
-                    if type(PageNames.value) == type("") and PageNames.value != "":
+                    if isinstance(PageNames.value, str) and PageNames.value != "":
                         names = string.split(PageNames.value,",")
                         for name in names:
                             PtPageOutNode(name)
-                    if RunFalse.value and type(Responder.value) != type(None):
+                    if RunFalse.value and Responder.value is not None:
                         Responder.run(self.key,state="false")

--- a/Python/xEventTrigger.py
+++ b/Python/xEventTrigger.py
@@ -71,7 +71,7 @@ class xEventTrigger(ptResponder):
         AgeStartedIn = PtGetAgeName()
     
     def OnServerInitComplete(self):
-        if isinstance(EventName.value, str) and EventName.value != "":
+        if EventName.value:
             ageSDL = PtGetAgeSDL()
             ageSDL.setNotify(self.key,EventName.value,0.0)
         
@@ -84,7 +84,7 @@ class xEventTrigger(ptResponder):
                 if ageSDL[EventName.value][0]:
                     #~ PtDebugPrint("Event %s is true!" % (VARname))
                     # are we paging things in?
-                    if isinstance(PageNames.value, str) and PageNames.value != "":
+                    if PageNames.value:
                         names = string.split(PageNames.value,",")
                         for name in names:
                             PtPageInNode(name)
@@ -93,7 +93,7 @@ class xEventTrigger(ptResponder):
                 else:
                     #~ PtDebugPrint("Event %s is false!" % (VARname))
                     # are we paging things in?
-                    if isinstance(PageNames.value, str) and PageNames.value != "":
+                    if PageNames.value:
                         names = string.split(PageNames.value,",")
                         for name in names:
                             PtPageOutNode(name)

--- a/Python/xGZMarker.py
+++ b/Python/xGZMarker.py
@@ -103,7 +103,7 @@ class xGZMarker(ptMultiModifier):
         vault = ptVault()
         # is there a chronicle for the GZ games?
         entry = vault.findChronicleEntry(kChronicleGZMarkersAquired)
-        if type(entry) != type(None):
+        if entry is not None:
             markers = entry.chronicleGetValue()
             markerIdx = aGZSerialNumber.value - 1
             if markerIdx >= 0 and markerIdx < len(markers):

--- a/Python/xHighLevelStarTrekDoor.py
+++ b/Python/xHighLevelStarTrekDoor.py
@@ -86,7 +86,7 @@ class xHighLevelStarTrekDoor(ptModifier):
         ageSDL.setNotify(self.key,strDoorEnabledVar.value,0.0)
         ageSDL.setNotify(self.key,strDoorClosedVar.value,0.0)
 
-        if isinstance(strDoorEnabledVar.value, str) and strDoorEnabledVar.value != "":
+        if strDoorEnabledVar.value:
             try:
                 self.DoorEnabled = ageSDL[strDoorEnabledVar.value][0]
             except:

--- a/Python/xHighLevelStarTrekDoor.py
+++ b/Python/xHighLevelStarTrekDoor.py
@@ -86,7 +86,7 @@ class xHighLevelStarTrekDoor(ptModifier):
         ageSDL.setNotify(self.key,strDoorEnabledVar.value,0.0)
         ageSDL.setNotify(self.key,strDoorClosedVar.value,0.0)
 
-        if type(strDoorEnabledVar.value) == type("") and strDoorEnabledVar.value != "":
+        if isinstance(strDoorEnabledVar.value, str) and strDoorEnabledVar.value != "":
             try:
                 self.DoorEnabled = ageSDL[strDoorEnabledVar.value][0]
             except:

--- a/Python/xInvite.py
+++ b/Python/xInvite.py
@@ -90,9 +90,9 @@ def CreateInvitation(params=None):
     "create an invitation"
     PtDebugPrint("xInvite: create invitation",level=kDebugDumpLevel)
     passkey = params
-    if type(passkey) == type(""):
+    if isinstance(passkey, str):
         invites = ptVault().getInviteFolder()
-        if type(invites) != type(None):
+        if invites is not None:
             if invites.getChildNodeCount() <= gMaxInviteCount:
                 # create the note
                 note = ptVaultTextNoteNode(PtVaultNodePermissionFlags.kDefaultPermissions)
@@ -121,7 +121,7 @@ def ShowInvitations(params=None):
     PtDebugPrint("xInvite: show invitations",level=kDebugDumpLevel)
     passkeys = ""
     invites = ptVault().getInviteFolder()
-    if type(invites) != type(None):
+    if invites is not None:
         l = invites.getChildNodeRefList()
         i = 0;
         for ref in l:
@@ -129,7 +129,7 @@ def ShowInvitations(params=None):
                 passkeys += ", "
             child = ref.getChild()
             child = child.upcastToTextNoteNode()
-            if type(child) != type(None):
+            if child is not None:
                 passkeys += child.noteGetTitle()
             else:
                 PtDebugPrint("xInvite: Couldn't cast list item to note",level=kErrorLevel)
@@ -143,15 +143,15 @@ def DeleteInvitation(params=None):
     "delete invitation"
     PtDebugPrint("xInvite: delete invitation",level=kDebugDumpLevel)
     passkey = params
-    if type(passkey) == type(""):
+    if isinstance(passkey, str):
         invites = ptVault().getInviteFolder()
-        if type(invites) != type(None):
+        if invites is not None:
             l = invites.getChildNodeRefList()
             removed = 0
             for ref in l:
                 child = ref.getChild()
                 child = child.upcastToTextNoteNode()
-                if type(child) != type(None):
+                if child is not None:
                     if passkey == child.noteGetTitle():
                         try:
                             invites.removeNode(child)

--- a/Python/xJournalBookGUIPopup.py
+++ b/Python/xJournalBookGUIPopup.py
@@ -101,7 +101,7 @@ class xJournalBookGUIPopup(ptModifier):
         if id == actClickableBook.id:
             if PtWasLocallyNotified(self.key) and state:
                 PtToggleAvatarClickability(false)
-                if type(SeekBehavior.value) != type(None): #remember, smart seek before GUI is optional. 
+                if SeekBehavior.value is not None: #remember, smart seek before GUI is optional. 
                     PtDebugPrint("xJournalBookGUIPopup: Smart seek used",level=kDebugDumpLevel)
                     LocalAvatar = PtFindAvatar(events)
                     SeekBehavior.run(LocalAvatar)

--- a/Python/xJourneyClothGate.py
+++ b/Python/xJourneyClothGate.py
@@ -102,10 +102,10 @@ class xJourneyClothGate(ptResponder):
         global AllCloths
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xJourneyClothGate.OnFirstUpdate():\tERROR: missing SDL var name")
 
-        if ClothsComplete.value is not None and ClothsComplete.value != "":
+        if ClothsComplete.value:
             AllCloths = ClothsComplete.value
             PtDebugPrint("DEBUG: xJourneyClothGate.OnFirstUpdate:\tUsing Max specified all cloths")
         else:
@@ -118,7 +118,7 @@ class xJourneyClothGate(ptResponder):
         # make sure that we are in the age we think we're in
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 ageSDL.setFlags(stringVarName.value,1,1)
                 ageSDL.sendToClients(stringVarName.value)
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)

--- a/Python/xJourneyClothGate.py
+++ b/Python/xJourneyClothGate.py
@@ -102,10 +102,10 @@ class xJourneyClothGate(ptResponder):
         global AllCloths
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: xJourneyClothGate.OnFirstUpdate():\tERROR: missing SDL var name")
 
-        if type(ClothsComplete.value) != type(None) and ClothsComplete.value != "":
+        if ClothsComplete.value is not None and ClothsComplete.value != "":
             AllCloths = ClothsComplete.value
             PtDebugPrint("DEBUG: xJourneyClothGate.OnFirstUpdate:\tUsing Max specified all cloths")
         else:
@@ -118,7 +118,7 @@ class xJourneyClothGate(ptResponder):
         # make sure that we are in the age we think we're in
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 ageSDL.setFlags(stringVarName.value,1,1)
                 ageSDL.sendToClients(stringVarName.value)
                 ageSDL.setNotify(self.key,stringVarName.value,0.0)
@@ -146,14 +146,14 @@ class xJourneyClothGate(ptResponder):
         if id == rgnLink.id:
             vault = ptVault()
             FoundJCs = ""
-            if type(vault) != type(None): #is the Vault online?
+            if vault is not None: #is the Vault online?
                 entry = vault.findChronicleEntry("JourneyClothProgress")
-                if type(entry) == type(None):
+                if entry is None:
                     PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: No JourneyClothProgress chronicle")
                     pass
                 else:
                     entry = self.GetCurrentAgeChronicle(entry)
-                    if type(entry) == type(None):
+                    if entry is None:
                         PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
                         return
                     FoundJCs = entry.chronicleGetValue()
@@ -227,15 +227,15 @@ class xJourneyClothGate(ptResponder):
 
         print "You clicked on the Gate"
         vault = ptVault()
-        if type(vault) != type(None): #is the Vault online?
+        if vault is not None: #is the Vault online?
             
             entry = vault.findChronicleEntry("JourneyClothProgress")
-            if type(entry) == type(None):
+            if entry is None:
                 PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: No JourneyClothProgress chronicle")
                 pass
             else:
                 entry = self.GetCurrentAgeChronicle(entry)
-                if type(entry) == type(None):
+                if entry is None:
                     PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
                     return
                 FoundJCs = entry.chronicleGetValue()

--- a/Python/xJourneyClothGate.py
+++ b/Python/xJourneyClothGate.py
@@ -146,17 +146,16 @@ class xJourneyClothGate(ptResponder):
         if id == rgnLink.id:
             vault = ptVault()
             FoundJCs = ""
-            if vault is not None: #is the Vault online?
-                entry = vault.findChronicleEntry("JourneyClothProgress")
+            entry = vault.findChronicleEntry("JourneyClothProgress")
+            if entry is None:
+                PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: No JourneyClothProgress chronicle")
+                pass
+            else:
+                entry = self.GetCurrentAgeChronicle(entry)
                 if entry is None:
-                    PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: No JourneyClothProgress chronicle")
-                    pass
-                else:
-                    entry = self.GetCurrentAgeChronicle(entry)
-                    if entry is None:
-                        PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
-                        return
-                    FoundJCs = entry.chronicleGetValue()
+                    PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
+                    return
+                FoundJCs = entry.chronicleGetValue()
                     
 
             length = len(FoundJCs)
@@ -227,43 +226,39 @@ class xJourneyClothGate(ptResponder):
 
         print "You clicked on the Gate"
         vault = ptVault()
-        if vault is not None: #is the Vault online?
             
-            entry = vault.findChronicleEntry("JourneyClothProgress")
-            if entry is None:
-                PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: No JourneyClothProgress chronicle")
-                pass
-            else:
-                entry = self.GetCurrentAgeChronicle(entry)
-                if entry is None:
-                    PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
-                    return
-                FoundJCs = entry.chronicleGetValue()
-                length = len(FoundJCs)
-                all = len(AllCloths)
-
-                print "You've found the following %d Journey Cloths: %s" % (length, FoundJCs)
-                
-                if length < 0 or length > all: 
-                    print "xJourneyClothGate: ERROR: Unexpected length value received."
-                    return
-                    
-                for each in FoundJCs:
-                    if each not in AllCloths:
-                        print "Unexpected value in the Chronicle:", each
-                        return
-
-                if length < all:
-                    print "There are more Cloths out there. Get to work."
-                    PalmGlowWeak.run(self.key)
-                 
-                elif length == all:
-                    print "All expected Cloths were found. Opening Door."
-                    PalmGlowStrong.run(self.key)
-                    self.ToggleSDL("fromOutside")
-           
+        entry = vault.findChronicleEntry("JourneyClothProgress")
+        if entry is None:
+            PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: No JourneyClothProgress chronicle")
+            pass
         else:
-            PtDebugPrint("ERROR: xJourneyClothGate.OnNotify: Error trying to access the Vault. Can't access JourneyClothProgress chronicle." )
+            entry = self.GetCurrentAgeChronicle(entry)
+            if entry is None:
+                PtDebugPrint("DEBUG: xJourneyClothGate.OnNotify: Sorry, couldn't find journey cloth chronicle for this age")
+                return
+            FoundJCs = entry.chronicleGetValue()
+            length = len(FoundJCs)
+            all = len(AllCloths)
+
+            print "You've found the following %d Journey Cloths: %s" % (length, FoundJCs)
+            
+            if length < 0 or length > all: 
+                print "xJourneyClothGate: ERROR: Unexpected length value received."
+                return
+                
+            for each in FoundJCs:
+                if each not in AllCloths:
+                    print "Unexpected value in the Chronicle:", each
+                    return
+
+            if length < all:
+                print "There are more Cloths out there. Get to work."
+                PalmGlowWeak.run(self.key)
+                
+            elif length == all:
+                print "All expected Cloths were found. Opening Door."
+                PalmGlowStrong.run(self.key)
+                self.ToggleSDL("fromOutside")
 
     def GetCurrentAgeChronicle(self, chron):
         ageChronRefList = chron.getChildNodeRefList()

--- a/Python/xJourneyCloths.py
+++ b/Python/xJourneyCloths.py
@@ -126,43 +126,36 @@ class xJourneyCloths(ptModifier):
         
         print "You clicked on cloth ", ClothLetter.value
         vault = ptVault()
-        if vault is not None: #is the Vault online?
             
-            entry = vault.findChronicleEntry("JourneyClothProgress")
-            if entry is None: # is this the player's first Journey Cloth?
-                print "First cloth found."
+        entry = vault.findChronicleEntry("JourneyClothProgress")
+        if entry is None: # is this the player's first Journey Cloth?
+            print "First cloth found."
 
-                print "trying to update JourneyClothProgress to: ", ClothLetter.value
-                vault = ptVault() 
-                vault.addChronicleEntry("JourneyClothProgress",0,"%s" % (ClothLetter.value))
-                self.IPlayHandAnim(1)
-            
-            else:
-                FoundJCs = entry.chronicleGetValue()
-                print "previously found JCs: ", FoundJCs
-                if ClothLetter.value in FoundJCs:
-                    print "You've already found this cloth."
-
-                    
-                else:
-                    print "This is a new cloth to you"
-                    
-                    FoundJCs = FoundJCs + ClothLetter.value
-                    print "trying to update JourneyClothProgress to ", FoundJCs
-
-                    entry.chronicleSetValue("%s" % (FoundJCs)) 
-                    entry.save() 
-                    
-                    self.RandomBahroSounds()
-            
-                length = len(FoundJCs)
-                self.IPlayHandAnim(length)
-                
-
-                    
-                
+            print "trying to update JourneyClothProgress to: ", ClothLetter.value
+            vault = ptVault() 
+            vault.addChronicleEntry("JourneyClothProgress",0,"%s" % (ClothLetter.value))
+            self.IPlayHandAnim(1)
+        
         else:
-            PtDebugPrint("xJourneyCloths: Error trying to access the Vault. Can't access JourneyClothProgress chronicle." )
+            FoundJCs = entry.chronicleGetValue()
+            print "previously found JCs: ", FoundJCs
+            if ClothLetter.value in FoundJCs:
+                print "You've already found this cloth."
+
+                
+            else:
+                print "This is a new cloth to you"
+                
+                FoundJCs = FoundJCs + ClothLetter.value
+                print "trying to update JourneyClothProgress to ", FoundJCs
+
+                entry.chronicleSetValue("%s" % (FoundJCs)) 
+                entry.save() 
+                
+                self.RandomBahroSounds()
+        
+            length = len(FoundJCs)
+            self.IPlayHandAnim(length)
 
 
     def IPlayHandAnim(self, length):

--- a/Python/xJourneyCloths.py
+++ b/Python/xJourneyCloths.py
@@ -126,10 +126,10 @@ class xJourneyCloths(ptModifier):
         
         print "You clicked on cloth ", ClothLetter.value
         vault = ptVault()
-        if type(vault) != type(None): #is the Vault online?
+        if vault is not None: #is the Vault online?
             
             entry = vault.findChronicleEntry("JourneyClothProgress")
-            if type(entry) == type(None): # is this the player's first Journey Cloth?
+            if entry is None: # is this the player's first Journey Cloth?
                 print "First cloth found."
 
                 print "trying to update JourneyClothProgress to: ", ClothLetter.value

--- a/Python/xJourneyClothsGen2.py
+++ b/Python/xJourneyClothsGen2.py
@@ -121,7 +121,7 @@ class xJourneyClothsGen2(ptModifier):
         vault = ptVault()
         entry = vault.findChronicleEntry("JourneyClothProgress")
 
-        if type(entry) == type(None):
+        if entry is None:
             PtDebugPrint("DEBUG: xJourneyClothsGen2.OnFirstUpdate: Did not find JourneyClothProgress chronicle...creating")
             vault.addChronicleEntry("JourneyClothProgress",0,"")
 
@@ -177,7 +177,7 @@ class xJourneyClothsGen2(ptModifier):
             agelink = vault.getOwnedAgeLink(ainfo)
 
             # commenting out, due to Design reversal
-#            if type(agelink) == type(None):
+#            if agelink is None:
 #                PtDebugPrint("DEBUG: xJourneyClothsGen2.OnNotify: I don't have this book yet, so click means nothing")
 #                ClothInUse = 0
 #                Activator.enable()
@@ -204,7 +204,7 @@ class xJourneyClothsGen2(ptModifier):
                     # camera stack is now being saved as a spawn point on the owned age link
                     savepoint = None
 
-                    if type(agelink) != type(None):
+                    if agelink is not None:
                         spawnpoints = agelink.getSpawnPoints()
 
                         for sp in spawnpoints:
@@ -212,7 +212,7 @@ class xJourneyClothsGen2(ptModifier):
                                 savepoint = sp
                                 break
 
-                        if type(savepoint) != type(None):
+                        if savepoint is not None:
                             agelink.removeSpawnPoint(savepoint.getName())
                             
                         savepoint = ptSpawnPointInfo("JCSavePoint", soSpawnpoint.value.getName())
@@ -353,10 +353,10 @@ class xJourneyClothsGen2(ptModifier):
             
             print "You clicked on cloth ", ClothLetter.value
             vault = ptVault()
-            if type(vault) != type(None): #is the Vault online?
+            if vault is not None: #is the Vault online?
                 
                 entry = vault.findChronicleEntry("JourneyClothProgress")
-                if type(entry) == type(None): # is this the player's first Journey Cloth?
+                if entry is None: # is this the player's first Journey Cloth?
                     PtDebugPrint("No JourneyClothProgress chronicle entry found, I'll add it.")
                     PtDebugPrint("You're going to have to press the button again.")
                     vault.addChronicleEntry("JourneyClothProgress",0,"")
@@ -364,7 +364,7 @@ class xJourneyClothsGen2(ptModifier):
                 else:
                     currentAgeChron = self.GetCurrentAgeChronicle(entry)
 
-                    if type(currentAgeChron) == type(None):
+                    if currentAgeChron is None:
                         print "You haven't found a JC in this age before, adding it now"
                         
                         currentAgeChron = self.AddNodeWithCurrentValue(entry)

--- a/Python/xJourneyClothsGen2.py
+++ b/Python/xJourneyClothsGen2.py
@@ -353,42 +353,41 @@ class xJourneyClothsGen2(ptModifier):
             
             print "You clicked on cloth ", ClothLetter.value
             vault = ptVault()
-            if vault is not None: #is the Vault online?
                 
-                entry = vault.findChronicleEntry("JourneyClothProgress")
-                if entry is None: # is this the player's first Journey Cloth?
-                    PtDebugPrint("No JourneyClothProgress chronicle entry found, I'll add it.")
-                    PtDebugPrint("You're going to have to press the button again.")
-                    vault.addChronicleEntry("JourneyClothProgress",0,"")
-                
+            entry = vault.findChronicleEntry("JourneyClothProgress")
+            if entry is None: # is this the player's first Journey Cloth?
+                PtDebugPrint("No JourneyClothProgress chronicle entry found, I'll add it.")
+                PtDebugPrint("You're going to have to press the button again.")
+                vault.addChronicleEntry("JourneyClothProgress",0,"")
+            
+            else:
+                currentAgeChron = self.GetCurrentAgeChronicle(entry)
+
+                if currentAgeChron is None:
+                    print "You haven't found a JC in this age before, adding it now"
+                    
+                    currentAgeChron = self.AddNodeWithCurrentValue(entry)
+                    FoundJCs = ClothLetter.value
+                    self.RandomBahroSounds()
                 else:
-                    currentAgeChron = self.GetCurrentAgeChronicle(entry)
-
-                    if currentAgeChron is None:
-                        print "You haven't found a JC in this age before, adding it now"
+                    FoundJCs = currentAgeChron.chronicleGetValue()
+                    print "previously found JCs: ", FoundJCs
+                    if ClothLetter.value in FoundJCs:
+                        print "You've already found this cloth."
                         
-                        currentAgeChron = self.AddNodeWithCurrentValue(entry)
-                        FoundJCs = ClothLetter.value
-                        self.RandomBahroSounds()
                     else:
-                        FoundJCs = currentAgeChron.chronicleGetValue()
-                        print "previously found JCs: ", FoundJCs
-                        if ClothLetter.value in FoundJCs:
-                            print "You've already found this cloth."
-                            
-                        else:
-                            print "This is a new cloth to you"
-                            
-                            FoundJCs = FoundJCs + ClothLetter.value
-                            print "trying to update JourneyClothProgress to ", FoundJCs
+                        print "This is a new cloth to you"
+                        
+                        FoundJCs = FoundJCs + ClothLetter.value
+                        print "trying to update JourneyClothProgress to ", FoundJCs
 
-                            currentAgeChron.chronicleSetValue("%s" % (FoundJCs)) 
-                            currentAgeChron.save() 
-                            
-                            self.RandomBahroSounds()
-                
-                    length = len(FoundJCs)
-                    self.IPlayHandAnim(length)
+                        currentAgeChron.chronicleSetValue("%s" % (FoundJCs)) 
+                        currentAgeChron.save() 
+                        
+                        self.RandomBahroSounds()
+            
+                length = len(FoundJCs)
+                self.IPlayHandAnim(length)
             
 ##        elif id == TimerID.FadeOut:
 ##            PtFadeLocalAvatar(0)

--- a/Python/xLinkingBookGUIPopup.py
+++ b/Python/xLinkingBookGUIPopup.py
@@ -205,7 +205,7 @@ class xLinkingBookGUIPopup(ptModifier):
             if PtWasLocallyNotified(self.key) and state:
                 actClickableBook.disable()
                 PtToggleAvatarClickability(false)
-                if type(SeekBehavior.value) != type(None): #remember, smart seek before GUI is optional. 
+                if SeekBehavior.value is not None: #remember, smart seek before GUI is optional. 
                     PtDebugPrint("xLinkingBookGUIPopup: Smart seek used",level=kDebugDumpLevel)
                     reportingAvatar = PtFindAvatar(events)
                     SeekBehavior.run(reportingAvatar)
@@ -215,7 +215,7 @@ class xLinkingBookGUIPopup(ptModifier):
                 BookOfferer = None
                 return
             elif not PtWasLocallyNotified(self.key) and state:
-                if type(SeekBehavior.value) != type(None): #remember, smart seek before GUI is optional. 
+                if SeekBehavior.value is not None: #remember, smart seek before GUI is optional. 
                     PtDebugPrint("xLinkingBookGUIPopup: Smart seek used",level=kDebugDumpLevel)
                     reportingAvatar = PtFindAvatar(events)
                     SeekBehavior.run(reportingAvatar)
@@ -346,7 +346,7 @@ class xLinkingBookGUIPopup(ptModifier):
                                     if linkTitle == "Tomahna" or linkTitle == "Cleft":
                                         vault = ptVault()
                                         entry = vault.findChronicleEntry("TomahnaLoad")
-                                        if type(entry) != type(None):
+                                        if entry is not None:
                                             if linkTitle == "Tomahna":
                                                 entry.chronicleSetValue("yes")
                                             else:
@@ -440,7 +440,7 @@ class xLinkingBookGUIPopup(ptModifier):
             elif agePanel == "TomahnaFromCleft":
                 vault = ptVault()
                 entry = vault.findChronicleEntry("TomahnaLoad")
-                if type(entry) != type(None):
+                if entry is not None:
                     entry.chronicleSetValue("yes")
                     entry.save()
                     PtDebugPrint("Chronicle entry TomahnaLoad already added, setting to yes")
@@ -524,7 +524,7 @@ class xLinkingBookGUIPopup(ptModifier):
             if agePanel == "Cleft":
                 vault = ptVault()
                 entry = vault.findChronicleEntry("TomahnaLoad")
-                if type(entry) != type(None):
+                if entry is not None:
                     agePanel = "CleftWithTomahna"
 
             # build the SpawnPointName/Title lists
@@ -657,7 +657,7 @@ class xLinkingBookGUIPopup(ptModifier):
         for content in contents:
             link = content.getChild()
             link = link.upcastToAgeLinkNode()
-            if type(link) != type(None):
+            if link is not None:
                 info = link.getAgeInfo()
             if not info: continue
             ageName = info.getAgeFilename()
@@ -668,7 +668,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
     def IGetHoodInfoNode(self):
         link = self.IGetHoodLinkNode()
-        if type(link) == type(None):
+        if link is None:
             return None
         info = link.getAgeInfo()
         return info
@@ -753,7 +753,7 @@ class xLinkingBookGUIPopup(ptModifier):
         CityLinks = []
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
-        if type(entryCityLinks) != type(None):
+        if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
             print "valCityLinks = ",valCityLinks
             CityLinks = valCityLinks.split(",")
@@ -783,7 +783,7 @@ class xLinkingBookGUIPopup(ptModifier):
         CityLinks = []
         vault = ptVault()
         entryCityLinks = vault.findChronicleEntry("CityBookLinks")
-        if type(entryCityLinks) != type(None):
+        if entryCityLinks is not None:
             valCityLinks = entryCityLinks.chronicleGetValue()
             print "xLinkingBookGUIPopup.IGetCityLinksChron(): valCityLinks = ",valCityLinks
             CityLinks = valCityLinks.split(",")
@@ -842,7 +842,7 @@ class xLinkingBookGUIPopup(ptModifier):
             tmpLink = NodeRef.getChild().upcastToAgeLinkNode()
             if tmpLink:
                 # make sure Micah doesn't try to break it by not waiting for the AgeInfo to be downloaded
-                if type(tmpLink.getAgeInfo()) != type(None):
+                if tmpLink.getAgeInfo() is not None:
                     if ageRequested == tmpLink.getAgeInfo().getAgeFilename():
                         spawnPoints = tmpLink.getSpawnPoints()
                         break
@@ -974,7 +974,7 @@ class xLinkingBookGUIPopup(ptModifier):
 
     def GetOwnedAgeLink(self, vault, age):
         PAL = vault.getAgesIOwnFolder()
-        if type(PAL) != type(None):
+        if PAL is not None:
             contents = PAL.getChildNodeRefList()
             for content in contents:
                 link = content.getChild().upcastToAgeLinkNode()
@@ -1143,7 +1143,7 @@ class xLinkingBookGUIPopup(ptModifier):
         caveLink.setAgeInfo(caveInfo)
         caveInfo = caveLink.getAgeInfo()
         caveInstance = caveInfo
-        if type(caveInstance) == type(None):
+        if caveInstance is None:
             PtDebugPrint("pellet cave instance is none, aborting link")
             return;
         info = ptAgeInfoStruct()

--- a/Python/xMusicBox.py
+++ b/Python/xMusicBox.py
@@ -122,7 +122,7 @@ class xMusicBox(ptModifier):
         SoundObjIndex = soSoundObj.value.getSoundIndex(strSoundObj.value)
         PtDebugPrint("xMusicBox.OnServerInitComplete: using sound object index:" + str(SoundObjIndex))
 
-        if isinstance(sdlCurrentSongVar.value, str) and len(sdlCurrentSongVar.value) > 0:
+        if sdlCurrentSongVar.value:
             ageSDL = PtGetAgeSDL()
             filename = ageSDL[sdlCurrentSongVar.value][0]
 
@@ -166,7 +166,7 @@ class xMusicBox(ptModifier):
             localClient = PtGetLocalClientID()
 
             islocalavatar = (playerid == localClient)
-            sdlvarisvalid = (isinstance(sdlCurrentSongVar.value, str) and len(sdlCurrentSongVar.value) > 0)
+            sdlvarisvalid = sdlCurrentSongVar.value
 
             if islocalavatar and sdlvarisvalid:
                 print "Setting cur song var to: ", currentSong

--- a/Python/xMusicBox.py
+++ b/Python/xMusicBox.py
@@ -122,7 +122,7 @@ class xMusicBox(ptModifier):
         SoundObjIndex = soSoundObj.value.getSoundIndex(strSoundObj.value)
         PtDebugPrint("xMusicBox.OnServerInitComplete: using sound object index:" + str(SoundObjIndex))
 
-        if type(sdlCurrentSongVar.value) == type("") and len(sdlCurrentSongVar.value) > 0:
+        if isinstance(sdlCurrentSongVar.value, str) and len(sdlCurrentSongVar.value) > 0:
             ageSDL = PtGetAgeSDL()
             filename = ageSDL[sdlCurrentSongVar.value][0]
 
@@ -166,7 +166,7 @@ class xMusicBox(ptModifier):
             localClient = PtGetLocalClientID()
 
             islocalavatar = (playerid == localClient)
-            sdlvarisvalid = (type(sdlCurrentSongVar.value) == type("") and len(sdlCurrentSongVar.value) > 0)
+            sdlvarisvalid = (isinstance(sdlCurrentSongVar.value, str) and len(sdlCurrentSongVar.value) > 0)
 
             if islocalavatar and sdlvarisvalid:
                 print "Setting cur song var to: ", currentSong

--- a/Python/xOpeningSequence.py
+++ b/Python/xOpeningSequence.py
@@ -396,7 +396,7 @@ class xOpeningSequence(ptModifier):
         # 1) set chronicle variable to say they've complete intro
         vault = ptVault()
         entry = vault.findChronicleEntry(kIntroPlayedChronicle)
-        if type(entry) != type(None):
+        if entry is not None:
             entry.chronicleSetValue("yes")
             entry.save()
         else:

--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -504,11 +504,10 @@ class xOptionsMenu(ptModifier):
             gFirstReltoVisit = false
 
             vault = ptVault()
-            if vault is not None:
-                entry = vault.findChronicleEntry("KeyMap")
-                if entry is None:
-                    # not found... create defaults
-                    self.ISetDefaultKeyMappings()
+            entry = vault.findChronicleEntry("KeyMap")
+            if entry is None:
+                # not found... create defaults
+                self.ISetDefaultKeyMappings()
 
             self.LoadAdvSettings()
             self.LoadKeyMap()
@@ -1743,38 +1742,32 @@ class xOptionsMenu(ptModifier):
         kModuleName = "Personal"
         kChronicleVarType = 0
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleVar)
-            if entry is None:
-                # not found... add current level chronicle
-                vault.addChronicleEntry(chronicleVar,kChronicleVarType,str(value))
-                print "%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar)
-            else:
-                entry.chronicleSetValue(str(value))
-                entry.save()
-                print "%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue())
+        entry = vault.findChronicleEntry(chronicleVar)
+        if entry is None:
+            # not found... add current level chronicle
+            vault.addChronicleEntry(chronicleVar,kChronicleVarType,str(value))
+            print "%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar)
         else:
-            PtDebugPrint("%s:\tERROR trying to access vault -- can't update %s variable in chronicle." % (kModuleName,chronicleVar))
+            entry.chronicleSetValue(str(value))
+            entry.save()
+            print "%s:\tyour current value for %s is %s" % (kModuleName,chronicleVar,entry.chronicleGetValue())
 
     def getChronicleVar(self, chronicleVar):
         kModuleName = "Personal"
         kChronicleVarType = 0
         vault = ptVault()
-        if vault is not None:
-            entry = vault.findChronicleEntry(chronicleVar)
-            print "getChronicleVar.chronicleVar: " + chronicleVar
-            #print "getChronicleVar.Entry: " , entry
-            if entry is None:
-                # not found... add current level chronicle
-                #vault.addChronicleEntry(chronicleVar,kChronicleVarType,"%d" %(0))
-                #PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
-                return None
-            else:
-                value = entry.chronicleGetValue()
-                print "getChronicleVar(): " + chronicleVar + " = " + value
-                return value
+        entry = vault.findChronicleEntry(chronicleVar)
+        print "getChronicleVar.chronicleVar: " + chronicleVar
+        #print "getChronicleVar.Entry: " , entry
+        if entry is None:
+            # not found... add current level chronicle
+            #vault.addChronicleEntry(chronicleVar,kChronicleVarType,"%d" %(0))
+            #PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
+            return None
         else:
-            PtDebugPrint("%s:\tERROR trying to access vault -- can't retrieve %s variable in chronicle." % (kModuleName,kChronicleVarName))
+            value = entry.chronicleGetValue()
+            print "getChronicleVar(): " + chronicleVar + " = " + value
+            return value
         
     def IRefreshHelpSettings(self):
         clickToTurn = ptGUIControlRadioGroup(NavigationDlg.dialog.getControlFromTag(kNormNoviceRGID))

--- a/Python/xOptionsMenu.py
+++ b/Python/xOptionsMenu.py
@@ -504,9 +504,9 @@ class xOptionsMenu(ptModifier):
             gFirstReltoVisit = false
 
             vault = ptVault()
-            if type(vault) != type(None):
+            if vault is not None:
                 entry = vault.findChronicleEntry("KeyMap")
-                if type(entry) == type(None):
+                if entry is None:
                     # not found... create defaults
                     self.ISetDefaultKeyMappings()
 
@@ -730,7 +730,7 @@ class xOptionsMenu(ptModifier):
                     # get the new keys and bind
                     km = ptKeyMap()
                     cCode,spFlag,mpFlag = gKM1ControlCodesRow1[kmID]
-                    if type(cCode) == type(""):
+                    if isinstance(cCode, str):
                         key1 = km.convertVKeyToChar(control.getLastKeyCaptured(),control.getLastModifiersCaptured())
                         km.bindKeyToConsoleCommand(key1,cCode)
                         KeyMapString = self.getChronicleVar("KeyMap")
@@ -739,7 +739,7 @@ class xOptionsMenu(ptModifier):
                         for key in KeyMapArray:
                             NewKeyMapString += key + " "
                         self.setNewChronicleVar("KeyMap", NewKeyMapString.rstrip())
-                    elif type(cCode) != type(None):
+                    elif cCode is not None:
                         otherID = kmID + 100
                         otherField = ptGUIControlEditBox(KeyMapDlg.dialog.getControlFromTag(otherID))
                         key1 = km.convertVKeyToChar(control.getLastKeyCaptured(),control.getLastModifiersCaptured())
@@ -765,7 +765,7 @@ class xOptionsMenu(ptModifier):
                     # get the new keys and bind
                     km = ptKeyMap()
                     cCode,spFlag,mpFlag = gKM1ControlCodesRow2[kmID]
-                    if type(cCode) == type(""):
+                    if isinstance(cCode, str):
                         # console command  - this shouldn't really happen!
                         key1 = km.convertVKeyToChar(control.getLastKeyCaptured(),control.getLastModifiersCaptured())
                         km.bindKeyToConsoleCommand(key1,cCode)
@@ -777,7 +777,7 @@ class xOptionsMenu(ptModifier):
                             NewKeyMapString += key + " "
                         self.setNewChronicleVar("KeyMap", NewKeyMapString.rstrip())
                         #xIniInput.SetConsoleKey('"'+cCode+'"',key1+',')
-                    elif type(cCode) != type(None):
+                    elif cCode is not None:
                         otherID = kmID - 100
                         otherField = ptGUIControlEditBox(KeyMapDlg.dialog.getControlFromTag(otherID))
                         key2 = km.convertVKeyToChar(control.getLastKeyCaptured(),control.getLastModifiersCaptured())
@@ -1391,7 +1391,7 @@ class xOptionsMenu(ptModifier):
             gLiveMovie.playPaused()
         elif id == kTrailerFadeInID:
             PtDebugPrint("xLiveTrailer - roll the movie",level=kDebugDumpLevel)
-            if type(gLiveMovie) != type(None):
+            if gLiveMovie is not None:
                 gLiveMovie.resume()
             #gLiveMovie.play()
         elif id == kTrailerFadeOutID:
@@ -1743,9 +1743,9 @@ class xOptionsMenu(ptModifier):
         kModuleName = "Personal"
         kChronicleVarType = 0
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleVar)
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add current level chronicle
                 vault.addChronicleEntry(chronicleVar,kChronicleVarType,str(value))
                 print "%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar)
@@ -1760,11 +1760,11 @@ class xOptionsMenu(ptModifier):
         kModuleName = "Personal"
         kChronicleVarType = 0
         vault = ptVault()
-        if type(vault) != type(None):
+        if vault is not None:
             entry = vault.findChronicleEntry(chronicleVar)
             print "getChronicleVar.chronicleVar: " + chronicleVar
             #print "getChronicleVar.Entry: " , entry
-            if type(entry) == type(None):
+            if entry is None:
                 # not found... add current level chronicle
                 #vault.addChronicleEntry(chronicleVar,kChronicleVarType,"%d" %(0))
                 #PtDebugPrint("%s:\tentered new chronicle counter %s" % (kModuleName,chronicleVar))
@@ -1881,7 +1881,7 @@ class xOptionsMenu(ptModifier):
         counter = 0
         # set the key binds back to the saved
         for control_code in defaultControlCodeBindsOrdered:
-            if type(control_code) == type(""):
+            if isinstance(control_code, str):
                 key1 = KeyMapArray[counter]
                 print "Binding " + key1 + " to " + control_code
                 km.bindKeyToConsoleCommand(key1,control_code)
@@ -1908,9 +1908,9 @@ class xOptionsMenu(ptModifier):
             field.setSpecialCaptureKeyMode(1)
             # set the mapping
             controlCode,spFlag,mpFlag = mapRow1[cID]
-            if type(controlCode) != type(None) and ( ( spFlag and PtIsSinglePlayerMode() ) or ( mpFlag and not PtIsSinglePlayerMode() ) ):
+            if controlCode is not None and ( ( spFlag and PtIsSinglePlayerMode() ) or ( mpFlag and not PtIsSinglePlayerMode() ) ):
                 # is the control code a console command?
-                if type(controlCode) == type(""):
+                if isinstance(controlCode, str):
                     field.setLastKeyCapture(km.getBindingKeyConsole(controlCode),km.getBindingFlagsConsole(controlCode))
                 # else must be a event binding
                 else:
@@ -1926,9 +1926,9 @@ class xOptionsMenu(ptModifier):
             field.setSpecialCaptureKeyMode(1)
             # set the mapping
             controlCode,spFlag,mpFlag = mapRow2[cID]
-            if type(controlCode) != type(None) and ( ( spFlag and PtIsSinglePlayerMode() ) or ( mpFlag and not PtIsSinglePlayerMode() ) ):
+            if controlCode is not None and ( ( spFlag and PtIsSinglePlayerMode() ) or ( mpFlag and not PtIsSinglePlayerMode() ) ):
                 # is the control code a console command?
-                if type(controlCode) == type(""):
+                if isinstance(controlCode, str):
                     # this shouldn't really happen!
                     field.setLastKeyCapture(km.getBindingKeyConsole(controlCode),km.getBindingFlagsConsole(controlCode))
                 # else must be a event binding
@@ -1943,7 +1943,7 @@ class xOptionsMenu(ptModifier):
         KeyMapString = ""
         # set the key binds back to the defaults
         for control_code in defaultControlCodeBindsOrdered:
-            if type(control_code) == type(""):
+            if isinstance(control_code, str):
                 key1 = defaultControlCodeBinds[control_code][0]
                 km.bindKeyToConsoleCommand(key1,control_code)
                 KeyMapString += key1 + " "

--- a/Python/xPodBahroSymbol.py
+++ b/Python/xPodBahroSymbol.py
@@ -91,7 +91,7 @@ class xPodBahroSymbol(ptResponder):
         self.ISetTimers()
         respSFX.run(self.key, state="stop")
 
-        if type(animMasterDayLight.value) != type(None):        
+        if animMasterDayLight.value is not None:        
             timeIntoMasterAnim = PtGetAgeTimeOfDayPercent() * (DayFrameSize.value / 30.0)
             print "xPodBahroSymbol.OnServerInitComplete: Master anim is skipping to %f seconds and playing at %f speed" % (timeIntoMasterAnim, kDayAnimationSpeed)
             animMasterDayLight.animation.skipToTime(timeIntoMasterAnim)

--- a/Python/xPotsSymbol.py
+++ b/Python/xPotsSymbol.py
@@ -91,13 +91,13 @@ class xPotsSymbol(ptResponder):
         global listSDL
         
         AgeStartedIn = PtGetAgeName()
-        if not (isinstance(sdlSaveCloth1.value, str) and sdlSaveCloth1.value != "")\
-        or not (isinstance(sdlSaveCloth2.value, str) and sdlSaveCloth2.value != "")\
-        or not (isinstance(sdlSaveCloth3.value, str) and sdlSaveCloth3.value != "")\
-        or not (isinstance(sdlSaveCloth4.value, str) and sdlSaveCloth4.value != "")\
-        or not (isinstance(sdlSaveCloth5.value, str) and sdlSaveCloth5.value != "")\
-        or not (isinstance(sdlSaveCloth6.value, str) and sdlSaveCloth6.value != "")\
-        or not (isinstance(sdlSaveCloth7.value, str) and sdlSaveCloth7.value != ""):
+        if not sdlSaveCloth1.value\
+        or not sdlSaveCloth2.value\
+        or not sdlSaveCloth3.value\
+        or not sdlSaveCloth4.value\
+        or not sdlSaveCloth5.value\
+        or not sdlSaveCloth6.value\
+        or not sdlSaveCloth7.value:
             PtDebugPrint("ERROR: xPotsSymbol.OnFirstUpdate():\tERROR: missing a SDL var name")
             pass
 

--- a/Python/xPotsSymbol.py
+++ b/Python/xPotsSymbol.py
@@ -89,22 +89,16 @@ class xPotsSymbol(ptResponder):
     def OnFirstUpdate(self):
         global AgeStartedIn
         global listSDL
-        
-        AgeStartedIn = PtGetAgeName()
-        if not sdlSaveCloth1.value\
-        or not sdlSaveCloth2.value\
-        or not sdlSaveCloth3.value\
-        or not sdlSaveCloth4.value\
-        or not sdlSaveCloth5.value\
-        or not sdlSaveCloth6.value\
-        or not sdlSaveCloth7.value:
-            PtDebugPrint("ERROR: xPotsSymbol.OnFirstUpdate():\tERROR: missing a SDL var name")
-            pass
 
-        listSDL = [sdlSaveCloth1.value,sdlSaveCloth2.value,sdlSaveCloth3.value,\
-                   sdlSaveCloth4.value,sdlSaveCloth5.value,sdlSaveCloth6.value,\
+        AgeStartedIn = PtGetAgeName()
+        listSDL = [sdlSaveCloth1.value, sdlSaveCloth2.value, sdlSaveCloth3.value,
+                   sdlSaveCloth4.value, sdlSaveCloth5.value, sdlSaveCloth6.value,
                    sdlSaveCloth7.value]
-        print "xPotsSymbol.OnFirstUpdate(): listSDL = ",listSDL
+
+        if not all(listSDL):
+            PtDebugPrint("ERROR: xPotsSymbol.OnFirstUpdate():\tERROR: missing a SDL var name")
+
+        print "xPotsSymbol.OnFirstUpdate(): listSDL = ", listSDL
 
         if boolFirstUpdate.value:
             self.Initialize()

--- a/Python/xPotsSymbol.py
+++ b/Python/xPotsSymbol.py
@@ -91,13 +91,13 @@ class xPotsSymbol(ptResponder):
         global listSDL
         
         AgeStartedIn = PtGetAgeName()
-        if not (type(sdlSaveCloth1.value) == type("") and sdlSaveCloth1.value != "")\
-        or not (type(sdlSaveCloth2.value) == type("") and sdlSaveCloth2.value != "")\
-        or not (type(sdlSaveCloth3.value) == type("") and sdlSaveCloth3.value != "")\
-        or not (type(sdlSaveCloth4.value) == type("") and sdlSaveCloth4.value != "")\
-        or not (type(sdlSaveCloth5.value) == type("") and sdlSaveCloth5.value != "")\
-        or not (type(sdlSaveCloth6.value) == type("") and sdlSaveCloth6.value != "")\
-        or not (type(sdlSaveCloth7.value) == type("") and sdlSaveCloth7.value != ""):
+        if not (isinstance(sdlSaveCloth1.value, str) and sdlSaveCloth1.value != "")\
+        or not (isinstance(sdlSaveCloth2.value, str) and sdlSaveCloth2.value != "")\
+        or not (isinstance(sdlSaveCloth3.value, str) and sdlSaveCloth3.value != "")\
+        or not (isinstance(sdlSaveCloth4.value, str) and sdlSaveCloth4.value != "")\
+        or not (isinstance(sdlSaveCloth5.value, str) and sdlSaveCloth5.value != "")\
+        or not (isinstance(sdlSaveCloth6.value, str) and sdlSaveCloth6.value != "")\
+        or not (isinstance(sdlSaveCloth7.value, str) and sdlSaveCloth7.value != ""):
             PtDebugPrint("ERROR: xPotsSymbol.OnFirstUpdate():\tERROR: missing a SDL var name")
             pass
 

--- a/Python/xPsnlVaultSDL.py
+++ b/Python/xPsnlVaultSDL.py
@@ -128,17 +128,17 @@ class xPsnlVaultSDL:
         #print "Attempting to set item %s to %s" % (sub, str(val))
 
         if vartype == PtSDLVarType.kInt:
-            if type(val) in (types.IntType, types.LongType):
+            if isintance(val, (int, long)):
                 #print "Set int"
                 var.setInt(val)
 
         elif vartype == PtSDLVarType.kFloat:
-            if type(val) in (types.IntType, types.LongType, types.FloatType):
+            if isinstance(val, (int, long, float)):
                 #print "Set float"
                 var.setFloat(val)
 
         elif vartype == PtSDLVarType.kDouble:
-            if type(val) in (types.IntType, types.LongType, types.FloatType):
+            if isinstance(val, (int, long, float)):
                 #print "Set double"
                 var.setDouble(val)
 
@@ -157,7 +157,7 @@ class xPsnlVaultSDL:
                 var.setString(str(val))
 
         else:
-            if type(val) in (types.IntType, types.LongType):
+            if isinstance(val, (int, long)):
                 #print "Set int"
                 var.setInt(val)
 

--- a/Python/xPsnlVaultSDL.py
+++ b/Python/xPsnlVaultSDL.py
@@ -78,7 +78,7 @@ class xPsnlVaultSDL:
 
     def __setitem__(self, sub, val):
 
-        if type(val) == type( () ):
+        if isinstance(val, tuple):
             val = val[0]
         else:
             raise ValueError("Value must be tuple type")
@@ -151,7 +151,7 @@ class xPsnlVaultSDL:
 
         elif vartype == PtSDLVarType.kString32:
             #print "Set string"
-            if type(val) == type(""):
+            if isinstance(val, str):
                 var.setString(val)
             else:
                 var.setString(str(val))

--- a/Python/xRandom.py
+++ b/Python/xRandom.py
@@ -54,7 +54,7 @@ _series_length = 0
 _lastvalue = None
 
 def seed(var = 0):
-    if type(var) == type(1):
+    if isinstance(var, int):
         random.seed(var)
     else:
         random.seed()
@@ -66,7 +66,7 @@ def randint(start, stop):
     
     newInt = random.randint(start, stop)
 
-    if type(_lastvalue) != type(None) and newInt == _lastvalue:
+    if _lastvalue is not None and newInt == _lastvalue:
         if _series_length >= _MAX_SERIES:
             iter = 0
             while newInt == _lastvalue and iter < _MAX_ITERATIONS:
@@ -87,11 +87,11 @@ def randint(start, stop):
 def setmaxseries(var = 2):
     global _MAX_SERIES
     
-    if type(var) == type(1):
+    if isinstance(var, int):
         _MAX_SERIES = var
 
 def shuffle(theList):
-    if type(theList) == type([]):
+    if isinstance(theList, list):
         n = len(theList)
         nmo = n - 1
         numIter = int(n * math.log(n))
@@ -108,7 +108,7 @@ def shuffle(theList):
 
 class xRandom:
     def __init__(self, seed = 0, maxseries = 2):
-        if type(maxseries) == type(1):
+        if isinstance(maxseries, int):
             self._MAX_SERIES = maxseries
         else:
             self._MAX_SERIES = 2
@@ -124,7 +124,7 @@ class xRandom:
     def randint(self, start, stop):
         newInt = random.randint(start, stop)
 
-        if type(_lastvalue) != type(None) and newInt == self._lastvalue:
+        if _lastvalue is not None and newInt == self._lastvalue:
             if self._series_length >= self._MAX_SERIES:
                 while newInt == _lastvalue:
                     newInt = random.randint(start, stop)
@@ -139,7 +139,7 @@ class xRandom:
         return _lastvalue
 
     def setmaxseries(self, var = 2):
-        if type(var) == type(1):
+        if isinstance(var, int):
             self._MAX_SERIES = var
 
     def setrange(self, rmin, rmax):
@@ -147,7 +147,7 @@ class xRandom:
 
     def getUniqueInt(self):
         numTries = 0
-        if type(self._range) == type( (0,) ):
+        if isinstance(self._range, tuple):
             newInt = random.randint(self._range[0], self._range[1])
             numTries += 1
 

--- a/Python/xRandomBoolChange.py
+++ b/Python/xRandomBoolChange.py
@@ -73,13 +73,13 @@ class xRandomBoolChange(ptModifier):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not(isinstance(strVarName.value, str) and strVarName.value != ""):
+        if not strVarName.value:
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDL var name on %s" % self.sceneobject.getName())
-        if not(isinstance(strEnabledVar.value, str) and strEnabledVar.value != ""):
+        if not strEnabledVar.value:
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDLEnabledVar var name on %s" % self.sceneobject.getName())
-        if not(isinstance(strChanceVar.value, str) and strChanceVar.value != ""):
+        if not strChanceVar.value:
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDLChanceVar var name on %s" % self.sceneobject.getName())
-        if not(isinstance(strProximityVar.value, str) and strProximityVar.value != ""):
+        if not strProximityVar.value:
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDLProximityVar var name on %s" % self.sceneobject.getName())
 
     def OnServerInitComplete(self):

--- a/Python/xRandomBoolChange.py
+++ b/Python/xRandomBoolChange.py
@@ -73,13 +73,13 @@ class xRandomBoolChange(ptModifier):
         self.version = 1
 
     def OnFirstUpdate(self):
-        if not(type(strVarName.value) == type("") and strVarName.value != ""):
+        if not(isinstance(strVarName.value, str) and strVarName.value != ""):
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDL var name on %s" % self.sceneobject.getName())
-        if not(type(strEnabledVar.value) == type("") and strEnabledVar.value != ""):
+        if not(isinstance(strEnabledVar.value, str) and strEnabledVar.value != ""):
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDLEnabledVar var name on %s" % self.sceneobject.getName())
-        if not(type(strChanceVar.value) == type("") and strChanceVar.value != ""):
+        if not(isinstance(strChanceVar.value, str) and strChanceVar.value != ""):
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDLChanceVar var name on %s" % self.sceneobject.getName())
-        if not(type(strProximityVar.value) == type("") and strProximityVar.value != ""):
+        if not(isinstance(strProximityVar.value, str) and strProximityVar.value != ""):
             PtDebugPrint("ERROR: xRandomBoolChange.OnFirstUpdate():\tERROR: missing SDLProximityVar var name on %s" % self.sceneobject.getName())
 
     def OnServerInitComplete(self):

--- a/Python/xSaveCloth.py
+++ b/Python/xSaveCloth.py
@@ -185,7 +185,7 @@ class xSaveCloth(ptModifier):
                     ainfo.setAgeFilename(PtGetAgeName())
                     agelink = vault.getOwnedAgeLink(ainfo)
 
-                    if type(agelink) != type(None):
+                    if agelink is not None:
                         spawnpoints = agelink.getSpawnPoints()
 
                         for sp in spawnpoints:
@@ -193,7 +193,7 @@ class xSaveCloth(ptModifier):
                                 savepoint = sp
                                 break
 
-                        if type(savepoint) != type(None):
+                        if savepoint is not None:
                             agelink.removeSpawnPoint(savepoint.getName())
                             
                         savepoint = ptSpawnPointInfo("SCSavePoint", soSpawnpoint.value.getName())

--- a/Python/xSaveScreenCapture.py
+++ b/Python/xSaveScreenCapture.py
@@ -62,6 +62,6 @@ class xSaveScreenCapture(ptModifier):
         print "__init__xSaveScreenCapture v.", self.version
 
     def OnScreenCaptureDone(self,image):
-        if type(strFileName.value) == type("") and strFileName.value != "":
+        if isinstance(strFileName.value, str) and strFileName.value != "":
             image.saveAsJPEG(strFileName.value, intQuality.value)
     

--- a/Python/xSaveScreenCapture.py
+++ b/Python/xSaveScreenCapture.py
@@ -62,6 +62,6 @@ class xSaveScreenCapture(ptModifier):
         print "__init__xSaveScreenCapture v.", self.version
 
     def OnScreenCaptureDone(self,image):
-        if isinstance(strFileName.value, str) and strFileName.value != "":
+        if strFileName.value:
             image.saveAsJPEG(strFileName.value, intQuality.value)
     

--- a/Python/xSimpleImager.py
+++ b/Python/xSimpleImager.py
@@ -126,7 +126,7 @@ class xSimpleImager(ptModifier):
                 if node:
                     PtDebugPrint("\tAdded device: %s"%(ImagerName.value),level=kDebugDumpLevel)
                     name = ""
-                    if isinstance(ImagerInboxVariable.value, str) and ImagerInboxVariable.value != "":
+                    if ImagerInboxVariable.value:
                         ageSDL = PtGetAgeSDL()
                         tempValue = ageSDL[ImagerInboxVariable.value]
                         if (len(tempValue) >= 1):
@@ -172,7 +172,7 @@ class xSimpleImager(ptModifier):
             PtDebugPrint("xSimpleImager:ERROR! simpleImager[%s]: ImagerObject not specified!" % (ImagerName.value),level=kErrorLevel)
             return
         # initialize age devices
-        if isinstance(ImagerName.value, str) and ImagerName.value != "":
+        if ImagerName.value:
             ageVault = ptAgeVault()
             # will only add if not already there.
             ageVault.addDevice(ImagerName.value, self, kAddingDevice)
@@ -181,7 +181,7 @@ class xSimpleImager(ptModifier):
     
     def OnServerInitComplete(self):
         if AgeStartedIn == PtGetAgeName():
-            if isinstance(ImagerInboxVariable.value, str) and ImagerInboxVariable.value:
+            if ImagerInboxVariable.value:
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setNotify(self.key,ImagerInboxVariable.value,0.0)
                 ageVault = ptAgeVault()

--- a/Python/xSimpleImager.py
+++ b/Python/xSimpleImager.py
@@ -126,7 +126,7 @@ class xSimpleImager(ptModifier):
                 if node:
                     PtDebugPrint("\tAdded device: %s"%(ImagerName.value),level=kDebugDumpLevel)
                     name = ""
-                    if type(ImagerInboxVariable.value) == type("") and ImagerInboxVariable.value != "":
+                    if isinstance(ImagerInboxVariable.value, str) and ImagerInboxVariable.value != "":
                         ageSDL = PtGetAgeSDL()
                         tempValue = ageSDL[ImagerInboxVariable.value]
                         if (len(tempValue) >= 1):
@@ -165,14 +165,14 @@ class xSimpleImager(ptModifier):
 ###==== Cheat
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if type(ImagerMap.textmap) == type(None):
+        if ImagerMap.textmap is None:
             PtDebugPrint("xSimpleImager:ERROR! simpleImager[%s]: Dynamic textmap is broken!" % (ImagerName.value),level=kErrorLevel)
             return
-        if type(ImagerObject.sceneobject) == type(None):
+        if ImagerObject.sceneobject is None:
             PtDebugPrint("xSimpleImager:ERROR! simpleImager[%s]: ImagerObject not specified!" % (ImagerName.value),level=kErrorLevel)
             return
         # initialize age devices
-        if type(ImagerName.value) == type("") and ImagerName.value != "":
+        if isinstance(ImagerName.value, str) and ImagerName.value != "":
             ageVault = ptAgeVault()
             # will only add if not already there.
             ageVault.addDevice(ImagerName.value, self, kAddingDevice)
@@ -181,7 +181,7 @@ class xSimpleImager(ptModifier):
     
     def OnServerInitComplete(self):
         if AgeStartedIn == PtGetAgeName():
-            if type(ImagerInboxVariable.value) == type("") and ImagerInboxVariable.value:
+            if isinstance(ImagerInboxVariable.value, str) and ImagerInboxVariable.value:
                 ageSDL = PtGetAgeSDL()
                 ageSDL.setNotify(self.key,ImagerInboxVariable.value,0.0)
                 ageVault = ptAgeVault()
@@ -207,7 +207,7 @@ class xSimpleImager(ptModifier):
         theCensorLevel = xCensor.xRatedPG
         vault = ptVault()
         entry = vault.findChronicleEntry(kChronicleCensorLevel)
-        if type(entry) == type(None):
+        if entry is None:
             # not found... add current level chronicle
             vault.addChronicleEntry(kChronicleCensorLevel,kChronicleCensorLevelType,"%d" % (theCensorLevel))
         else:
@@ -338,7 +338,7 @@ class xSimpleImager(ptModifier):
         global CurrentContentIdx
         ageVault = ptAgeVault()
         folder = ageVault.getDeviceInbox(ImagerName.value)
-        if type(folder) != type(None):
+        if folder is not None:
             prevsize = len(ImagerContents)
             ImagerContents = folder.getChildNodeRefList()
             # check to make sure we are not over budget... but only on the master
@@ -360,9 +360,9 @@ class xSimpleImager(ptModifier):
     def IRefreshImagerContent(self,updated_content):
         "Refresh a content of the Imager (if being displayed)"
         global CurrentDisplayedElementID
-        if type(updated_content) != type(None):
+        if updated_content is not None:
             updated_element = updated_content.getChild()
-            if type(updated_element) != type(None):
+            if updated_element is not None:
                 if updated_element.getID() == CurrentDisplayedElementID:
                     self.IShowCurrentContent()
                 else:
@@ -372,17 +372,17 @@ class xSimpleImager(ptModifier):
     def IRefreshImagerElement(self,updated_element):
         "Refresh an element of the Imager (if being displayed)"
         global CurrentDisplayedElementID
-        if type(updated_element) != type(None):
+        if updated_element is not None:
             if updated_element.getID() == CurrentDisplayedElementID:
                 self.IShowCurrentContent()
             else:
                 ageVault = ptAgeVault()
                 folder = ageVault.getDeviceInbox(ImagerName.value)
-                if type(folder) != type(None):
+                if folder is not None:
                     frefs = folder.getChildNodeRefList()
                     for ref in frefs:
                         elem = ref.getChild()
-                        if type(elem) != type(None) and elem.getID() == updated_element.getID():
+                        if elem is not None and elem.getID() == updated_element.getID():
                             if not ref.beenSeen():
                                 self.IChangeCurrentContent(updated_element.getID())
                                 return
@@ -395,10 +395,10 @@ class xSimpleImager(ptModifier):
         # only the owner of the imager changes the images
         if ImagerObject.sceneobject.isLocallyOwned():
             nextID = -1
-            if type(next) == type(None):
+            if next is None:
                 try:
                     element = ImagerContents[CurrentContentIdx].getChild()
-                    if type(element) != type(None):
+                    if element is not None:
                         nextID = element.getID()
                 except LookupError:
                     pass
@@ -424,11 +424,11 @@ class xSimpleImager(ptModifier):
         if CurrentDisplayedElementID != -1:
             ageVault = ptAgeVault()
             folder = ageVault.getDeviceInbox(ImagerName.value)
-            if type(folder) != type(None):
+            if folder is not None:
                 fcontents = folder.getChildNodeRefList()
                 for content in fcontents:
                     element = content.getChild()
-                    if type(element) != type(None) and element.getID() == CurrentDisplayedElementID:
+                    if element is not None and element.getID() == CurrentDisplayedElementID:
                         # set that we've seen this... at least once
                         content.setSeen()
                         elemType = element.getType()

--- a/Python/xSitAugment.py
+++ b/Python/xSitAugment.py
@@ -139,7 +139,7 @@ class xSitAugment(ptModifier):
         "Disengage and exit"
         global LocalAvatar
         # exit every thing
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtHideDialog(Vignette.value)
             print "Dialog: %s goes down" % Vignette.value
         else:

--- a/Python/xSitAugment.py
+++ b/Python/xSitAugment.py
@@ -139,7 +139,7 @@ class xSitAugment(ptModifier):
         "Disengage and exit"
         global LocalAvatar
         # exit every thing
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtHideDialog(Vignette.value)
             print "Dialog: %s goes down" % Vignette.value
         else:

--- a/Python/xSndLogTracks.py
+++ b/Python/xSndLogTracks.py
@@ -53,7 +53,7 @@ def LogTrack(currentState,nextState):
     updated = 0
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
-    if type(entry) != type(None):
+    if entry is not None:
         state = entry.chronicleGetValue()
         if state == currentState:
             avatar = PtGetLocalAvatar()
@@ -84,7 +84,7 @@ def LogTrack(currentState,nextState):
 def InitLogTrack(nextState):
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue(nextState)
         entry.save()
     else:
@@ -93,7 +93,7 @@ def InitLogTrack(nextState):
 def SetLogMode():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogModeVarname)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("white")
         entry.save()
     else:
@@ -102,14 +102,14 @@ def SetLogMode():
 def UnsetLogMode():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogModeVarname)
-    if type(entry) != type(None):
+    if entry is not None:
         entry.chronicleSetValue("blue")
         entry.save()
 
 def IsLogMode():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogModeVarname)
-    if type(entry) != type(None):
+    if entry is not None:
         if entry.chronicleGetValue() == "white":
             return 1
     return 0
@@ -117,7 +117,7 @@ def IsLogMode():
 def WhatIsLog():
     vault = ptVault()
     entry = vault.findChronicleEntry(kLogTrackVarname)
-    if type(entry) != type(None):
+    if entry is not None:
         print entry.chronicleGetValue()
     else:
         print "not initialized"

--- a/Python/xStandardDoor.py
+++ b/Python/xStandardDoor.py
@@ -112,7 +112,7 @@ class xStandardDoor(ptResponder):
         # get the age we started in
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if not (isinstance(stringSDLVarClosed.value, str) and stringSDLVarClosed.value != ""):
+        if not stringSDLVarClosed.value:
             PtDebugPrint("xStandardDoor.OnFirstUpdate():\tERROR: missing SDL var name in max file")
 
     def OnServerInitComplete(self):

--- a/Python/xStandardDoor.py
+++ b/Python/xStandardDoor.py
@@ -112,7 +112,7 @@ class xStandardDoor(ptResponder):
         # get the age we started in
         global AgeStartedIn
         AgeStartedIn = PtGetAgeName()
-        if not (type(stringSDLVarClosed.value) == type("") and stringSDLVarClosed.value != ""):
+        if not (isinstance(stringSDLVarClosed.value, str) and stringSDLVarClosed.value != ""):
             PtDebugPrint("xStandardDoor.OnFirstUpdate():\tERROR: missing SDL var name in max file")
 
     def OnServerInitComplete(self):

--- a/Python/xTakableClothing.py
+++ b/Python/xTakableClothing.py
@@ -108,13 +108,13 @@ class xTakableClothing(ptModifier):
         AgeStartedIn = PtGetAgeName()
         self.useChance = true
         self.shown = false
-        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
+        if not stringVarName.value:
             PtDebugPrint("ERROR: xTakableClothing.OnFirstUpdate():\tERROR: missing SDL var name on %s" % self.sceneobject.getName())
-        if not (isinstance(stringFClothingName.value, str) and stringFClothingName.value != ""):
+        if not stringFClothingName.value:
             PtDebugPrint("ERROR: xTakableClothing.OnFirstUpdate():\tERROR: missing female clothing name on %s" % self.sceneobject.getName())
-        if not (isinstance(stringMClothingName.value, str) and stringMClothingName.value != ""):
+        if not stringMClothingName.value:
             PtDebugPrint("ERROR: xTakableClothing.OnFirstUpdate():\tERROR: missing male clothing name on %s" % self.sceneobject.getName())
-        if not (isinstance(stringChanceSDLName.value, str) and stringChanceSDLName.value != ""):
+        if not stringChanceSDLName.value:
             PtDebugPrint("DEBUG: xTakableClothing.OnFirstUpdate(): Chance SDL var name is empty, so we will not use chance rolls for showing %s" % self.sceneobject.getName())
             self.useChance = false
         allFClothing = stringFClothingName.value.split(";")
@@ -136,7 +136,7 @@ class xTakableClothing(ptModifier):
     def Initialize(self):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if isinstance(stringVarName.value, str) and stringVarName.value != "":
+            if stringVarName.value:
                 try:
                     ageSDL.setNotify(self.key,stringVarName.value,0.0)
                     if not (ageSDL[stringVarName.value][0] ^ boolShowOnTrue.value):

--- a/Python/xTakableClothing.py
+++ b/Python/xTakableClothing.py
@@ -108,13 +108,13 @@ class xTakableClothing(ptModifier):
         AgeStartedIn = PtGetAgeName()
         self.useChance = true
         self.shown = false
-        if not (type(stringVarName.value) == type("") and stringVarName.value != ""):
+        if not (isinstance(stringVarName.value, str) and stringVarName.value != ""):
             PtDebugPrint("ERROR: xTakableClothing.OnFirstUpdate():\tERROR: missing SDL var name on %s" % self.sceneobject.getName())
-        if not (type(stringFClothingName.value) == type("") and stringFClothingName.value != ""):
+        if not (isinstance(stringFClothingName.value, str) and stringFClothingName.value != ""):
             PtDebugPrint("ERROR: xTakableClothing.OnFirstUpdate():\tERROR: missing female clothing name on %s" % self.sceneobject.getName())
-        if not (type(stringMClothingName.value) == type("") and stringMClothingName.value != ""):
+        if not (isinstance(stringMClothingName.value, str) and stringMClothingName.value != ""):
             PtDebugPrint("ERROR: xTakableClothing.OnFirstUpdate():\tERROR: missing male clothing name on %s" % self.sceneobject.getName())
-        if not (type(stringChanceSDLName.value) == type("") and stringChanceSDLName.value != ""):
+        if not (isinstance(stringChanceSDLName.value, str) and stringChanceSDLName.value != ""):
             PtDebugPrint("DEBUG: xTakableClothing.OnFirstUpdate(): Chance SDL var name is empty, so we will not use chance rolls for showing %s" % self.sceneobject.getName())
             self.useChance = false
         allFClothing = stringFClothingName.value.split(";")
@@ -136,7 +136,7 @@ class xTakableClothing(ptModifier):
     def Initialize(self):
         if AgeStartedIn == PtGetAgeName():
             ageSDL = PtGetAgeSDL()
-            if type(stringVarName.value) == type("") and stringVarName.value != "":
+            if isinstance(stringVarName.value, str) and stringVarName.value != "":
                 try:
                     ageSDL.setNotify(self.key,stringVarName.value,0.0)
                     if not (ageSDL[stringVarName.value][0] ^ boolShowOnTrue.value):
@@ -290,7 +290,7 @@ class xTakableClothing(ptModifier):
                 if childNode != type(None):
                     print "xTakableClothing: Child Node Node ID"
                     SDLNode = childNode.upcastToSDLNode()
-                    if type(SDLNode) != type(None):
+                    if SDLNode is not None:
                         rec = SDLNode.getStateDataRecord()
                         print "xTakableClothing: getStateDataRecord().getName(): " + str(rec.getName())
                         SDLVarList = rec.getVarList()
@@ -389,7 +389,7 @@ class xTakableClothing(ptModifier):
                     avatar.avatar.tintClothingItem(name,color1,0)
                     avatar.avatar.tintClothingItemLayer(name,color2,2,1)
                     matchingItem = avatar.avatar.getMatchingClothingItem(name)
-                    if type(matchingItem) == type([]):
+                    if isinstance(matchingItem, list):
                         avatar.avatar.wearClothingItem(matchingItem[0],0)
                         avatar.avatar.tintClothingItem(matchingItem[0],color1,0)
 

--- a/Python/xTelescope.py
+++ b/Python/xTelescope.py
@@ -183,7 +183,7 @@ class xTelescope(ptModifier):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtLoadDialog(Vignette.value,self.key)
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -198,7 +198,7 @@ class xTelescope(ptModifier):
 
         Telescope.popTelescope()
         # exit every thing
-        if type(Vignette.value) != type(None) and Vignette.value != "":
+        if Vignette.value is not None and Vignette.value != "":
             PtHideDialog(Vignette.value)
         virtCam = ptCamera()
         virtCam.restore(Camera.sceneobject.getKey())

--- a/Python/xTelescope.py
+++ b/Python/xTelescope.py
@@ -183,7 +183,7 @@ class xTelescope(ptModifier):
         virtCam = ptCamera()
         virtCam.save(Camera.sceneobject.getKey())
         # show the cockpit
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtLoadDialog(Vignette.value,self.key)
             if ( PtIsDialogLoaded(Vignette.value) ):
                 PtShowDialog(Vignette.value)
@@ -198,7 +198,7 @@ class xTelescope(ptModifier):
 
         Telescope.popTelescope()
         # exit every thing
-        if Vignette.value is not None and Vignette.value != "":
+        if Vignette.value:
             PtHideDialog(Vignette.value)
         virtCam = ptCamera()
         virtCam.restore(Camera.sceneobject.getKey())

--- a/Python/xTrackActivatorUsage.py
+++ b/Python/xTrackActivatorUsage.py
@@ -70,7 +70,7 @@ class xTrackActivatorUsage(ptModifier):
             vault = ptVault()
             entry = vault.findChronicleEntry(strChronVar.value)
 
-            if type(entry) != type(None):
+            if entry is not None:
                 entry.chronicleSetValue( str(self.currentValue) )
                 entry.save()
             else:
@@ -83,7 +83,7 @@ class xTrackActivatorUsage(ptModifier):
             vault = ptVault()
             entry = vault.findChronicleEntry(strChronVar.value)
 
-            if type(entry) != type(None):
+            if entry is not None:
                 self.currentValue = int(entry.chronicleGetValue())
 
         self.startingValue = self.currentValue

--- a/Python/xYeeshaPages.py
+++ b/Python/xYeeshaPages.py
@@ -158,43 +158,39 @@ class xYeeshaPages(ptModifier):
             PtHideDialog(DialogName)
             
             vault = ptVault()
-            if vault is not None: #is the Vault online?
                 
-                psnlSDL = vault.getPsnlAgeSDL()
-                if psnlSDL:
-                    YeeshaPageVar = psnlSDL.findVar("YeeshaPage" + str(PageNumber.value))
+            psnlSDL = vault.getPsnlAgeSDL()
+            if psnlSDL:
+                YeeshaPageVar = psnlSDL.findVar("YeeshaPage" + str(PageNumber.value))
+                
+                PtDebugPrint ("xYeeshaPages.py: The previous value of the SDL variable %s is %s" % ("YeeshaPage" + str(PageNumber.value), YeeshaPageVar.getInt()))
+
+                if YeeshaPageVar.getInt() != 0: 
+                    PtDebugPrint ("xYeeshaPages.py: You've already found Yeesha Page #%s. Move along. Move along." % (PageNumber.value))
+                    return
                     
-                    PtDebugPrint ("xYeeshaPages.py: The previous value of the SDL variable %s is %s" % ("YeeshaPage" + str(PageNumber.value), YeeshaPageVar.getInt()))
-    
-                    if YeeshaPageVar.getInt() != 0: 
-                        PtDebugPrint ("xYeeshaPages.py: You've already found Yeesha Page #%s. Move along. Move along." % (PageNumber.value))
-                        return
-                        
-                    else:
-                        PtDebugPrint ("xYeeshaPages.py: Yeesha Page #%s is new to you." % (PageNumber.value))
-                        
-                        PtDebugPrint ("xYeeshaPages.py: Trying to update the value of the SDL variable %s to 1" % ("YeeshaPage" + str(PageNumber.value)))
-                        YeeshaPageVar.setInt(4)
-                        vault.updatePsnlAgeSDL (psnlSDL)
-
-                        PtSendKIMessageInt(kStartBookAlert,0)
-
-                        if (PageNumber.value) == 25:
-                            #Cleft is done, set SDL to start link back to Relto
-                            actClickableBook.disableActivator()
-                            PtSendKIMessage(kDisableKIandBB,0)
-                            ageSDL = PtGetAgeSDL()
-                            ageSDL["clftIsCleftDone"] = (1,)
-                            vault = ptVault()
-                            vault.addChronicleEntry("CleftSolved",1,"yes")
-                            PtDebugPrint("Chronicle updated with variable 'CleftSolved'.",level=kDebugDumpLevel)
-                            #PtAtTimeCallback(self.key,kWaitFadeoutSecs,kStartFadeoutID)
-
                 else:
-                    PtDebugPrint("xYeeshaPages: Error trying to access the Chronicle psnlSDL. psnlSDL = %s" % ( psnlSDL))
+                    PtDebugPrint ("xYeeshaPages.py: Yeesha Page #%s is new to you." % (PageNumber.value))
                     
+                    PtDebugPrint ("xYeeshaPages.py: Trying to update the value of the SDL variable %s to 1" % ("YeeshaPage" + str(PageNumber.value)))
+                    YeeshaPageVar.setInt(4)
+                    vault.updatePsnlAgeSDL (psnlSDL)
+
+                    PtSendKIMessageInt(kStartBookAlert,0)
+
+                    if (PageNumber.value) == 25:
+                        #Cleft is done, set SDL to start link back to Relto
+                        actClickableBook.disableActivator()
+                        PtSendKIMessage(kDisableKIandBB,0)
+                        ageSDL = PtGetAgeSDL()
+                        ageSDL["clftIsCleftDone"] = (1,)
+                        vault = ptVault()
+                        vault.addChronicleEntry("CleftSolved",1,"yes")
+                        PtDebugPrint("Chronicle updated with variable 'CleftSolved'.",level=kDebugDumpLevel)
+                        #PtAtTimeCallback(self.key,kWaitFadeoutSecs,kStartFadeoutID)
+
             else:
-                PtDebugPrint("xYeeshaPages: Error trying to access the Vault. Can't access YeeshaPageChanges chronicle." )
+                PtDebugPrint("xYeeshaPages: Error trying to access the Chronicle psnlSDL. psnlSDL = %s" % ( psnlSDL))
 
         elif event == 2 and btnID == kYeeshaPageCancel:
             PtHideDialog(DialogName)

--- a/Python/xYeeshaPages.py
+++ b/Python/xYeeshaPages.py
@@ -158,7 +158,7 @@ class xYeeshaPages(ptModifier):
             PtHideDialog(DialogName)
             
             vault = ptVault()
-            if type(vault) != type(None): #is the Vault online?
+            if vault is not None: #is the Vault online?
                 
                 psnlSDL = vault.getPsnlAgeSDL()
                 if psnlSDL:


### PR DESCRIPTION
Especially, replace things like `type(x) == type([])` by `isinstance(x, list)`.

Also do `x is None` special casing.

Using the following py3 script:

```py
import pathlib
import re
import sys

simple = {
    r"\[\]": r"list",
    r"\(\)": r"tuple",
    r"\(\d+,\)": r"tuple",
    r"\{\}": r"dict",
    r"\d+": r"int",
    r"''": r"str",
    r'""': r"str",
    r"long\(\d+\)": r"long",
}

others = {
    r"type\((.*?)\)\s*==\s*type\(\s*None\s*\)": r"\1 is None",
    r"type\((.*?)\)\s*!=\s*type\(\s*None\s*\)": r"\1 is not None",
    r"type\((.*?)\)\s*==\s*(type\(.*?\))": r"isinstance(\1, \2)",
    r"type\((.*?)\)\s*!=\s*(type\(.*?\))": r"not isinstance(\1, \2)",
}

def replace_in_all_files(root, pat, sub):
    for path in root.glob("**/*.py"):
        with path.open() as file:
            data = file.read()
        new_data = pat.sub(sub, data)
        if data != new_data:
            with path.open("w") as file:
                file.write(new_data)

root = pathlib.Path(sys.argv[1])

for str_pat, sub in simple.items():
    replace_in_all_files(
        root,
        re.compile(rf"type\((.*?)\)\s*==\s*type\(\s*{str_pat}\s*\)"),
        rf"isinstance(\1, {sub})",
    )
    replace_in_all_files(
        root,
        re.compile(rf"type\((.*?)\)\s*!=\s*type\(\s*{str_pat}\s*\)"),
        rf"not isinstance(\1, {sub})",
    )

for str_pat, sub in others.items():
    replace_in_all_files(root, re.compile(str_pat), sub)
```